### PR TITLE
Static ingress

### DIFF
--- a/dockerfiles/haproxy-static-ingress/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress/Dockerfile
@@ -1,0 +1,5 @@
+FROM haproxy:1.9.0-alpine
+
+RUN addgroup -S haproxy && adduser -S -G haproxy haproxy
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress/Dockerfile
@@ -2,4 +2,12 @@ FROM haproxy:1.9.0-alpine
 
 RUN addgroup -S haproxy && adduser -S -G haproxy haproxy
 
+WORKDIR /tmp
+
+USER haproxy
+
+COPY . /tmp
+
+ENTRYPOINT ["/tmp/docker-entrypoint.sh"]
+
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env ash
+set -ueo pipefail
+
+backends="${BACKENDS:?BACKENDS not set}"
+backends="$(echo "$backends" | base64 -d)"
+export backends
+
+envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl
+
+CMD ["haproxy", "-f", "/tmp/haproxy.cfg"]

--- a/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 set -ueo pipefail
 
 backends="${BACKENDS:?BACKENDS not set}"
-backends="$(echo "$backends" | base64 -d)"
 export backends
 
 envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg
@@ -3,23 +3,17 @@ global
     log stdout local0 info
     user haproxy
     group haproxy
-    ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
-    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
 
 defaults
     timeout connect 10s
     timeout client 30s
     timeout server 30s
     log global
-    mode http
-    option httplog
+    option tcplog
     maxconn 3000
 
 frontend gitweb
     bind *:4500
-    # bind 10.0.0.3:443 ssl crt /etc/ssl/certs/mysite.pem
-    # http-request redirect scheme https unless { ssl_fc }
-    # use_backend api_servers if { path_beg /api/ }
     default_backend web_servers
 
 backend web_servers

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg
@@ -1,5 +1,5 @@
 global
-    maxconn 50000
+    maxconn 10000
     log stdout local0 info
     user haproxy
     group haproxy
@@ -10,7 +10,7 @@ defaults
     timeout server 30s
     log global
     option tcplog
-    maxconn 3000
+    maxconn 10000
 
 frontend gitweb
     bind *:4500

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg
@@ -1,0 +1,30 @@
+global
+    maxconn 50000
+    log stdout local0 info
+    user haproxy
+    group haproxy
+    ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+    log global
+    mode http
+    option httplog
+    maxconn 3000
+
+frontend gitweb
+    bind *:4500
+    # bind 10.0.0.3:443 ssl crt /etc/ssl/certs/mysite.pem
+    # http-request redirect scheme https unless { ssl_fc }
+    # use_backend api_servers if { path_beg /api/ }
+    default_backend web_servers
+
+backend web_servers
+    balance roundrobin
+    option httpchk GET /
+    default-server check maxconn 20
+    server firstserver host.docker.internal:1234
+    server secondserver host.docker.internal:1233

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg
@@ -12,13 +12,12 @@ defaults
     option tcplog
     maxconn 10000
 
-frontend gitweb
+frontend nlb
     bind *:4500
-    default_backend web_servers
+    default_backend alb
 
-backend web_servers
+backend alb
     balance roundrobin
-    option httpchk GET /
     default-server check maxconn 20
     server firstserver host.docker.internal:1234
     server secondserver host.docker.internal:1233

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg.tpl
@@ -19,4 +19,4 @@ frontend nlb
 backend alb
     balance roundrobin
     default-server check maxconn 200
-$BACKENDS
+    $BACKENDS

--- a/dockerfiles/haproxy-static-ingress/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress/haproxy.cfg.tpl
@@ -18,6 +18,5 @@ frontend nlb
 
 backend alb
     balance roundrobin
-    default-server check maxconn 20
-    server firstserver host.docker.internal:1234
-    server secondserver host.docker.internal:1233
+    default-server check maxconn 200
+$BACKENDS

--- a/terraform/modules/hub/eips.tf
+++ b/terraform/modules/hub/eips.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "ingress" {
-  count = "${var.number_of_availability_zones}"
+  count = 3
   vpc   = true
 }
 

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "static-ingress",
+    "image": "${image_and_tag}",
+    "cpu": 0,
+    "memory": 3500,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 4500,
+        "hostPort": 4500
+      }
+    ],
+    "entryPoint": [
+        "TODO"
+    ],
+    "environment": [{
+      "Name": "BACKENDS",
+      "Value": "${backends}"
+    }]
+  }
+]

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -11,9 +11,6 @@
         "hostPort": 4500
       }
     ],
