### PR TITLE
Add nginx in front of applications

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "frontend",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "links": ["config"],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "config",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -44,6 +44,6 @@
       "Value": "${domain}"
     }, {
       "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|saml-engine.${domain}|saml-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+      "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|saml-engine.${domain}|saml-proxy.${domain}|saml-soap-proxy.${domain}|event-sink.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "links": ["policy"],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "policy",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "links": ["saml-engine"],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "saml-engine",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "links": ["saml-proxy"],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "saml-proxy",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -41,6 +41,6 @@
       "Value": "${deployment}"
     }, {
       "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+      "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|event-sink.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
+    "cpu": 0,
+    "memory": 250,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "links": ["saml-soap-proxy"],
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
+    ]
+  },
+  {
     "name": "saml-soap-proxy",
     "image": "${image_and_tag}",
     "cpu": 0,

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -41,6 +41,6 @@
       "Value": "${deployment}"
     }, {
       "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-engine.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+      "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-engine.${domain}|event-sink.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/stub.json
+++ b/terraform/modules/hub/files/tasks/stub.json
@@ -1,20 +1,21 @@
 [
   {
-    "name": "stub",
-    "image": "ruby:2.5.3",
+    "name": "nginx",
+    "image": "${nginx_image_and_tag}",
     "cpu": 0,
-    "memory": 3500,
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
-        "containerPort": 8080,
-        "hostPort": 8080
+        "containerPort": 8443,
+        "hostPort": 8443
       }
     ],
-    "entryPoint": [
-      "ruby",
-      "-e",
-      "require 'webrick'; class S < WEBrick::HTTPServlet::AbstractServlet; def do_GET(req,res); res.status = 200; res.content_type = 'text/plain'; app = ENV['APP_NAME']; res.body = ''; end; def do_POST(req,res); res.status = 200; res.content_type = 'text/plain'; app = ENV['APP_NAME']; res.body = ''; end; end; server = WEBrick::HTTPServer.new(Port: 8080); server.mount('/', S); server.start"
+    "environment": [
+      {
+        "Name": "LOCATION_BLOCKS",
+        "Value": "${location_blocks_base64}"
+      }
     ]
   }
 ]

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -18,33 +18,47 @@ module "config_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  config_location_blocks = <<-LOCATIONS
+  location / {
+    proxy_pass http://config:8080;
+    proxy_set_header Host config.${local.root_domain};
+  }
+  LOCATIONS
+
+  nginx_config_location_blocks_base64 = "${base64encode(local.config_location_blocks)}"
+}
+
 data "template_file" "config_task_def" {
   template = "${file("${path.module}/files/tasks/hub-config.json")}"
 
   vars {
-    image_and_tag       = "${local.tools_account_ecr_url_prefix}-verify-config:latest"
-    domain              = "${local.root_domain}"
-    deployment          = "${var.deployment}"
-    truststore_password = "${var.truststore_password}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-config:latest"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                 = "${local.root_domain}"
+    deployment             = "${var.deployment}"
+    truststore_password    = "${var.truststore_password}"
+    location_blocks_base64 = "${local.nginx_config_location_blocks_base64}"
   }
 }
 
 module "config" {
   source = "modules/ecs_app"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "config"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.config_task_def.rendered}"
