### PR TITLE
Add some load balancer rules to direct traffic to prom-n instances

### DIFF
--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -52,8 +52,13 @@ resource "aws_lb_listener" "mgmt_http" {
   #   }
   # }
   default_action {
-    type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus.arn}"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "🛠️"
+      status_code  = "200"
+    }
   }
 }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -220,3 +220,19 @@ resource "aws_lb_target_group_attachment" "prometheus" {
   target_id        = "${element(aws_instance.prometheus.*.id, count.index)}"
   port             = 9090
 }
+
+resource "aws_lb_listener_rule" "prometheus_https" {
+  count = "${var.number_of_availability_zones}"
+  listener_arn = "${aws_lb_listener.mgmt_http.arn}"
+  priority     = "${100 + count.index}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.prometheus.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["prom-${count.index + 1}.*"]
+  }
+}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -214,7 +214,7 @@ resource "aws_lb_target_group" "prometheus" {
 }
 
 resource "aws_lb_target_group_attachment" "prometheus" {
-  count = 1
+  count = "${var.number_of_availability_zones}"
 
   target_group_arn = "${aws_lb_target_group.prometheus.arn}"
   target_id        = "${element(aws_instance.prometheus.*.id, count.index)}"


### PR DESCRIPTION
- Fix up the `count` of the target group I forgot in #18.
- Add some load balancer rules to send traffic to `prom-{1,2}`.
- Add a static response (🛠) to `mgmt.root_domain`.

Paired with @tlwr. 🎉 