### PR TITLE
HUB 5

### DIFF
--- a/terraform/modules/hub/data.tf
+++ b/terraform/modules/hub/data.tf
@@ -1,12 +1,13 @@
-data "aws_ami" "awslinux2" {
+data "aws_ami" "ubuntu_bionic" {
   most_recent = true
+
+  # canonical
+  owners = ["099720109477"]
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
   }
-
-  owners = ["amazon"]
 }
 
 data "aws_caller_identity" "account" {}

--- a/terraform/modules/hub/deployer.tf
+++ b/terraform/modules/hub/deployer.tf
@@ -1,0 +1,49 @@
+resource "aws_iam_role" "deployer" {
+  name        = "${var.deployment}-deployer"
+  description = "assumed by deployer concourse to deploy things"
+
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+          "AWS": "arn:aws:iam::${var.tools_account_id}:role/concourse-worker"
+        },
+        "Effect": "Allow"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_policy" "deployer_update_ecs" {
+  name        = "${var.deployment}-deployer-update-ecs"
+  description = "${var.deployment}-deployer-update-ecs"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecs:List*",
+          "ecs:Describe*",
+          "ecs:UpdateService",
+          "ecs:RegisterTaskDefinition"
+        ],
+        "Resource": [
+          "*"
+        ]
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "deployer_deployer_update_ecs" {
+  role = "${aws_iam_role.deployer.name}"
+  policy_arn = "${aws_iam_policy.deployer_update_ecs.arn}"
+}

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -1,7 +1,7 @@
 module "egress_proxy_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id              = "${data.aws_ami.awslinux2.id}"
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
   deployment          = "${var.deployment}"
   cluster             = "egress-proxy"
   vpc_id              = "${aws_vpc.hub.id}"
