### PR TITLE
Allow metadata-exporter to make OCSP requests

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -59,6 +59,7 @@ locals {
     "test-rp-msa-stub-${var.deployment}\\.ida.digital\\.cabinet-office\\.gov\\.uk", # Test RP
     "${replace(var.logit_elasticsearch_url, ".", "\\.")}",                          # Logit
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
+    "std-ocsp\\.trustwise\\.com",                                                   # OCSP check URI
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -15,6 +15,12 @@
       "bash",
       "-c",
       "bundle exec bin/prometheus-metadata-exporter -h https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas $(find /tmp/cas/${deployment} -name '*.crt' | tr '\n' ',')"
+    ],
+    "environment": [
+      {
+        "Name": "http_proxy",
+        "Value": "egress-proxy.${domain}"
+      }
     ]
   }
 ]

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -5,6 +5,7 @@ data "template_file" "metadata_exporter_task_def" {
     image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter:latest"
     signin_domain = "${var.signin_domain}"
     deployment    = "${var.deployment}"
+    domain        = "${local.root_domain}"
   }
 }
 


### PR DESCRIPTION
This PR adds the egress-proxy settings to metadata-exporter and adds the OCSP URI to the whitelist.