### PR TITLE
[metadata-exporter] update to latest CLI args

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -14,7 +14,7 @@
     "entryPoint": [
       "bash",
       "-c",
-      "bundle exec bin/prometheus-metadata-exporter -h https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas $(find /tmp/cas/${deployment} -name '*.crt' | tr '\n' ',') --metadata_cas $(find /tmp/cas/${deployment} -name '*.crt' | tr '\n' ',')"
+      "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment}"
     ],
     "environment": [
       {


### PR DESCRIPTION
alphagov/metadata-checker@1100be9a3735 changes the CLI:

  - no more `--metadata_cas` arg
  - `--cas` takes a directory rather than a comma-separated list of
    files
  - the `-h` arg has been renamed `-m`