### PR TITLE
Run multiple hub apps

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -58,7 +58,7 @@ module "config" {
   task_definition            = "${data.template_file.config_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = 1
+  number_of_tasks            = "${var.number_of_availability_zones}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-config"

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -57,7 +57,7 @@ module "policy" {
   task_definition            = "${data.template_file.policy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = 1
+  number_of_tasks            = "${var.number_of_availability_zones}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-policy"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -59,7 +59,7 @@ module "saml_engine" {
   task_definition            = "${data.template_file.saml_engine_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = 1
+  number_of_tasks            = "${var.number_of_availability_zones}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-saml-engine"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -56,7 +56,7 @@ module "saml_proxy" {
   task_definition            = "${data.template_file.saml_proxy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = 1
+  number_of_tasks            = "${var.number_of_availability_zones}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -56,7 +56,7 @@ module "saml_soap_proxy" {
   task_definition            = "${data.template_file.saml_soap_proxy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = 1
+  number_of_tasks            = "${var.number_of_availability_zones}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"

--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -22,7 +22,10 @@ resource "aws_ecs_service" "cluster" {
   name            = "${local.identifier}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
   task_definition = "${aws_ecs_task_definition.cluster.arn}"
-  desired_count   = "${var.number_of_tasks}"
+
+  desired_count                      = "${var.number_of_tasks}"
+  deployment_minimum_healthy_percent = "${var.deployment_min_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_max_percent}"
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.task.arn}"

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -25,6 +25,14 @@ variable "number_of_tasks" {
   default = 2
 }
 
+variable "deployment_min_healthy_percent" {
+  default = 50
+}
+
+variable "deployment_max_percent" {
+  default = 200
+}
+
 variable "additional_task_role_policy_arns" {
   default = []
 }


### PR DESCRIPTION
What
---

Right now we run one of each hub app, we did this for simpler debugging while
we were getting hub journeys working, and because policy could only be single
instance because of infinispan.

Now policy is using redis and we have journeys working reliably and we have
distributed logging we can run as many apps as we have instances.

How to review
---

Code review