### PR TITLE
Add an S3 bucket for verify-frontend assets and put CloudFront in front of it

### DIFF
--- a/terraform/modules/hub/cloudfront.tf
+++ b/terraform/modules/hub/cloudfront.tf
@@ -1,0 +1,41 @@
+locals {
+  s3_origin_id = "${aws_s3_bucket.verify_frontend_assets.arn}-origin"
+}
+
+resource "aws_cloudfront_distribution" "verify_frontend_assets_distribution" {
+  enabled = true
+
+  origin {
+    domain_name = "${aws_s3_bucket.verify_frontend_assets.bucket_regional_domain_name}"
+    origin_id   = "${local.s3_origin_id}"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${local.s3_origin_id}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/terraform/modules/hub/s3.tf
+++ b/terraform/modules/hub/s3.tf
@@ -5,6 +5,13 @@ resource "random_string" "deployment_config_bucket_name_suffix" {
   number  = false
 }
 
+resource "random_string" "verify_frontend_assets_bucket_name_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
 resource "aws_s3_bucket" "deployment_config" {
   bucket = "gds-${var.deployment}-config-${random_string.deployment_config_bucket_name_suffix.result}"
 
@@ -21,4 +28,9 @@ resource "aws_s3_bucket" "deployment_config" {
       }
     }
   }
+}
+
+resource "aws_s3_bucket" "verify_frontend_assets" {
+  bucket = "gds-${var.deployment}-verify-frontend-app-assets-${random_string.verify_frontend_assets_bucket_name_suffix.result}"
+  acl    = "private"
 }


### PR DESCRIPTION
- We want to store verify-frontend app assets in S3, so that we don't
  get unexpected downtime for users on deploys.
- We set up an S3 bucket with a randomized name, as well as a CloudFront
  "distribution" for CloudFront to be our CDN for the assets.
- This is using a default CloudFront certificate now, as I've not looked
  into how to set up ACM in Terraform yet, or what we need to set it to).

https://trello.com/c/uEJY5iZj/101-verify-hub-build-assets-and-ship-to-cloudfront-inside-pipeline