### PR TITLE
Prometheus config tweaks

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -32,6 +32,7 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Team]
         target_label: team
       - source_labels: [__meta_ec2_tag_Cluster]
+        replacement: $1_node
         target_label: job
   - job_name: apps
     scheme: 'https'

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -58,5 +58,7 @@ scrape_configs:
         target_label: team
       - source_labels: [__meta_ec2_tag_Cluster]
         regex: '(config|policy|saml-engine|saml-proxy|saml-soap-proxy)'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Cluster]
         target_label: job
 


### PR DESCRIPTION
## use separate job label for node_exporter jobs

This appends `_node` to node_exporter jobs, so that they are given
names like `policy_node`.  This makes it easier to see when all of a
single type of metric exporter is broken.


## only keep the instances we're expecting
The static-ingress instances confused the `apps` scrape_config and
added targets for the static-ingress which would never successfully be
scraped.

If this scrape_config is just for apps, we should use `action: keep`
to only scrape app servers.