### PR TITLE
cloudwatch_exporter and metadata_exporter

### DIFF
--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -1,0 +1,20 @@
+data "template_file" "cloudwatch_exporter_task_def" {
+  template = "${file("${path.module}/files/tasks/cloudwatch-exporter.json")}"
+
+  vars {
+    image_and_tag = "prom/cloudwatch-exporter"
+    config_base64 = "${base64encode(file("${path.module}/files/prometheus/cloudwatch_exporter.yml"))}"
+  }
+}
+
+resource "aws_ecs_task_definition" "cloudwatch_exporter" {
+  family                = "${var.deployment}-cloudwatch-exporter"
+  container_definitions = "${data.template_file.cloudwatch_exporter_task_def.rendered}"
+}
+
+resource "aws_ecs_service" "cloudwatch_exporter" {
+  name                = "cloudwatch_exporter"
+  cluster             = "${aws_ecs_cluster.prometheus.id}"
+  task_definition     = "${aws_ecs_task_definition.cloudwatch_exporter.arn}"
+  scheduling_strategy = "DAEMON"
+}

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -7,51 +7,9 @@ data "template_file" "cloudwatch_exporter_task_def" {
   }
 }
 
-resource "aws_iam_role" "cloudwatch_exporter_readonly" {
-  name = "${var.deployment}-cloudwatch-exporter-readonly-task"
-
-  assume_role_policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "ecs-tasks.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-      }
-    ]
-  }
-  EOF
-}
-
-resource "aws_iam_role_policy" "cloudwatch_exporter_readonly" {
-  name = "cloudwatch_exporter_readonly"
-  role = "${aws_iam_role.cloudwatch_exporter_readonly.id}"
-
-  policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "cloudwatch:Describe*",
-                "cloudwatch:Get*",
-                "cloudwatch:List*"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
-  }
-  EOF
-}
-
 resource "aws_ecs_task_definition" "cloudwatch_exporter" {
   family                = "${var.deployment}-cloudwatch-exporter"
   container_definitions = "${data.template_file.cloudwatch_exporter_task_def.rendered}"
-  task_role_arn         = "${aws_iam_role.cloudwatch_exporter_readonly.arn}"
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -7,9 +7,51 @@ data "template_file" "cloudwatch_exporter_task_def" {
   }
 }
 
