### PR TITLE
More metadata checker

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -20,6 +20,10 @@
       {
         "Name": "http_proxy",
         "Value": "${egress_proxy_url_with_port}"
+      },
+      {
+        "Name": "no_proxy",
+        "Value": "${signin_domain}"
       }
     ]
   }

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -14,7 +14,7 @@
     "entryPoint": [
       "bash",
       "-c",
-      "bundle exec bin/prometheus-metadata-exporter -h https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas $(find /tmp/cas/${deployment} -name '*.crt' | tr '\n' ',')"
+      "bundle exec bin/prometheus-metadata-exporter -h https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas $(find /tmp/cas/${deployment} -name '*.crt') --metadata_cas $(find /tmp/cas/${deployment} -name '*.crt') | tr '\n' ',')"
     ],
     "environment": [
       {


### PR DESCRIPTION
- add `--metadata_cas` (just containing the same CAs as --cas for the moment)
- add `no_proxy` envvar to avoid sending metadata requests through the egress proxy