### PR TITLE
Add an S3 bucket for verify-frontend app assets

### DIFF
--- a/terraform/modules/hub/s3.tf
+++ b/terraform/modules/hub/s3.tf
@@ -5,6 +5,13 @@ resource "random_string" "deployment_config_bucket_name_suffix" {
   number  = false
 }
 
+resource "random_string" "verify_frontend_assets_bucket_name_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
 resource "aws_s3_bucket" "deployment_config" {
   bucket = "gds-${var.deployment}-config-${random_string.deployment_config_bucket_name_suffix.result}"
 
@@ -21,4 +28,9 @@ resource "aws_s3_bucket" "deployment_config" {
       }
     }
   }
+}
+
+resource "aws_s3_bucket" "verify_frontend_assets" {
+  bucket = "gds-${var.deployment}-verify-frontend-app-assets-${random_string.verify_frontend_assets_bucket_name_suffix.result}"
+  acl    = "private"
 }

--- a/terraform/modules/hub/s3.tf
+++ b/terraform/modules/hub/s3.tf
@@ -43,3 +43,23 @@ resource "aws_s3_bucket" "verify_frontend_assets" {
     }
   }
 }
+
+resource "aws_s3_bucket_policy" "verify_frontend_assets" {
+  bucket = "${aws_s3_bucket.verify_frontend_assets.id}"
+
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "s3:GetObject"
+        ]
+        "Effect": "Allow",
+        "Principal": "*",
+        "Resource": "${aws_s3_bucket.verify_frontend_assets.arn}/*"
+      }
+    ]
+  }
+  POLICY
+}

--- a/terraform/modules/hub/s3.tf
+++ b/terraform/modules/hub/s3.tf
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "deployment_config" {
 
 resource "aws_s3_bucket" "verify_frontend_assets" {
   bucket = "gds-${var.deployment}-verify-frontend-app-assets-${random_string.verify_frontend_assets_bucket_name_suffix.result}"
-  acl    = "private"
+  acl    = "public-read"
 
   lifecycle_rule {
     id      = "verify-frontend-assets"

--- a/terraform/modules/hub/s3.tf
+++ b/terraform/modules/hub/s3.tf
@@ -33,4 +33,13 @@ resource "aws_s3_bucket" "deployment_config" {
 resource "aws_s3_bucket" "verify_frontend_assets" {
   bucket = "gds-${var.deployment}-verify-frontend-app-assets-${random_string.verify_frontend_assets_bucket_name_suffix.result}"
   acl    = "private"
+
+  lifecycle_rule {
+    id      = "verify-frontend-assets"
+    enabled = true
+
+    expiration {
+      days = 365
+    }
+  }
 }


### PR DESCRIPTION
- This is for storage of assets generated by `verify-frontend` deployments, ie CSS/JS/images.
- It's private because we're planning on putting CloudFront in front of it and have that serve the objects.
- Objects stay in this bucket for 365 days (a year) and then are "expired".

https://trello.com/c/uEJY5iZj/101-verify-hub-build-assets-and-ship-to-cloudfront-inside-pipeline