### PR TITLE
Add `reboot_required` as a metric that Prometheus collects

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -173,6 +173,8 @@ EOF
 
 chmod +x /usr/bin/instance-reboot-required-metric.sh
 
+apt-get install --yes moreutils
+
 cat <<EOF | crontab -
 $(crontab -l | grep -v 'no crontab')
 * * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -175,7 +175,7 @@ chmod +x /usr/bin/instance-reboot-required-metric.sh
 
 apt-get install --yes moreutils
 
-cat <<EOF | crontab -
+crontab - <<EOF
 $(crontab -l | grep -v 'no crontab')
 */5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
 EOF

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -177,5 +177,5 @@ apt-get install --yes moreutils
 
 cat <<EOF | crontab -
 $(crontab -l | grep -v 'no crontab')
-* * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
+*/5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
 EOF


### PR DESCRIPTION
- We need to know when hosts require rebooting (for updates etc.).
- This adds a script that runs every minute to check for the presence of
  the reboot-required file and if it's there, update the Prometheus
  `node_reboot_required` metric to `1`. The textfile collector is
  already set up to read this directory.

Co-authored-by: @sakisv