### PR TITLE
AUTO-109: Add redis for policy

### DIFF
--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -92,3 +92,11 @@ module "policy_can_connect_to_saml_soap_proxy" {
   source_sg_id      = "${module.policy_ecs_asg.instance_sg_id}"
   destination_sg_id = "${module.saml_soap_proxy.lb_sg_id}"
 }
+
+module "policy_can_connect_to_policy_redis" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${module.policy_ecs_asg.instance_sg_id}"
+  destination_sg_id = "${aws_security_group.policy_redis.id}"
+  port              = 6379
+}

--- a/terraform/modules/hub/redis.tf
+++ b/terraform/modules/hub/redis.tf
@@ -1,0 +1,31 @@
+resource "aws_elasticache_replication_group" "policy_session_store" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["${local.azs}"]
+  replication_group_id          = "${var.deployment}-policy"
+  replication_group_description = "Replication group for the ${var.deployment} Policy session store"
+  maintenance_window            = "tue:02:00-tue:04:00"
+  node_type                     = "${var.redis_cache_size}"
+  number_cache_clusters         = "${var.number_of_availability_zones}"
+  parameter_group_name          = "${aws_elasticache_parameter_group.policy_session_store.name}"
+  security_group_ids            = ["${aws_security_group.policy_redis.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.policy_session_store.name}"
+  at_rest_encryption_enabled    = true
+  transit_encryption_enabled    = true
+  port                          = 6379
+}
+
+resource "aws_elasticache_subnet_group" "policy_session_store" {
+  name       = "${var.deployment}-policy"
+  subnet_ids = ["${aws_subnet.internal.*.id}"]
+}
+
+resource "aws_elasticache_parameter_group" "policy_session_store" {
+  name   = "${var.deployment}-policy"
+  family = "redis5.0"
+}
+
+resource "aws_security_group" "policy_redis" {
+  name        = "${var.deployment}-policy-redis"
+  description = "${var.deployment}-policy-redis"
+  vpc_id      = "${var.vpc_id}"
+}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -18,6 +18,10 @@ variable "publically_accessible_from_cidrs" {
   default = ["0.0.0.0/0"]
 }
 
+variable "redis_cache_size" {
+  default = "cache.t2.small"
+}
+
 variable "truststore_password" {}
 
 locals {


### PR DESCRIPTION
- Adds a non-clustered redis instance per-AZ (so for joint there will be
  a single node, in 2 AZs)
- Create a security group and connection for Policy to talk to Redis
- Setup for both at rest and in transit encryption to ensure IA are
  happy