### PR TITLE
fix prometheus config syntax

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -32,7 +32,7 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Team]
         target_label: team
       - source_labels: [__meta_ec2_tag_Cluster]
-        replacement: $1_node
+        replacement: ${1}_node
         target_label: job
   - job_name: apps
     scheme: 'https'


### PR DESCRIPTION
I don't know why but the old config caused the `job` label to be
removed completely 🤯

Hopefully this will work. Also it will test #30.