-  container_name             = "config"
-  container_port             = "8080"
-  number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
-  health_check_path          = "/service-status"
-  tools_account_id           = "${var.tools_account_id}"
-  image_name                 = "verify-config"
-  instance_security_group_id = "${module.config_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  deployment                   = "${var.deployment}"
+  cluster                      = "config"
+  domain                       = "${local.root_domain}"
+  vpc_id                       = "${aws_vpc.hub.id}"
+  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
+  task_definition              = "${data.template_file.config_task_def.rendered}"
+  container_name               = "nginx"
+  container_port               = "8443"
+  number_of_tasks              = 1
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
+  health_check_path            = "/service-status"
+  tools_account_id             = "${var.tools_account_id}"
+  image_name                   = "verify-config"
+  instance_security_group_id   = "${module.config_ecs_asg.instance_sg_id}"
+  certificate_arn              = "${local.wildcard_cert_arn}"
 }

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -45,20 +45,18 @@ data "template_file" "config_task_def" {
 module "config" {
   source = "modules/ecs_app"
 
-  deployment                   = "${var.deployment}"
-  cluster                      = "config"
-  domain                       = "${local.root_domain}"
-  vpc_id                       = "${aws_vpc.hub.id}"
-  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
-  task_definition              = "${data.template_file.config_task_def.rendered}"
-  container_name               = "nginx"
-  container_port               = "8443"
-  number_of_tasks              = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
-  health_check_path            = "/service-status"
-  tools_account_id             = "${var.tools_account_id}"
-  image_name                   = "verify-config"
-  instance_security_group_id   = "${module.config_ecs_asg.instance_sg_id}"
-  certificate_arn              = "${local.wildcard_cert_arn}"
+  deployment                 = "${var.deployment}"
+  cluster                    = "config"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.config_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  health_check_path          = "/service-status"
+  tools_account_id           = "${var.tools_account_id}"
+  image_name                 = "verify-config"
+  instance_security_group_id = "${module.config_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
 }

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -44,22 +44,20 @@ data "template_file" "policy_task_def" {
 module "policy" {
   source = "modules/ecs_app"
 
-  deployment                   = "${var.deployment}"
-  cluster                      = "policy"
-  domain                       = "${local.root_domain}"
-  vpc_id                       = "${aws_vpc.hub.id}"
-  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
-  task_definition              = "${data.template_file.policy_task_def.rendered}"
-  container_name               = "nginx"
-  container_port               = "8443"
-  number_of_tasks              = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
-  health_check_path            = "/service-status"
-  tools_account_id             = "${var.tools_account_id}"
-  image_name                   = "verify-policy"
-  instance_security_group_id   = "${module.policy_ecs_asg.instance_sg_id}"
-  certificate_arn              = "${local.wildcard_cert_arn}"
+  deployment                 = "${var.deployment}"
+  cluster                    = "policy"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.policy_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  health_check_path          = "/service-status"
+  tools_account_id           = "${var.tools_account_id}"
+  image_name                 = "verify-policy"
+  instance_security_group_id = "${module.policy_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
 }
 
 module "policy_can_connect_to_config" {

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -18,36 +18,49 @@ module "policy_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  policy_location_blocks = <<-LOCATIONS
+  location / {
+    proxy_pass http://policy:8080;
+    proxy_set_header Host policy.${local.root_domain};
+  }
+  LOCATIONS
+
+  nginx_policy_location_blocks_base64 = "${base64encode(local.policy_location_blocks)}"
+}
+
 data "template_file" "policy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-policy.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-policy:latest"
-    domain        = "${local.root_domain}"
-    deployment    = "${var.deployment}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-policy:latest"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                 = "${local.root_domain}"
+    deployment             = "${var.deployment}"
+    location_blocks_base64 = "${local.nginx_policy_location_blocks_base64}"
   }
 }
 
 module "policy" {
   source = "modules/ecs_app"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "policy"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.policy_task_def.rendered}"
-  container_name             = "policy"
-  container_port             = "8080"
-  number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
-  health_check_path          = "/service-status"
-  tools_account_id           = "${var.tools_account_id}"
-  image_name                 = "verify-policy"
-  instance_security_group_id = "${module.policy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  deployment                   = "${var.deployment}"
+  cluster                      = "policy"
+  domain                       = "${local.root_domain}"
+  vpc_id                       = "${aws_vpc.hub.id}"
+  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
+  task_definition              = "${data.template_file.policy_task_def.rendered}"
+  container_name               = "nginx"
+  container_port               = "8443"
+  number_of_tasks              = 1
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
+  health_check_path            = "/service-status"
+  tools_account_id             = "${var.tools_account_id}"
+  image_name                   = "verify-policy"
+  instance_security_group_id   = "${module.policy_ecs_asg.instance_sg_id}"
+  certificate_arn              = "${local.wildcard_cert_arn}"
 }
