### PR TITLE
Add MGMT route53 zone and ACM cert & make Prom use it

### DIFF
--- a/terraform/modules/account/signin_domain.tf
+++ b/terraform/modules/account/signin_domain.tf
@@ -14,7 +14,6 @@ locals {
   domain_root = "${replace(var.signin_domain, "/^www[.]/", "")}"
 }
 
-# terraform state mv wildcard_new to wildcard after we change the environment domain
 resource "aws_acm_certificate" "wildcard" {
   domain_name               = "${var.signin_domain}"
   subject_alternative_names = ["*.${local.domain_root}"]

--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -85,6 +85,18 @@ resource "aws_route53_record" "mgmt_subdomain" {
   }
 }
 
+resource "aws_route53_record" "mgmt_wildcard_subdomain" {
+  zone_id = "${aws_route53_zone.mgmt_domain.zone_id}"
+  name    = "*.${local.mgmt_domain}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.mgmt.dns_name}"
+    zone_id                = "${aws_lb.mgmt.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_lb" "mgmt" {
   name               = "${var.deployment}-mgmt"
   internal           = false

--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -42,15 +42,23 @@ resource "aws_lb_listener" "mgmt_http" {
   port              = "80"
   protocol          = "HTTP"
 
-  # default_action {
-  #   type = "redirect"
+  default_action {
+    type = "redirect"
 
-  #   redirect {
-  #     port        = "443"
-  #     protocol    = "HTTPS"
-  #     status_code = "HTTP_301"
-  #   }
-  # }
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "mgmt_https" {
+  load_balancer_arn = "${aws_lb.mgmt.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = "${aws_acm_certificate.mgmt_wildcard.arn}"
+
   default_action {
     type = "fixed-response"
 
@@ -61,18 +69,6 @@ resource "aws_lb_listener" "mgmt_http" {
     }
   }
 }
-
-# resource "aws_lb_listener" "mgmt_https" {
-#   load_balancer_arn = "${aws_lb.mgmt.arn}"
-#   port              = "443"
-#   protocol          = "HTTPS"
-#   certificate_arn   = "${local.wildcard_cert_arn}"
-# 
-#   default_action {
-#     type             = "forward"
-#     target_group_arn = "${aws_lb_target_group.mgmt_frontend.arn}"
-#   }
-# }
 
 locals {
   mgmt_domain = "mgmt.${local.root_domain}"

--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -74,10 +74,41 @@ resource "aws_lb_listener" "mgmt_http" {
 #   }
 # }
 
+locals {
+  mgmt_domain = "mgmt.${local.root_domain}"
+}
+
 resource "aws_route53_zone" "mgmt_domain" {
-  name = "mgmt.${local.root_domain}"
+  name = "${local.mgmt_domain}"
 
   tags {
     Deployment = "${var.deployment}"
   }
+}
+
+resource "aws_acm_certificate" "mgmt_wildcard" {
+  domain_name       = "${local.mgmt_domain}"
+  subject_alternative_names = ["*.${local.mgmt_domain}"]
+  validation_method = "DNS"
+
+  tags {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_route53_record" "mgmt_wildcard_cert_validation" {
+  name    = "${aws_acm_certificate.mgmt_wildcard.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.mgmt_wildcard.domain_validation_options.0.resource_record_type}"
+  zone_id = "${aws_route53_zone.mgmt_domain.zone_id}"
+
+  records = [
+    "${aws_acm_certificate.mgmt_wildcard.domain_validation_options.0.resource_record_value}",
+  ]
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "mgmt_wildcard" {
+  certificate_arn         = "${aws_acm_certificate.mgmt_wildcard.arn}"
+  validation_record_fqdns = ["${aws_route53_record.mgmt_wildcard_cert_validation.fqdn}"]
 }

--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -74,3 +74,10 @@ resource "aws_lb_listener" "mgmt_http" {
 #   }
 # }
 
+resource "aws_route53_zone" "mgmt_domain" {
+  name = "mgmt.${local.root_domain}"
+
+  tags {
+    Deployment = "${var.deployment}"
+  }
+}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -223,7 +223,7 @@ resource "aws_lb_target_group_attachment" "prometheus" {
 
 resource "aws_lb_listener_rule" "prometheus_https" {
   count = "${var.number_of_availability_zones}"
-  listener_arn = "${aws_lb_listener.mgmt_http.arn}"
+  listener_arn = "${aws_lb_listener.mgmt_https.arn}"
   priority     = "${100 + count.index}"
 
   action {


### PR DESCRIPTION
What
----

- Adds MGMT route53 zone (mgmt.$root_domain)
- Adds wildcard ACM cert for mgmt.$root_domain
- prometheus-$N to use ACM cert (via mgmt LB)

Why
---

We want to have a mgmt subdomain so we can make sweeping mgmt dns changes
inside the hub module rather than doing across the dns main repo and this one.

Additional
---

We have also snowflaked the data sources in the tools grafana and made them use prometheus as a datasource variable.

Co-author: @issyl0 @tlwr