### PR TITLE
Change Target Groups to forward to correct Prom.

### DIFF
--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -200,7 +200,9 @@ resource "aws_volume_attachment" "prometheus_prometheus" {
 }
 
 resource "aws_lb_target_group" "prometheus" {
-  name     = "${var.deployment}-prometheus"
+  count = "${var.number_of_availability_zones}"
+
+  name     = "${var.deployment}-prometheus-${count.index}"
   port     = 9090
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.hub.id}"
@@ -216,7 +218,7 @@ resource "aws_lb_target_group" "prometheus" {
 resource "aws_lb_target_group_attachment" "prometheus" {
   count = "${var.number_of_availability_zones}"
 
-  target_group_arn = "${aws_lb_target_group.prometheus.arn}"
+  target_group_arn = "${element(aws_lb_target_group.prometheus.*.arn, count.index)}"
   target_id        = "${element(aws_instance.prometheus.*.id, count.index)}"
   port             = 9090
 }

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -230,7 +230,9 @@ resource "aws_lb_listener_rule" "prometheus_https" {
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus.arn}"
+    target_group_arn = "${
+      element(aws_lb_target_group.prometheus.*.arn, count.index)
+    }"
   }
 
   condition {


### PR DESCRIPTION
There was one target group which was sending traffic to both Prometheus
and this target group was addressed on both domains so traffic could
arrive at either Prometheis.

Added new target group to direct traffic to each Prometheus
individually.

Co-author: @matthewcullum-gds @tlwr