### PR TITLE
Fix the variable declaration for the envvars

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -135,6 +135,8 @@ systemctl daemon-reload
 systemctl enable  prometheus
 systemctl restart prometheus
 
+export CONFIG_BUCKET=${config_bucket}
+export CRONITOR_URL=${cronitor_prometheus_config_url}
 cat <<EOF > /usr/bin/cronitor-prometheus-config-update.sh
 #!/usr/bin/env bash
 set -ueo pipefail


### PR DESCRIPTION
- The script gets created before the cron command runs (so that the
  crontab can run the script), so if we pass the variables in via cron,
  they don't exist in the first place.
- The `cloud-init-output.log` had `line 138: CRONITOR_URL: CRONITOR_URL not set"`