### PR TITLE
Add prometheus ECS cluster for colocated exporters

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -50,6 +50,27 @@ sed '/pool/d' /etc/chrony/chrony.conf \
 | cat <(echo "server 169.254.169.123 prefer iburst") - > /tmp/chrony.conf
 mv /tmp/chrony.conf /etc/chrony/chrony.conf
 
+# Docker
+echo 'Installing and configuring docker'
+mkdir -p /etc/systemd/system/docker.service.d
+apt-get install --yes docker.io
+cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd --log-driver journald --dns 10.0.0.2
+EOF
+if [ -n "${egress_proxy_url_with_protocol}" ]; then
+cat <<EOF >> /etc/systemd/system/docker.service.d/override.conf
+Environment="HTTP_PROXY=${egress_proxy_url_with_protocol}"
+Environment="HTTPS_PROXY=${egress_proxy_url_with_protocol}"
+EOF
+fi
+
+# Reload systemctl daemon to pick up new override files
+systemctl stop docker
+systemctl daemon-reload
+systemctl start docker
+
 # Journalbeat for log shipping
 echo 'Installing and configuring journalbeat'
 (
@@ -159,3 +180,38 @@ cat <<EOF | crontab -
 $(crontab -l | grep -v 'no crontab')
 * * * * * /usr/bin/prometheus-update-config
 EOF
+
+# ECS
+echo 'Running ECS using Docker'
+mkdir -p /etc/ecs
+mkdir -p /var/lib/ecs/data
+
+docker run \
+  --init \
+  --privileged \
+  --name ecs-agent \
+  --detach=true \
+  --restart=on-failure:10 \
+  --volume=/etc/ecs:/etc/ecs \
+  --volume=/lib64:/lib64 \
+  --volume=/lib:/lib \
+  --volume=/proc:/host/proc \
+  --volume=/sbin:/sbin \
+  --volume=/sys/fs/cgroup:/sys/fs/cgroup \
+  --volume=/usr/lib:/usr/lib \
+  --volume=/var/lib/ecs/data:/data \
+  --volume=/var/lib/ecs/dhclient:/var/lib/dhclient \
+  --volume=/var/run:/var/run \
+  --net=host \
+  --env="ECS_CLUSTER=${cluster}" \
+  --env="HTTP_PROXY=${egress_proxy_url_with_protocol}" \
+  --env="HTTPS_PROXY=${egress_proxy_url_with_protocol}" \
+  --env=AWS_DEFAULT_REGION=eu-west-2 \
+  --env="NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock" \
+  --env=ECS_DATADIR=/data \
+  --env=ECS_ENABLE_TASK_ENI=true \
+  --env=ECS_ENABLE_TASK_IAM_ROLE=true \
+  --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
+  --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
+  --env="ECS_LOGLEVEL=warn" \
+  amazon/amazon-ecs-agent:v1.23.0

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -1,3 +1,8 @@
+# This is for colocating exporters as ECS DAEMON tasks with Prometheus
+resource "aws_ecs_cluster" "prometheus" {
+  name = "${var.deployment}-prometheus"
+}
+
 resource "aws_security_group" "prometheus" {
   name        = "${var.deployment}-prometheus"
   description = "${var.deployment}-prometheus"
@@ -178,6 +183,16 @@ resource "aws_iam_policy" "prometheus" {
       {
         "Effect": "Allow",
         "Action": [
+          "ecs:RegisterContainerInstance",
+          "ecs:DeregisterContainerInstance"
+        ],
+        "Resource": [
+          "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.account.account_id}:cluster/${aws_ecs_cluster.prometheus.name}"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
           "ec2:DescribeInstances"
         ],
         "Resource": "*"
@@ -239,6 +254,7 @@ data "template_file" "prometheus_cloud_init" {
     logit_elasticsearch_url        = "${var.logit_elasticsearch_url}"
     logit_api_key                  = "${var.logit_api_key}"
     config_bucket                  = "${aws_s3_bucket.deployment_config.id}"
+    cluster                        = "${aws_ecs_cluster.prometheus.name}"
   }
 }
 


### PR DESCRIPTION
We want to run various exporters in our cluster, they should be
colocated with Prometheus.

The easiest way to run these exporters is as ECS tasks on the box using
the Daemon service scheduler strategy

AC
---

- Check the ECS console that `joint-prometheus` has registered container instances
- Code review
- Check that prometheus still works