-
 
 module "policy_can_connect_to_config" {
   source = "modules/microservice_connection"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -55,8 +55,6 @@ module "saml_engine" {
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-saml-engine"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -18,15 +18,28 @@ module "saml_engine_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  saml_engine_location_blocks = <<-LOCATIONS
+  location / {
+    proxy_pass http://saml-engine:8080;
+    proxy_set_header Host saml-engine.${local.root_domain};
+  }
+  LOCATIONS
+
+  nginx_saml_engine_location_blocks_base64 = "${base64encode(local.saml_engine_location_blocks)}"
+}
+
 data "template_file" "saml_engine_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-engine.json")}"
 
   vars {
-    account_id    = "${data.aws_caller_identity.account.account_id}"
-    deployment    = "${var.deployment}"
-    domain        = "${local.root_domain}"
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:latest"
-    region        = "${data.aws_region.region.id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
+    deployment             = "${var.deployment}"
+    domain                 = "${local.root_domain}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:latest"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    region                 = "${data.aws_region.region.id}"
+    location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"
   }
 }
 
@@ -39,10 +52,11 @@ module "saml_engine" {
   vpc_id                     = "${aws_vpc.hub.id}"
   lb_subnets                 = ["${aws_subnet.internal.*.id}"]
   task_definition            = "${data.template_file.saml_engine_task_def.rendered}"
-  container_name             = "saml-engine"
-  container_port             = "8080"
+  container_name             = "nginx"
+  container_port             = "8443"
   number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-saml-engine"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -17,34 +17,48 @@ module "saml_proxy_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  saml_proxy_location_blocks = <<-LOCATIONS
+  location / {
+    proxy_pass http://saml-proxy:8080;
+    proxy_set_header Host saml-proxy.${local.root_domain};
+  }
+  LOCATIONS
+
+  nginx_saml_proxy_location_blocks_base64 = "${base64encode(local.saml_proxy_location_blocks)}"
+}
+
 data "template_file" "saml_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-proxy.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:latest"
-    domain        = "${local.root_domain}"
-    deployment    = "${var.deployment}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:latest"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                 = "${local.root_domain}"
+    deployment             = "${var.deployment}"
+    location_blocks_base64 = "${local.nginx_saml_proxy_location_blocks_base64}"
   }
 }
 
 module "saml_proxy" {
   source = "modules/ecs_app"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "saml-proxy"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.saml_proxy_task_def.rendered}"
-  container_name             = "saml-proxy"
-  container_port             = "8080"
-  number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
-  health_check_path          = "/service-status"
-  tools_account_id           = "${var.tools_account_id}"
-  instance_security_group_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
-  image_name                 = "verify-saml-proxy"
+  deployment                   = "${var.deployment}"
+  cluster                      = "saml-proxy"
+  domain                       = "${local.root_domain}"
+  vpc_id                       = "${aws_vpc.hub.id}"
+  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
+  task_definition              = "${data.template_file.saml_proxy_task_def.rendered}"
+  container_name               = "nginx"
+  container_port               = "8443"
+  number_of_tasks              = 1
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
+  health_check_path            = "/service-status"
+  tools_account_id             = "${var.tools_account_id}"
+  instance_security_group_id   = "${module.saml_proxy_ecs_asg.instance_sg_id}"
+  certificate_arn              = "${local.wildcard_cert_arn}"
+  image_name                   = "verify-saml-proxy"
 }
 
 module "saml_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -43,22 +43,20 @@ data "template_file" "saml_proxy_task_def" {
 module "saml_proxy" {
   source = "modules/ecs_app"
 
-  deployment                   = "${var.deployment}"
-  cluster                      = "saml-proxy"
-  domain                       = "${local.root_domain}"
-  vpc_id                       = "${aws_vpc.hub.id}"
-  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
-  task_definition              = "${data.template_file.saml_proxy_task_def.rendered}"
-  container_name               = "nginx"
-  container_port               = "8443"
-  number_of_tasks              = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
-  health_check_path            = "/service-status"
-  tools_account_id             = "${var.tools_account_id}"
-  instance_security_group_id   = "${module.saml_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn              = "${local.wildcard_cert_arn}"
-  image_name                   = "verify-saml-proxy"
+  deployment                 = "${var.deployment}"
+  cluster                    = "saml-proxy"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.saml_proxy_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  health_check_path          = "/service-status"
+  tools_account_id           = "${var.tools_account_id}"
+  instance_security_group_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
+  image_name                 = "verify-saml-proxy"
 }
 
 module "saml_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -17,34 +17,48 @@ module "saml_soap_proxy_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  saml_soap_proxy_location_blocks = <<-LOCATIONS
