### PR TITLE
Initialise node_creation_time metric

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -159,6 +159,9 @@ systemctl daemon-reload
 systemctl enable prometheus-node-exporter
 systemctl restart prometheus-node-exporter
 
+#Initialise a node_creation_time metric to enable the predict_linear function to handle new nodes
+echo "node_creation_time `date +%s`" > /var/lib/prometheus/node-exporter/node-creation-time.prom
+
 cat <<EOF > /usr/bin/instance-reboot-required-metric.sh
 #!/usr/bin/env bash
 


### PR DESCRIPTION
This is for use with the predict_linear function. So we can measure
data in a time period that the node was created in. Without this the
results are incorrect and will always trigger an alert on node creation.

Single: matthew.cullum-gds