-    "entryPoint": [
-        "TODO"
-    ],
     "environment": [{
       "Name": "BACKENDS",
       "Value": "${backends}"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -28,23 +28,43 @@ data "template_file" "static_ingress_task_def" {
   }
 }
 
-module "static-ingress" {
-  source = "modules/ecs_app"
+module "static_ingress_ecs_roles" {
+  source = "modules/ecs_iam_role_pair"
 
-  deployment                 = "${var.deployment}"
-  cluster                    = "static-ingress"
-  domain                     = "${local.root_domain}"
-  vpc_id                     = "${aws_vpc.hub.id}"
-  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
-  task_definition            = "${data.template_file.config_task_def.rendered}"
-  container_name             = "nginx"
-  container_port             = "8443"
-  number_of_tasks            = 1
-  health_check_path          = "/service-status"
-  tools_account_id           = "${var.tools_account_id}"
-  image_name                 = "verify-config"
-  instance_security_group_id = "${module.config_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  deployment       = "${var.deployment}"
+  tools_account_id = "${var.tools_account_id}"
+  service_name     = "static-ingress"
+  image_name       = "verify-static-ingress"
+}
+
+resource "aws_ecs_task_definition" "static_ingress" {
+  family                = "${var.deployment}-static-ingress"
+  container_definitions = "${data.template_file.static_ingress_task_def.rendered}"
+  execution_role_arn    = "${module.static_ingress_ecs_roles.execution_role_arn}"
+}
+
+resource "aws_ecs_cluster" "static-ingress" {
+  name = "${var.deployment}-static-ingress"
+}
+
+resource "aws_security_group" "static_ingress" {
+  name        = "${var.deployment}-static-ingress"
+  description = "${var.deployment}-static-ingress"
+
+  vpc_id = "${aws_vpc.hub.id}"
+}
+
+resource "aws_ecs_service" "static_ingress" {
+  name            = "${var.deployment}-static-ingress"
+  cluster         = "${aws_ecs_cluster.static-ingress.id}"
+  task_definition = "${aws_ecs_task_definition.static_ingress.arn}"
+  desired_count   = 1
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.static_ingress.arn}"
+    container_name   = "static-ingress"
+    container_port   = "4500"
+  }
 }
 
 resource "aws_lb" "static_ingress" {

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -10,6 +10,11 @@ module "static_ingress_ecs_asg" {
   use_egress_proxy    = true
   domain              = "${local.root_domain}"
 
+  additional_instance_security_group_ids = [
+    "${aws_security_group.egress_via_proxy.id}",
+    "${aws_security_group.scraped_by_prometheus.id}",
+  ]
+
   logit_api_key           = "${var.logit_api_key}"
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
 }

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -1,8 +1,3 @@
-resource "aws_eip" "static_ingress" {
-  count = "${var.number_of_availability_zones}"
-  vpc   = false
-}
-
 resource "aws_lb" "static_ingress" {
   name                             = "static_ingress"
   load_balancer_type               = "network"
@@ -10,9 +5,18 @@ resource "aws_lb" "static_ingress" {
   enable_cross_zone_load_balancing = true
 
   subnet_mapping {
-    count         = "${var.number_of_availability_zones}"
-    subnet_id     = "${element(aws_subnet.ingress.*id, count.index)}"
-    allocation_id = "${element(aws_eip.static_ingress.*.id, count.index)}"
+    subnet_id     = "${element(aws_subnet.ingress.*id, 0)}"
+    allocation_id = "${element(aws_eip.ingress.*.id, 0)}"
+  }
+
+  subnet_mapping {
+    subnet_id     = "${element(aws_subnet.ingress.*id, 1)}"
+    allocation_id = "${element(aws_eip.ingress.*.id, 1)}"
+  }
+
+  subnet_mapping {
+    subnet_id     = "${element(aws_subnet.ingress.*id, 2)}"
+    allocation_id = "${element(aws_eip.ingress.*.id, 2)}"
   }
 }
 

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "static_ingress" {
-  name                             = "static_ingress"
+  name                             = "${var.deployment}-static-ingress"
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true
@@ -21,7 +21,7 @@ resource "aws_lb" "static_ingress" {
 }
 
 resource "aws_lb_target_group" "static_ingress" {
-  name     = "static_ingress"
+  name     = "${var.deployment}-static-ingress"
   port     = 4500
   protocol = "TCP"
   vpc_id   = "${aws_vpc.hub.vpc_id}"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -1,3 +1,47 @@
+module "static_ingress_ecs_asg" {
+  source = "modules/ecs_asg"
+
+  ami_id              = "${data.aws_ami.ubuntu_bionic.id}"
+  deployment          = "${var.deployment}"
+  cluster             = "static-ingress"
+  vpc_id              = "${aws_vpc.hub.id}"
+  instance_subnets    = ["${aws_subnet.internal.*.id}"]
+  number_of_instances = "${var.number_of_availability_zones}"
+  use_egress_proxy    = true
+  domain              = "${local.root_domain}"
+
+  logit_api_key           = "${var.logit_api_key}"
+  logit_elasticsearch_url = "${var.logit_elasticsearch_url}"
+}
+
+data "template_file" "static_ingress_task_def" {
+  template = "${file("${path.module}/files/tasks/static-ingress.json")}"
+
+  vars {
+    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-static-ingress:latest"
+    deployment    = "${var.deployment}"
+  }
+}
+
+module "static-ingress" {
+  source = "modules/ecs_app"
+
+  deployment                 = "${var.deployment}"
+  cluster                    = "static-ingress"
+  domain                     = "${local.root_domain}"
+  vpc_id                     = "${aws_vpc.hub.id}"
+  lb_subnets                 = ["${aws_subnet.internal.*.id}"]
+  task_definition            = "${data.template_file.config_task_def.rendered}"
+  container_name             = "nginx"
+  container_port             = "8443"
+  number_of_tasks            = 1
+  health_check_path          = "/service-status"
+  tools_account_id           = "${var.tools_account_id}"
+  image_name                 = "verify-config"
+  instance_security_group_id = "${module.config_ecs_asg.instance_sg_id}"
+  certificate_arn            = "${local.wildcard_cert_arn}"
+}
+
 resource "aws_lb" "static_ingress" {
   name                             = "${var.deployment}-static-ingress"
   load_balancer_type               = "network"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -19,7 +19,7 @@ data "template_file" "static_ingress_task_def" {
 
   vars {
     image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-static-ingress:latest"
-    deployment    = "${var.deployment}"
+    backends      = "${aws_lb.ingress.dns_name}"
   }
 }
 

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -5,17 +5,17 @@ resource "aws_lb" "static_ingress" {
   enable_cross_zone_load_balancing = true
 
   subnet_mapping {
-    subnet_id     = "${element(aws_subnet.ingress.*id, 0)}"
+    subnet_id     = "${element(aws_subnet.ingress.*.id, 0)}"
     allocation_id = "${element(aws_eip.ingress.*.id, 0)}"
   }
 
   subnet_mapping {
-    subnet_id     = "${element(aws_subnet.ingress.*id, 1)}"
+    subnet_id     = "${element(aws_subnet.ingress.*.id, 1)}"
     allocation_id = "${element(aws_eip.ingress.*.id, 1)}"
   }
 
   subnet_mapping {
-    subnet_id     = "${element(aws_subnet.ingress.*id, 2)}"
+    subnet_id     = "${element(aws_subnet.ingress.*.id, 2)}"
     allocation_id = "${element(aws_eip.ingress.*.id, 2)}"
   }
 }
@@ -24,15 +24,16 @@ resource "aws_lb_target_group" "static_ingress" {
   name     = "${var.deployment}-static-ingress"
   port     = 4500
   protocol = "TCP"
-  vpc_id   = "${aws_vpc.hub.vpc_id}"
+  vpc_id   = "${aws_vpc.hub.id}"
 }
 
 resource "aws_lb_listener" "static_ingress" {
   load_balancer_arn = "${aws_lb.static_ingress.arn}"
   protocol          = "TCP"
+  port              = 443
 
   default_action {
     type             = "forward"
-    target_group_arn = []
+    target_group_arn = "${aws_lb_target_group.static_ingress.arn}"
   }
 }

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -1,0 +1,34 @@
+resource "aws_eip" "static_ingress" {
+  count = "${var.number_of_availability_zones}"
+  vpc   = false
+}
+
+resource "aws_lb" "static_ingress" {
+  name                             = "static_ingress"
+  load_balancer_type               = "network"
+  internal                         = false
+  enable_cross_zone_load_balancing = true
+
+  subnet_mapping {
+    count         = "${var.number_of_availability_zones}"
+    subnet_id     = "${element(aws_subnet.ingress.*id, count.index)}"
+    allocation_id = "${element(aws_eip.static_ingress.*.id, count.index)}"
+  }
+}
+
+resource "aws_lb_target_group" "static_ingress" {
+  name     = "static_ingress"
+  port     = 4500
+  protocol = "TCP"
+  vpc_id   = "${aws_vpc.hub.vpc_id}"
+}
+
+resource "aws_lb_listener" "static_ingress" {
+  load_balancer_arn = "${aws_lb.static_ingress.arn}"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = []
+  }
+}


### PR DESCRIPTION
First attempt at adding a static ingress route.

It essentially consists of an NLB so that we can have a static IP address, which forwards TCP traffic to EC2 instances running haproxy in docker via ECS, which in turn forwards it to the ingress ALB.

First attempt limitations: 
- Only listens/forwards traffic on 443