### PR TITLE
remove unused PROMETHEUS_METRICS_PATH envvars

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -56,10 +56,6 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
-      },
-      {
-        "Name": "PROMETHEUS_METRICS_PATH",
-        "Value": "/prometheus/metrics"
       }
     ]
   }

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -48,10 +48,6 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|saml-engine.${domain}|saml-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
-      },
-      {
-        "Name": "PROMETHEUS_METRICS_PATH",
-        "Value": "/prometheus/metrics"
       }
     ]
   }

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -58,10 +58,6 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
-      },
-      {
-        "Name": "PROMETHEUS_METRICS_PATH",
-        "Value": "/prometheus/metrics"
       }
     ]
   }

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -44,10 +44,6 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
-      },
-      {
-        "Name": "PROMETHEUS_METRICS_PATH",
-        "Value": "/prometheus/metrics"
       }
     ]
   }

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -44,10 +44,6 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"config.${domain}|policy.${domain}|saml-engine.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5",
-      },
-      {
-        "Name": "PROMETHEUS_METRICS_PATH",
-        "Value": "/prometheus/metrics"
       }
     ]
   }


### PR DESCRIPTION
These are consumed by MetricsBundle which is the Old And Busted way of
doing prometheus metrics.  The new thing (PrometheusBundle) just
hardcodes the metrics path to /prometheus/metrics.