### PR TITLE
Add TargetResponseTime Metric to cloudwatch exporter

### DIFF
--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -23,6 +23,11 @@ metrics:
   aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
+  aws_metric_name: TargetResponseTime
+  aws_dimensions: [AvailabilityZone, LoadBalancer]
+  aws_statistics: [Sum, Average, Minimum, Maximum, Average]
+  aws_extended_statistics: [p50, p75, p90]
+- aws_namespace: AWS/ApplicationELB
   aws_metric_name: RequestCountPerTarget
   aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]


### PR DESCRIPTION
Added TargetResponseTime to the cloudwatch exporter to we can measure
responses that are fast enough for our SLIs

Single: matthewcullum-gds