### PR TITLE
Send logs to logit

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -13,6 +13,9 @@ module "config_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "config_task_def" {

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -13,6 +13,9 @@ module "policy_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "policy_task_def" {

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -13,6 +13,9 @@ module "saml_engine_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "saml_engine_task_def" {

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -12,6 +12,9 @@ module "saml_proxy_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "saml_proxy_task_def" {

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -12,6 +12,9 @@ module "saml_soap_proxy_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "saml_soap_proxy_task_def" {

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -200,6 +200,9 @@ module "ingress_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 resource "aws_ecs_cluster" "ingress" {

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -12,15 +12,24 @@ locals {
     ? "HTTP_PROXY=${local.egress_proxy_url}"
     : "NOT_USING_HTTP_PROXY=yes"
   }"
+
+  journalbeat_egress_proxy_setting = "${
+    var.use_egress_proxy
+    ? "proxy_url: ${local.egress_proxy_url_with_protocol}"
+    : ""
+  }"
 }
 
 data "template_file" "cloud_init" {
   template = "${file("${path.module}/files/cloud-init.sh")}"
 
   vars {
-    cluster                        = "${local.identifier}"
-    egress_proxy_url_with_protocol = "${local.egress_proxy_url_with_protocol}"
-    ecs_egress_proxy_setting       = "${local.ecs_egress_proxy_setting}"
+    cluster                          = "${local.identifier}"
+    egress_proxy_url_with_protocol   = "${local.egress_proxy_url_with_protocol}"
+    ecs_egress_proxy_setting         = "${local.ecs_egress_proxy_setting}"
+    journalbeat_egress_proxy_setting = "${local.journalbeat_egress_proxy_setting}"
+    logit_elasticsearch_url          = "${var.logit_elasticsearch_url}"
+    logit_api_key                    = "${var.logit_api_key}"
   }
 }
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -69,15 +69,15 @@ elastic_beats="artifacts.elastic.co/downloads/beats"
 mkdir -p /tmp/journalbeat
 cd /tmp/journalbeat
 
-cat <<EOF > journalbeat-6.5.4-amd64.deb.sha1
-4cd9f172d243bb9ea365e5a9300d297662305201  journalbeat-6.5.4-amd64.deb
+cat <<EOF > journalbeat-6.5.4-amd64.deb.sha512
+5c748e2661d16e004606dea4332deb2e990996056e00a54ecbbf691ab3cd33e02d76ce3609fecade326d8fd06e7b3eb328f92de24cd16c8f49ec3c80e14c8ad4  journalbeat-6.5.4-amd64.deb
 EOF
 
 $CURL --silent --fail \
       -L -O \
       "https://$elastic_beats/journalbeat/journalbeat-6.5.4-amd64.deb"
 
-sha1sum -c journalbeat-6.5.4-amd64.deb.sha1
+sha512sum -c journalbeat-6.5.4-amd64.deb.sha512
 dpkg -i journalbeat-6.5.4-amd64.deb
 )
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -30,6 +30,21 @@ Environment="https_proxy=${egress_proxy_url_with_protocol}"
 Environment="no_proxy=169.254.169.254"
 EOF
 fi
+mkdir -p /etc/amazon/ssm
+cat <<EOF > /etc/amazon/ssm/seelog.xml
+<seelog type="adaptive" mininterval="2000000" maxinterval="100000000" critmsgcount="500" minlevel="warn">
+    <exceptions>
+        <exception filepattern="test*" minlevel="error"/>
+    </exceptions>
+    <outputs formatid="fmtinfo">
+        <console formatid="fmtinfo"/>
+    </outputs>
+    <formats>
+        <format id="fmterror" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+        <format id="fmtdebug" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+    </formats>
+</seelog>
+EOF
 systemctl stop snap.amazon-ssm-agent.amazon-ssm-agent
 systemctl daemon-reload
 systemctl start snap.amazon-ssm-agent.amazon-ssm-agent

--- a/terraform/modules/hub/modules/ecs_asg/iam.tf
+++ b/terraform/modules/hub/modules/ecs_asg/iam.tf
@@ -80,7 +80,13 @@ resource "aws_iam_policy" "instance" {
           "ssmmessages:CreateControlChannel",
           "ssmmessages:CreateDataChannel",
           "ssmmessages:OpenControlChannel",
-          "ssmmessages:OpenDataChannel"
+          "ssmmessages:OpenDataChannel",
+          "ec2messages:AcknowledgeMessage",
+          "ec2messages:DeleteMessage",
+          "ec2messages:FailMessage",
+          "ec2messages:GetEndpoint",
+          "ec2messages:GetMessages",
+          "ec2messages:SendReply"
         ],
         "Resource": "*"
       },

--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -31,3 +31,6 @@ variable "instance_type" {
 variable "use_egress_proxy" {
   default = true
 }
+
+variable "logit_api_key" {}
+variable "logit_elasticsearch_url" {}

--- a/terraform/modules/hub/stub_event_sink.tf
+++ b/terraform/modules/hub/stub_event_sink.tf
@@ -12,6 +12,9 @@ module "event_sink_ecs_asg" {
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
   ]
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
 data "template_file" "event_sink_task_def" {

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -27,3 +27,11 @@ locals {
 variable "wildcard_cert_arn" {
   default = "ACM cert arn for wildcard of signin_domain"
 }
+
+variable "logit_api_key" {
+  description = "Api key used for writing to the logit.io stack"
+}
+
+variable "logit_elasticsearch_url" {
+  description = "URL for logit.io elasticsearch, format: $guid-es.logit.io"
+}


### PR DESCRIPTION
What
----

Sends logs to logit using journalbeat

Why
---

So we get logs

Journalbeat is used so we can just use the OS journal and not worry about
rotating logs

Journalbeat is configured to add some metadata etc

See also
--------

https://github.com/alphagov/verify-infrastructure-config/pull/5