+  location / {
+    proxy_pass http://saml-soap-proxy:8080;
+    proxy_set_header Host saml-soap-proxy.${local.root_domain};
+  }
+  LOCATIONS
+
+  nginx_saml_soap_proxy_location_blocks_base64 = "${base64encode(local.saml_soap_proxy_location_blocks)}"
+}
+
 data "template_file" "saml_soap_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-soap-proxy.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:latest"
-    domain        = "${local.root_domain}"
-    deployment    = "${var.deployment}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:latest"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                 = "${local.root_domain}"
+    deployment             = "${var.deployment}"
+    location_blocks_base64 = "${local.nginx_saml_soap_proxy_location_blocks_base64}"
   }
 }
 
 module "saml_soap_proxy" {
   source = "modules/ecs_app"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "saml-soap-proxy"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.saml_soap_proxy_task_def.rendered}"
-  container_name             = "saml-soap-proxy"
-  container_port             = "8080"
-  number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
-  health_check_path          = "/service-status"
-  tools_account_id           = "${var.tools_account_id}"
-  instance_security_group_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
-  image_name                 = "verify-saml-soap-proxy"
+  deployment                   = "${var.deployment}"
+  cluster                      = "saml-soap-proxy"
+  domain                       = "${local.root_domain}"
+  vpc_id                       = "${aws_vpc.hub.id}"
+  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
+  task_definition              = "${data.template_file.saml_soap_proxy_task_def.rendered}"
+  container_name               = "nginx"
+  container_port               = "8443"
+  number_of_tasks              = 1
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
+  health_check_path            = "/service-status"
+  tools_account_id             = "${var.tools_account_id}"
+  instance_security_group_id   = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
+  certificate_arn              = "${local.wildcard_cert_arn}"
+  image_name                   = "verify-saml-soap-proxy"
 }
 
 module "saml_soap_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -43,22 +43,20 @@ data "template_file" "saml_soap_proxy_task_def" {
 module "saml_soap_proxy" {
   source = "modules/ecs_app"
 
-  deployment                   = "${var.deployment}"
-  cluster                      = "saml-soap-proxy"
-  domain                       = "${local.root_domain}"
-  vpc_id                       = "${aws_vpc.hub.id}"
-  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
-  task_definition              = "${data.template_file.saml_soap_proxy_task_def.rendered}"
-  container_name               = "nginx"
-  container_port               = "8443"
-  number_of_tasks              = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
-  health_check_path            = "/service-status"
-  tools_account_id             = "${var.tools_account_id}"
-  instance_security_group_id   = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn              = "${local.wildcard_cert_arn}"
-  image_name                   = "verify-saml-soap-proxy"
+  deployment                 = "${var.deployment}"
+  cluster                    = "saml-soap-proxy"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.saml_soap_proxy_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  health_check_path          = "/service-status"
+  tools_account_id           = "${var.tools_account_id}"
+  instance_security_group_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
+  image_name                 = "verify-saml-soap-proxy"
 }
 
 module "saml_soap_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/modules/ecs_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_app/lb.tf
