### PR TITLE
add Cluster tag to prometheus instances

### DIFF
--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -280,6 +280,7 @@ resource "aws_instance" "prometheus" {
   tags {
     Name       = "${var.deployment}-prometheus"
     Deployment = "${var.deployment}"
+    Cluster    = "prometheus"
   }
 }
 


### PR DESCRIPTION
This makes them consistent with the other ECS cluster instances and
means that our node_exporter relabel_configs don't behave weirdly for
prometheus.