### PR TITLE
Add sentry to egress proxy list and let apps know about it

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -58,6 +58,7 @@ locals {
     "production\\.cloudflare\\.docker\\.com",                                       # Docker Hub
     "test-rp-msa-stub-${var.deployment}\\.ida.digital\\.cabinet-office\\.gov\\.uk", # Test RP
     "${replace(var.logit_elasticsearch_url, ".", "\\.")}",                          # Logit
+    "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -42,6 +42,9 @@
       {
         "name": "SECRET_KEY_BASE",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/secret-key-base"
+      }, {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/sentry-dsn"
       }
     ],
     "environment": [{
@@ -137,6 +140,15 @@
     }, {
       "Name": "RAILS_LOG_TO_STDOUT",
       "Value": "true"
+    }, {
+      "Name": "http_proxy",
+      "Value": "${egress_proxy_url_with_port}"
+    }, {
+      "Name": "https_proxy",
+      "Value": "${egress_proxy_url_with_port}"
+    }, {
+      "Name": "no_proxy",
+      "Value": "config.${domain},policy.${domain},saml-proxy.${domain},www.${domain}"
     }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -36,6 +36,12 @@
       "server",
       "/tmp/config.yml"
     ],
+    "secrets": [
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      }
+    ],
     "environment": [
       {
         "Name": "CONFIG_DATA_PATH",

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -36,6 +36,12 @@
       "server",
       "/tmp/policy.yml"
     ],
+    "secrets": [
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      }
+    ],
     "environment": [
       {
         "Name": "DEPLOYMENT",

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -33,6 +33,10 @@
     ],
     "secrets": [
       {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      },
+      {
         "name": "HUB_SIGNING_PRIVATE_KEY",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}-hub-signing-private-key"
       },

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -36,6 +36,12 @@
       "server",
       "/tmp/saml-proxy.yml"
     ],
+    "secrets": [
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      }
+    ],
     "environment": [
       {
         "Name": "DEPLOYMENT",

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -36,6 +36,12 @@
       "server",
       "/tmp/saml-soap-proxy.yml"
     ],
+    "secrets": [
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      }
+    ],
     "environment": [
       {
         "Name": "DEPLOYMENT",

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -44,6 +44,8 @@ data "template_file" "config_task_def" {
     deployment             = "${var.deployment}"
     truststore_password    = "${var.truststore_password}"
     location_blocks_base64 = "${local.nginx_config_location_blocks_base64}"
+    region                 = "${data.aws_region.region.id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
   }
 }
 

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -29,13 +29,14 @@ data "template_file" "frontend_task_def" {
   template = "${file("${path.module}/files/tasks/frontend.json")}"
 
   vars {
-    account_id             = "${data.aws_caller_identity.account.account_id}"
-    deployment             = "${var.deployment}"
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-frontend:latest"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
-    domain                 = "${local.root_domain}"
-    region                 = "${data.aws_region.region.id}"
-    location_blocks_base64 = "${local.location_blocks_base64}"
+    account_id                 = "${data.aws_caller_identity.account.account_id}"
+    deployment                 = "${var.deployment}"
+    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:latest"
+    nginx_image_and_tag        = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                     = "${local.root_domain}"
+    region                     = "${data.aws_region.region.id}"
+    location_blocks_base64     = "${local.location_blocks_base64}"
+    egress_proxy_url_with_port = "${local.egress_proxy_url_with_protocol}"
   }
 }
 
@@ -69,7 +70,10 @@ resource "aws_ecs_service" "frontend" {
 
   network_configuration {
     subnets         = ["${aws_subnet.internal.*.id}"]
-    security_groups = ["${aws_security_group.frontend_task.id}"]
+    security_groups = [
+      "${aws_security_group.frontend_task.id}",
+      "${aws_security_group.egress_via_proxy.id}",
+    ]
   }
 }
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -43,6 +43,8 @@ data "template_file" "policy_task_def" {
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"
     location_blocks_base64 = "${local.nginx_policy_location_blocks_base64}"
+    region                 = "${data.aws_region.region.id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
   }
 }
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -42,6 +42,8 @@ data "template_file" "saml_proxy_task_def" {
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"
     location_blocks_base64 = "${local.nginx_saml_proxy_location_blocks_base64}"
+    region                 = "${data.aws_region.region.id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
   }
 }
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -42,6 +42,8 @@ data "template_file" "saml_soap_proxy_task_def" {
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"
     location_blocks_base64 = "${local.nginx_saml_soap_proxy_location_blocks_base64}"
+    region                 = "${data.aws_region.region.id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
   }
 }
 

--- a/terraform/modules/hub/modules/ecs_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_app/lb.tf
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "task" {
   protocol             = "HTTPS"
   target_type          = "instance"
   vpc_id               = "${var.vpc_id}"
-  deregistration_delay = 60
+  deregistration_delay = 15
   slow_start           = 30
 
   health_check {

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
@@ -52,6 +52,16 @@ resource "aws_iam_policy" "execution" {
         "ecr:GetAuthorizationToken"
       ],
       "Resource": "*"
+    }, {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters",
+        "ssm:GetParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:eu-west-2:${local.account_id}:parameter/${var.deployment}/${var.service_name}/*",
+        "arn:aws:ssm:eu-west-2:${local.account_id}:parameter/${var.deployment}/ecs-app-shared/*"
+      ]
     }]
   }
   EOF

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
@@ -21,3 +21,9 @@ variable "additional_execution_role_policy_arns" {
 variable "additional_task_role_policy_arns" {
   default = []
 }
+
+data "aws_caller_identity" "account" {}
+
+locals {
+  account_id = "${data.aws_caller_identity.account.account_id}"
+}


### PR DESCRIPTION
- [x] Adds sentry.tools.signin.service.gov.uk to the egress proxy safelist

- [x] Pass SENTRY_DSN to frontend via SSM parameter store (I have put the value there)

- [x] hub apps know about SENTRY_DSN (I have put the value there)

- [x] Frontend can send events to sentry

- [x] Hub apps can send events to sentry