+resource "aws_iam_role" "cloudwatch_exporter_readonly" {
+  name = "${var.deployment}-cloudwatch-exporter-readonly-task"
+
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ecs-tasks.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "cloudwatch_exporter_readonly" {
+  name = "cloudwatch_exporter_readonly"
+  role = "${aws_iam_role.cloudwatch_exporter_readonly.id}"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "cloudwatch:Describe*",
+                "cloudwatch:Get*",
+                "cloudwatch:List*"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+  }
+  EOF
+}
+
 resource "aws_ecs_task_definition" "cloudwatch_exporter" {
   family                = "${var.deployment}-cloudwatch-exporter"
   container_definitions = "${data.template_file.cloudwatch_exporter_task_def.rendered}"
+  task_role_arn         = "${aws_iam_role.cloudwatch_exporter_readonly.arn}"
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_task_definition" "cloudwatch_exporter" {
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {
-  name                = "cloudwatch_exporter"
+  name                = "${var.deployment}-cloudwatch-exporter"
   cluster             = "${aws_ecs_cluster.prometheus.id}"
   task_definition     = "${aws_ecs_task_definition.cloudwatch_exporter.arn}"
   scheduling_strategy = "DAEMON"

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -1,15 +1,23 @@
 ---
 region: eu-west-2
 metrics:
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: HTTPCode_Target2XX_Count
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: HTTPCode_Target3XX_Count
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: HTTPCode_Target4XX_Count
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: HTTPCode_Target5XX_Count
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: RequestCount
- - aws_namespace: AWS/ApplicationELB
-   aws_metric_name: TargetResponseTime
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: RequestCountPerTarget
+  aws_dimensions: [TargetGroup, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: HTTPCode_Target_2XX_Count
+  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: HTTPCode_Target_3XX_Count
+  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: HTTPCode_Target_4XX_Count
+  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: HTTPCode_Target_5XX_Count
+  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -19,6 +19,10 @@ metrics:
   aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
+  aws_metric_name: RequestCount
+  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
   aws_metric_name: RequestCountPerTarget
   aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -2,22 +2,22 @@
 region: eu-west-2
 metrics:
 - aws_namespace: AWS/ApplicationELB
-  aws_metric_name: RequestCountPerTarget
-  aws_dimensions: [TargetGroup, LoadBalancer]
-  aws_statistics: [Sum]
-- aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_2XX_Count
-  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_3XX_Count
-  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_4XX_Count
-  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_5XX_Count
-  aws_dimensions: [TargetGroup, LoadBalancer, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum]
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: RequestCountPerTarget
+  aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -1,5 +1,6 @@
 ---
 region: eu-west-2
+delay_seconds: 120
 metrics:
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_2XX_Count

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -1,0 +1,15 @@
+---
+region: eu-west-2
+metrics:
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: HTTPCode_Target2XX_Count
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: HTTPCode_Target3XX_Count
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: HTTPCode_Target4XX_Count
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: HTTPCode_Target5XX_Count
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: RequestCount
+ - aws_namespace: AWS/ApplicationELB
+   aws_metric_name: TargetResponseTime

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -61,4 +61,8 @@ scrape_configs:
         action: keep
       - source_labels: [__meta_ec2_tag_Cluster]
         target_label: job
-
+  - job_name: cloudwatch_exporter
+    metrics_path: '/metrics'
+    scheme: 'http'
+    static_configs:
+      - targets: ['localhost:9106']

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -66,3 +66,8 @@ scrape_configs:
     scheme: 'http'
     static_configs:
       - targets: ['localhost:9106']
+  - job_name: metadata_exporter
+    metrics_path: '/metrics'
+    scheme: 'http'
+    static_configs:
+      - targets: ['localhost:9199']

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -17,6 +17,6 @@
         "Value": "${config_base64}"
       }
     ],
-    "entryPoint": ["bash", "-c", "echo $CONFIG_BASE64 | base64 -d > /config/config.yml; java -jar /cloudwatch_exporter.jar 9106 /config/config.yml"]
+    "entryPoint": ["bash", "-c", "unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /config/config.yml; java -jar /cloudwatch_exporter.jar 9106 /config/config.yml"]
   }
 ]

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "cloudwatch-exporter",
+    "image": "${image_and_tag}",
+    "cpu": 0,
+    "memory": 3500,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 9106,
+        "hostPort": 9106
+      }
+    ],
+    "environment": [
+      {
+        "Name": "CONFIG_BASE64",
+        "Value": "${config_base64}"
+      }
+    ],
+    "entryPoint": ["bash", "-c", "echo $CONFIG_BASE64 | base64 -d > /config/config.yml; java -jar /cloudwatch_exporter.jar 9106 /config/config.yml"]
+  }
+]

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -11,6 +11,10 @@
         "hostPort": 9199
       }
     ],
