### PR TITLE
BAU: Update Node Exporter to ignore docker directory

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -152,5 +152,6 @@ docker run \
   amazon/amazon-ecs-agent:v1.23.0
 
 apt-get install --yes prometheus-node-exporter
+sed -i 's/sys|proc|dev|run/sys|proc|dev|run|var\/lib\/docker/' /etc/default/prometheus-node-exporter
 systemctl enable prometheus-node-exporter
-systemctl start prometheus-node-exporter
+systemctl restart prometheus-node-exporter


### PR DESCRIPTION
Prometheus Node Exporter does not have permission to read /var/lib/docker directory and it generates permission denied errors regularly in its log file. This commit updates Prometheus Node Exporter not to access /var/lib/docker directory. This will eliminate permission denied errors from the log file. It also updates cloud-init.sh to restart prometheus-node-exporter to pick up config changes.

Co-authored-by: Isabell (Issy) Long <me@issyl0.co.uk>