### PR TITLE
AUTO110: Update Prometheus to scrape metrics from all apps

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -36,20 +36,31 @@
       "server",
       "/tmp/config.yml"
     ],
-    "environment": [{
-      "Name": "CONFIG_DATA_PATH",
-      "Value": "/tmp/federation/configuration/config-service-data/${deployment}"
-    }, {
-      "Name": "RP_TRUSTSTORE_PASSWORD",
-      "Value": "${truststore_password}"
-    }, {
-      "Name": "CLIENT_TRUSTSTORE_PASSWORD",
-      "Value": "${truststore_password}"
-    }, {
-      "Name": "DEPLOYMENT",
-      "Value": "${deployment}"
-    }, {
-      "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+    "environment": [
+      {
+        "Name": "CONFIG_DATA_PATH",
+        "Value": "/tmp/federation/configuration/config-service-data/${deployment}"
+      },
+      {
+        "Name": "RP_TRUSTSTORE_PASSWORD",
+        "Value": "${truststore_password}"
+      },
+      {
+        "Name": "CLIENT_TRUSTSTORE_PASSWORD",
+        "Value": "${truststore_password}"
+      },
+      {
+        "Name": "DEPLOYMENT",
+        "Value": "${deployment}"
+      },
+      {
+        "Name": "JAVA_OPTS",
+        "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
+      },
+      {
+        "Name": "PROMETHEUS_METRICS_PATH",
+        "Value": "/prometheus/metrics"
+      }
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -46,14 +46,23 @@
       }
     ],
     "entryPoint": ["/saml-engine/bin/saml-engine", "server", "/tmp/saml-engine.yml"],
-    "environment": [{
-      "Name": "DEPLOYMENT",
-      "Value": "${deployment}"
-    }, {
-      "Name": "DOMAIN",
-      "Value": "${domain}"
-    }, {
-      "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+    "environment": [
+      {
+        "Name": "DEPLOYMENT",
+        "Value": "${deployment}"
+      },
+      {
+        "Name": "DOMAIN",
+        "Value": "${domain}"
+      },
+      {
+        "Name": "JAVA_OPTS",
+        "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
+      },
+      {
+        "Name": "PROMETHEUS_METRICS_PATH",
+        "Value": "/prometheus/metrics"
+      }
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -36,11 +36,19 @@
       "server",
       "/tmp/saml-proxy.yml"
     ],
-    "environment": [{
-      "Name": "DEPLOYMENT",
-      "Value": "${deployment}"
-    }, {
-      "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+    "environment": [
+      {
+        "Name": "DEPLOYMENT",
+        "Value": "${deployment}"
+      },
+      {
+        "Name": "JAVA_OPTS",
+        "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
+      },
+      {
+        "Name": "PROMETHEUS_METRICS_PATH",
+        "Value": "/prometheus/metrics"
+      }
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -36,11 +36,19 @@
       "server",
       "/tmp/saml-soap-proxy.yml"
     ],
-    "environment": [{
-      "Name": "DEPLOYMENT",
-      "Value": "${deployment}"
-    }, {
-      "Name": "JAVA_OPTS",
-      "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-engine.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5" }]
+    "environment": [
+      {
+        "Name": "DEPLOYMENT",
+        "Value": "${deployment}"
+      },
+      {
+        "Name": "JAVA_OPTS",
+        "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-engine.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
+      },
+      {
+        "Name": "PROMETHEUS_METRICS_PATH",
+        "Value": "/prometheus/metrics"
+      }
+    ]
   }
 ]

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -21,6 +21,10 @@ module "config_ecs_asg" {
 
 locals {
   config_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://config:8081;
+    proxy_set_header Host config.${local.root_domain};
+  }
   location / {
     proxy_pass http://config:8080;
     proxy_set_header Host config.${local.root_domain};

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -21,6 +21,10 @@ module "saml_engine_ecs_asg" {
 
 locals {
   saml_engine_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://saml-engine:8081;
+    proxy_set_header Host saml-engine.${local.root_domain};
+  }
   location / {
     proxy_pass http://saml-engine:8080;
     proxy_set_header Host saml-engine.${local.root_domain};

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -20,6 +20,10 @@ module "saml_proxy_ecs_asg" {
 
 locals {
   saml_proxy_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://saml-proxy:8081;
+    proxy_set_header Host saml-proxy.${local.root_domain};
+  }
   location / {
     proxy_pass http://saml-proxy:8080;
     proxy_set_header Host saml-proxy.${local.root_domain};

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -20,6 +20,10 @@ module "saml_soap_proxy_ecs_asg" {
 
 locals {
   saml_soap_proxy_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://saml-soap-proxy:8081;
+    proxy_set_header Host saml-soap-proxy.${local.root_domain};
+  }
   location / {
     proxy_pass http://saml-soap-proxy:8080;
     proxy_set_header Host saml-soap-proxy.${local.root_domain};

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -41,6 +41,42 @@ module "prometheus_can_talk_to_policy" {
   port = 8443
 }
 
+module "prometheus_can_talk_to_config" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.config_ecs_asg.instance_sg_id}"
+
+  port = 8443
+}
+
+module "prometheus_can_talk_to_saml_engine" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.saml_engine_ecs_asg.instance_sg_id}"
+
+  port = 8443
+}
+
+module "prometheus_can_talk_to_saml_proxy" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"
+
+  port = 8443
+}
+
+module "prometheus_can_talk_to_saml_soap_proxy" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
+
+  port = 8443
+}
+
 resource "aws_iam_role" "prometheus" {
   name = "${var.deployment}-prometheus"
 


### PR DESCRIPTION
This pull request contains the following changes.

- Update nginx to allow requests to go to prometheus metrics endpoints in all Hub applications (Config, SAML Engine, SAML Proxy and SAML SOAP Proxy).
- Update the applications' task definitions files to include a specified PROMETHEUS_METRICS_PATH environment variable to request them to use the specified Prometheus metrics endpoints.

Prometheus server currently uses https (port number: 8443) to scrape metrics data from policy application in Joint environment.

Author: @adityapahuja