-    "command": ["-h", "https://${signin_domain}/SAML2/metadata/federation"]
+    "entryPoint": [
+      "bash",
+      "-c",
+      "bundle exec bin/prometheus-metadata-exporter -h https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas $(find /tmp/cas/${deployment} -name '*.crt' | tr '\n' ',')"
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "metadata-exporter",
+    "image": "${image_and_tag}",
+    "cpu": 0,
+    "memory": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 9199,
+        "hostPort": 9199
+      }
+    ],
+    "command": ["-h", "https://${signin_domain}/SAML2/metadata/federation"]
+  }
+]

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -203,6 +203,7 @@ module "ingress_ecs_asg" {
 
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",
+    "${aws_security_group.scraped_by_prometheus.id}",
   ]
 
   logit_api_key           = "${var.logit_api_key}"

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -1,0 +1,20 @@
+data "template_file" "metadata_exporter_task_def" {
+  template = "${file("${path.module}/files/tasks/metadata-exporter.json")}"
+
+  vars {
+    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter:latest"
+    signin_domain = "${var.signin_domain}"
+  }
+}
+
+resource "aws_ecs_task_definition" "metadata_exporter" {
+  family                = "${var.deployment}-metadata-exporter"
+  container_definitions = "${data.template_file.metadata_exporter_task_def.rendered}"
+}
+
+resource "aws_ecs_service" "metadata_exporter" {
+  name                = "${var.deployment}-metadata-exporter"
+  cluster             = "${aws_ecs_cluster.prometheus.id}"
+  task_definition     = "${aws_ecs_task_definition.metadata_exporter.arn}"
+  scheduling_strategy = "DAEMON"
+}

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -4,6 +4,7 @@ data "template_file" "metadata_exporter_task_def" {
   vars {
     image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter:latest"
     signin_domain = "${var.signin_domain}"
+    deployment    = "${var.deployment}"
   }
 }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -190,6 +190,15 @@ resource "aws_iam_policy" "prometheus" {
       {
         "Effect": "Allow",
         "Action": [
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
           "ecs:RegisterContainerInstance",
           "ecs:DeregisterContainerInstance"
         ],

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -82,6 +82,13 @@ module "prometheus_can_talk_to_saml_soap_proxy" {
   port = 8443
 }
 
+module "prometheus_can_talk_to_cloudwatch_vpc_endpoint" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${aws_security_group.cloudwatch_vpc_endpoint.id}"
+}
+
 resource "aws_security_group_rule" "prometheus_can_pull_config_from_s3" {
   type      = "egress"
   protocol  = "tcp"

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -82,6 +82,13 @@ module "prometheus_can_talk_to_saml_soap_proxy" {
   port = 8443
 }
 
+module "prometheus_can_talk_to_ingress_for_scraping_metadata" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${aws_security_group.ingress.id}"
+}
+
 module "prometheus_can_talk_to_cloudwatch_vpc_endpoint" {
   source = "modules/microservice_connection"
 
@@ -207,8 +214,24 @@ resource "aws_iam_policy" "prometheus" {
         ]
       },
       {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:DescribeImages",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [
+          "arn:aws:ecr:eu-west-2:${var.tools_account_id}:repository/platform-deployer-verify-metadata-exporter"
+        ]
+      },
+      {
         "Effect": "Allow",
         "Action": [
+          "ecr:GetAuthorizationToken",
           "ec2:DescribeInstances"
         ],
         "Resource": "*"

--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -42,3 +42,13 @@ resource "aws_vpc_endpoint" "s3" {
   }
   EOF
 }
+
+resource "aws_vpc_endpoint" "cloudwatch" {
+  vpc_id            = "${aws_vpc.hub.id}"
+  service_name      = "com.amazonaws.eu-west-2.monitoring"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    "${aws_security_group.prometheus.id}",
+  ]
+}

--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -43,12 +43,19 @@ resource "aws_vpc_endpoint" "s3" {
   EOF
 }
 
+resource "aws_security_group" "cloudwatch_vpc_endpoint" {
+  name        = "${var.deployment}-cloudwatch-vpc-endpoint"
+  description = "${var.deployment}-cloudwatch-vpc-endpoint"
+
+  vpc_id = "${aws_vpc.hub.id}"
+}
+
 resource "aws_vpc_endpoint" "cloudwatch" {
   vpc_id            = "${aws_vpc.hub.id}"
   service_name      = "com.amazonaws.eu-west-2.monitoring"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${aws_security_group.prometheus.id}",
+    "${aws_security_group.cloudwatch_vpc_endpoint.id}",
   ]
 }

--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -55,7 +55,9 @@ resource "aws_vpc_endpoint" "cloudwatch" {
   service_name      = "com.amazonaws.eu-west-2.monitoring"
   vpc_endpoint_type = "Interface"
 
-  security_group_ids = [
-    "${aws_security_group.cloudwatch_vpc_endpoint.id}",
-  ]
+  subnet_ids = ["${aws_subnet.internal.*.id}"]
+
+  security_group_ids = ["${aws_security_group.cloudwatch_vpc_endpoint.id}"]
+
+  private_dns_enabled = true
 }


### PR DESCRIPTION
We are using some AWS services which emit metrics, however we use Prometheus and Grafana for observing the system. Therefore we want to get AWS metrics (from Cloudwatch) into Prometheus. This PR adds cloudwatch_exporter colocated with each Prometheus. Cloudwatch exporter will scrape metrics from cloudwatch, and Prometheus will scrape metrics from the exporter.

We have metadata for our SAML federation and we want to monitor the expiry time of certificates. In the alphagov/metadata-checker repo on the `prometheus` branch there is a metadata metrics exporter (extremely alpha) which, after it gets built, gets colocated with prometheus and scraped. The metadata exporter is quite early and we will have the opportunity to cleanup the task definition when the exporter is "prod-ready"