@@ -35,20 +35,27 @@ resource "aws_security_group_rule" "egress_proxy_instance_egress_to_internet_ove
 
 locals {
   egress_proxy_whitelist_list = [
+    "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com ",                               # Apt
+    "security\\.ubuntu\\.com",                                                 # Apt
+
     "amazonlinux\\.eu-west-2\\.amazonaws\\.com",                               # Yum
     "repo\\.eu-west-2\\.amazonaws\\.com",                                      # Yum
     "packages\\.eu-west-2\\.amazonaws\\.com",                                  # Yum
     "amazon-ssm-eu-west-2\\.s3\\.amazonaws\\.com",                             # Where the package is from
+
     "ec2messages\\.eu-west-2\\.amazonaws\\.com",                               # SSM agent
     "ssmmessages\\.eu-west-2\\.amazonaws\\.com",                               # SSM agent
     "ssm\\.eu-west-2\\.amazonaws\\.com",                                       # SSM agent
+
     "ecs[^.]*\\.eu-west-2\\.amazonaws\\.com",                                  # ECS agent
     "ecr\\.eu-west-2\\.amazonaws\\.com",                                       # ECR
     "prod-eu-west-2-starport-layer-bucket\\.s3\\.eu-west-2\\.amazonaws\\.com", # ECR s3 bucket
     "${var.tools_account_id}\\.dkr\\.ecr\\.eu-west-2\\.amazonaws\\.com",       # Tools ECR auth
+
     "registry-1\\.docker\\.io",                                                # Docker Hub
     "auth\\.docker\\.io",                                                      # Docker Hub
     "production\\.cloudflare\\.docker\\.com",                                  # Docker Hub
+
     "www\\.${var.deployment}\\.signin\\.service\\.gov\\.uk",                   # Metadata
     "test-rp-msa-stub-${var.deployment}.ida.digital.cabinet-office.gov.uk",    # Test RP
   ]

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -1,7 +1,7 @@
 module "config_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id           = "${data.aws_ami.awslinux2.id}"
+  ami_id           = "${data.aws_ami.ubuntu_bionic.id}"
   deployment       = "${var.deployment}"
   cluster          = "config"
   vpc_id           = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -1,7 +1,7 @@
 module "policy_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id           = "${data.aws_ami.awslinux2.id}"
+  ami_id           = "${data.aws_ami.ubuntu_bionic.id}"
   deployment       = "${var.deployment}"
   cluster          = "policy"
   vpc_id           = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -1,7 +1,7 @@
 module "saml_engine_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id           = "${data.aws_ami.awslinux2.id}"
+  ami_id           = "${data.aws_ami.ubuntu_bionic.id}"
   deployment       = "${var.deployment}"
   cluster          = "saml-engine"
   vpc_id           = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -1,7 +1,7 @@
 module "saml_proxy_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id              = "${data.aws_ami.awslinux2.id}"
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
   deployment          = "${var.deployment}"
   cluster             = "saml-proxy"
   vpc_id              = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -1,7 +1,7 @@
 module "saml_soap_proxy_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id              = "${data.aws_ami.awslinux2.id}"
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
   deployment          = "${var.deployment}"
   cluster             = "saml-soap-proxy"
   vpc_id              = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -189,7 +189,7 @@ resource "aws_route53_record" "ingress_www" {
 module "ingress_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id              = "${data.aws_ami.awslinux2.id}"
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
   deployment          = "${var.deployment}"
   cluster             = "ingress"
   vpc_id              = "${aws_vpc.hub.id}"

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -10,7 +10,7 @@ locals {
   ecs_egress_proxy_setting = "${
     var.use_egress_proxy
     ? "HTTP_PROXY=${local.egress_proxy_url}"
-    : "# NO PROXY USED"
+    : "NOT_USING_HTTP_PROXY=yes"
   }"
 }
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -1,47 +1,85 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
+# Apt
+mkdir -p /etc/apt/apt.conf.d
 if [ -n "${egress_proxy_url_with_protocol}" ]; then
-  sed -i \
-      '/\[main\]/a proxy=${egress_proxy_url_with_protocol}' \
-      /etc/yum.conf
-fi
-yum update --assumeyes
-
-mkdir -p /etc/systemd/system/docker.service.d
-
-if [ -n "${egress_proxy_url_with_protocol}" ]; then
-cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
-[Service]
-Environment="HTTP_PROXY=${egress_proxy_url_with_protocol}"
-Environment="HTTPS_PROXY=${egress_proxy_url_with_protocol}"
+  cat << EOF > /etc/apt/apt.conf.d/egress.conf
+Acquire::http::Proxy "${egress_proxy_url_with_protocol}/";
+Acquire::https::Proxy "${egress_proxy_url_with_protocol}/";
 EOF
 fi
+apt-get update  --yes
+apt-get upgrade --yes
 
-mkdir -p /etc/systemd/system/amazon-ssm-agent.service.d
-
+# AWS SSM Agent
+# Installed by default on Ubuntu Bionic AMIs via Snap
+mkdir -p /etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service.d
 if [ -n "${egress_proxy_url_with_protocol}" ]; then
-cat <<EOF > /etc/systemd/system/amazon-ssm-agent.service.d/override.conf
+cat <<EOF > /etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service.d/override.conf
 [Service]
 Environment="http_proxy=${egress_proxy_url_with_protocol}"
 Environment="https_proxy=${egress_proxy_url_with_protocol}"
 Environment="no_proxy=169.254.169.254"
 EOF
 fi
+systemctl stop snap.amazon-ssm-agent.amazon-ssm-agent
+systemctl daemon-reload
+systemctl start snap.amazon-ssm-agent.amazon-ssm-agent
+
+# Use Amazon NTP
+apt-get install --yes chrony
+sed '/pool/d' /etc/chrony/chrony.conf \
+| cat <(echo "server 169.254.169.123 prefer iburst") - > /tmp/chrony.conf
+mv /tmp/chrony.conf /etc/chrony/chrony.conf
+
+# Docker
+mkdir -p /etc/systemd/system/docker.service.d
+apt-get install --yes docker.io
+cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd --log-driver journald --dns 10.0.0.2
+EOF
+if [ -n "${egress_proxy_url_with_protocol}" ]; then
+cat <<EOF >> /etc/systemd/system/docker.service.d/override.conf
+Environment="HTTP_PROXY=${egress_proxy_url_with_protocol}"
+Environment="HTTPS_PROXY=${egress_proxy_url_with_protocol}"
+EOF
+fi
 
 # Reload systemctl daemon to pick up new override files
+systemctl stop docker
 systemctl daemon-reload
-systemctl restart docker
-
-logger "Installing and enabling SSM agent"
-yum install --assumeyes "https://amazon-ssm-eu-west-2.s3.amazonaws.com/latest/linux_amd64/amazon-ssm-agent.rpm"
+systemctl start docker
 
 mkdir -p /etc/ecs
-mkdir -p /data
-cat <<ECS > /etc/ecs/ecs.config
-ECS_CLUSTER=${cluster}
-AWS_DEFAULT_REGION=eu-west-2
-ECS_DATADIR=/data
-NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock
-${ecs_egress_proxy_setting}
-ECS
+mkdir -p /var/lib/ecs/data
+
+docker run \
+  --init \
+  --privileged \
+  --name ecs-agent \
+  --detach=true \
+  --restart=on-failure:10 \
+  --volume=/etc/ecs:/etc/ecs \
+  --volume=/lib64:/lib64 \
+  --volume=/lib:/lib \
+  --volume=/proc:/host/proc \
+  --volume=/sbin:/sbin \
+  --volume=/sys/fs/cgroup:/sys/fs/cgroup \
+  --volume=/usr/lib:/usr/lib \
+  --volume=/var/lib/ecs/data:/data \
+  --volume=/var/lib/ecs/dhclient:/var/lib/dhclient \
+  --volume=/var/run:/var/run \
+  --net=host \
+  --env="ECS_CLUSTER=${cluster}" \
+  --env="${ecs_egress_proxy_setting}" \
+  --env=AWS_DEFAULT_REGION=eu-west-2 \
+  --env="NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock" \
+  --env=ECS_DATADIR=/data \
+  --env=ECS_ENABLE_TASK_ENI=true \
+  --env=ECS_ENABLE_TASK_IAM_ROLE=true \
+  --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
+  --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
+  amazon/amazon-ecs-agent:v1.23.0

--- a/terraform/modules/hub/stub_event_sink.tf
+++ b/terraform/modules/hub/stub_event_sink.tf
@@ -1,7 +1,7 @@
 module "event_sink_ecs_asg" {
   source = "modules/ecs_asg"
 
-  ami_id              = "${data.aws_ami.awslinux2.id}"
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
   deployment          = "${var.deployment}"
   cluster             = "event-sink"
   vpc_id              = "${aws_vpc.hub.id}"


### PR DESCRIPTION
- adds deployer role that can be assumed by deployer-concourse

- uses ubuntu instead of amazon linux, this is so we can use cyber security's
splunk package which is packaged for ubuntu

- use journald for container log driver so we can use journalbeat and not worry
about log rotation

solo @tlwr