### PR TITLE
BAU: Remove an extra permission from SAML Engine

### DIFF
--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -78,7 +78,6 @@ resource "aws_iam_policy" "saml_engine_parameter_execution" {
       "Effect": "Allow",
       "Action": [
         "ssm:GetParameters",
-        "secretsmanager:GetSecretValue",
         "kms:Decrypt"
       ],
       "Resource": [


### PR DESCRIPTION
SAML Engine does not use parameters referencing Secret Manager secrets. This commit removes the extra permission (GetSecretValue) from SAML Engine Execution Role.

Author: @adityapahuja