@@ -13,8 +13,8 @@ resource "aws_lb" "cluster" {
 
 resource "aws_lb_target_group" "task" {
   name                 = "${local.identifier}-task"
-  port                 = "${var.aws_lb_target_group_port}"
-  protocol             = "${var.aws_lb_target_group_protocol}"
+  port                 = "8443"
+  protocol             = "HTTPS"
   target_type          = "instance"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = 60

--- a/terraform/modules/hub/modules/ecs_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_app/lb.tf
@@ -13,8 +13,8 @@ resource "aws_lb" "cluster" {
 
 resource "aws_lb_target_group" "task" {
   name                 = "${local.identifier}-task"
-  port                 = 80
-  protocol             = "HTTP"
+  port                 = "${var.aws_lb_target_group_port}"
+  protocol             = "${var.aws_lb_target_group_protocol}"
   target_type          = "instance"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = 60

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -52,11 +52,3 @@ variable "health_check_timeout" {
 variable "health_check_http_codes" {
   default = "200"
 }
-
-variable "aws_lb_target_group_port" {
-  default = 80
-}
-
-variable "aws_lb_target_group_protocol" {
-  default = "HTTP"
-}

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -52,3 +52,11 @@ variable "health_check_timeout" {
 variable "health_check_http_codes" {
   default = "200"
 }
+
+variable "aws_lb_target_group_port" {
+  default = 80
+}
+
+variable "aws_lb_target_group_protocol" {
+  default = "HTTP"
+}

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
@@ -42,7 +42,10 @@ resource "aws_iam_policy" "execution" {
         "ecr:DescribeImages",
         "ecr:BatchGetImage"
       ],
-      "Resource": "arn:aws:ecr:eu-west-2:${var.tools_account_id}:repository/platform-deployer-${local.image_name}"
+      "Resource": [
+        "arn:aws:ecr:eu-west-2:${var.tools_account_id}:repository/platform-deployer-${local.image_name}",
+        "arn:aws:ecr:eu-west-2:${var.tools_account_id}:repository/platform-deployer-verify-nginx-tls"
+      ]
     }, {
       "Effect": "Allow",
       "Action": [

--- a/terraform/modules/hub/stub_event_sink.tf
+++ b/terraform/modules/hub/stub_event_sink.tf
@@ -39,18 +39,16 @@ data "template_file" "event_sink_task_def" {
 module "event_sink" {
   source = "modules/ecs_app"
 
-  deployment                   = "${var.deployment}"
-  cluster                      = "event-sink"
-  domain                       = "${local.root_domain}"
-  vpc_id                       = "${aws_vpc.hub.id}"
-  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
-  task_definition              = "${data.template_file.event_sink_task_def.rendered}"
-  container_name               = "nginx"
-  container_port               = "8443"
-  number_of_tasks              = 1
-  aws_lb_target_group_port     = 8443
-  aws_lb_target_group_protocol = "HTTPS"
-  tools_account_id             = "${var.tools_account_id}"
-  instance_security_group_id   = "${module.event_sink_ecs_asg.instance_sg_id}"
-  certificate_arn              = "${local.wildcard_cert_arn}"
+  deployment                 = "${var.deployment}"
+  cluster                    = "event-sink"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.event_sink_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  tools_account_id           = "${var.tools_account_id}"
+  instance_security_group_id = "${module.event_sink_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
 }

--- a/terraform/modules/hub/stub_event_sink.tf
+++ b/terraform/modules/hub/stub_event_sink.tf
@@ -17,24 +17,40 @@ module "event_sink_ecs_asg" {
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }
 
+locals {
+  event_sink_location_blocks = <<-LOCATIONS
+  location / {
+    return 200;
+  }
+  LOCATIONS
+
+  nginx_event_sink_location_blocks_base64 = "${base64encode(local.event_sink_location_blocks)}"
+}
+
 data "template_file" "event_sink_task_def" {
   template = "${file("${path.module}/files/tasks/stub.json")}"
+
+  vars {
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    location_blocks_base64 = "${local.nginx_event_sink_location_blocks_base64}"
+  }
 }
 
 module "event_sink" {
   source = "modules/ecs_app"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "event-sink"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.event_sink_task_def.rendered}"
-  container_name             = "stub"
-  container_port             = "8080"
-  number_of_tasks            = 1
-  health_check_protocol      = "HTTP"
-  tools_account_id           = "${var.tools_account_id}"
-  instance_security_group_id = "${module.event_sink_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  deployment                   = "${var.deployment}"
+  cluster                      = "event-sink"
+  domain                       = "${local.root_domain}"
+  vpc_id                       = "${aws_vpc.hub.id}"
+  lb_subnets                   = ["${aws_subnet.internal.*.id}"]
+  task_definition              = "${data.template_file.event_sink_task_def.rendered}"
+  container_name               = "nginx"
+  container_port               = "8443"
+  number_of_tasks              = 1
+  aws_lb_target_group_port     = 8443
+  aws_lb_target_group_protocol = "HTTPS"
+  tools_account_id             = "${var.tools_account_id}"
+  instance_security_group_id   = "${module.event_sink_ecs_asg.instance_sg_id}"
+  certificate_arn              = "${local.wildcard_cert_arn}"
 }


### PR DESCRIPTION
This pull request adds nginx in front of all applications to act as a SSL termination and is used for encrypting communications between Application Load Balancer (ALB) and nginx over the network since they are not running on the same server or EC2 instance.