### PR TITLE
Make network consistent in all environments

### DIFF
--- a/terraform/modules/hub/azs.tf
+++ b/terraform/modules/hub/azs.tf
@@ -5,7 +5,7 @@ locals {
     slice(
       data.aws_availability_zones.available.names,
       0,
-      var.number_of_availability_zones
+      local.number_of_availability_zones
     )
   }"
 }

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -6,7 +6,7 @@ module "egress_proxy_ecs_asg" {
   cluster             = "egress-proxy"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   use_egress_proxy    = false
   domain              = "${local.root_domain}"
 

--- a/terraform/modules/hub/eips.tf
+++ b/terraform/modules/hub/eips.tf
@@ -1,10 +1,10 @@
 resource "aws_eip" "ingress" {
-  count = 2
+  count = "${local.number_of_availability_zones}"
   vpc   = true
 }
 
 resource "aws_eip" "egress" {
-  count = "${var.number_of_availability_zones}"
+  count = "${local.number_of_availability_zones}"
   vpc   = true
 }
 

--- a/terraform/modules/hub/gateways.tf
+++ b/terraform/modules/hub/gateways.tf
@@ -7,7 +7,7 @@ resource "aws_internet_gateway" "hub" {
 }
 
 resource "aws_nat_gateway" "static_egress" {
-  count = "${var.number_of_availability_zones}"
+  count = "${local.number_of_availability_zones}"
 
   allocation_id = "${element(aws_eip.egress.*.id,    count.index)}"
   subnet_id     = "${element(aws_subnet.egress.*.id, count.index)}"

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -7,7 +7,7 @@ module "config_ecs_asg" {
   vpc_id           = "${aws_vpc.hub.id}"
   instance_subnets = ["${aws_subnet.internal.*.id}"]
 
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
@@ -64,7 +64,7 @@ module "config" {
   task_definition            = "${data.template_file.config_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = "${var.number_of_availability_zones}"
+  number_of_tasks            = "${var.number_of_apps}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-config"

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -7,7 +7,7 @@ module "policy_ecs_asg" {
   vpc_id           = "${aws_vpc.hub.id}"
   instance_subnets = ["${aws_subnet.internal.*.id}"]
 
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
@@ -67,7 +67,7 @@ module "policy" {
   task_definition            = "${data.template_file.policy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = "${var.number_of_availability_zones}"
+  number_of_tasks            = "${var.number_of_apps}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-policy"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -7,7 +7,7 @@ module "saml_engine_ecs_asg" {
   vpc_id           = "${aws_vpc.hub.id}"
   instance_subnets = ["${aws_subnet.internal.*.id}"]
 
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
@@ -63,7 +63,7 @@ module "saml_engine" {
   task_definition            = "${data.template_file.saml_engine_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = "${var.number_of_availability_zones}"
+  number_of_tasks            = "${var.number_of_apps}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-saml-engine"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -6,7 +6,7 @@ module "saml_proxy_ecs_asg" {
   cluster             = "saml-proxy"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
@@ -62,7 +62,7 @@ module "saml_proxy" {
   task_definition            = "${data.template_file.saml_proxy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = "${var.number_of_availability_zones}"
+  number_of_tasks            = "${var.number_of_apps}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -6,7 +6,7 @@ module "saml_soap_proxy_ecs_asg" {
   cluster             = "saml-soap-proxy"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
@@ -62,7 +62,7 @@ module "saml_soap_proxy" {
   task_definition            = "${data.template_file.saml_soap_proxy_task_def.rendered}"
   container_name             = "nginx"
   container_port             = "8443"
-  number_of_tasks            = "${var.number_of_availability_zones}"
+  number_of_tasks            = "${var.number_of_apps}"
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -198,7 +198,7 @@ module "ingress_ecs_asg" {
   cluster             = "ingress"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_availability_zones + 1}"
+  number_of_instances = "${var.number_of_apps + 1}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -302,7 +302,7 @@ data "template_file" "prometheus_cloud_init" {
 }
 
 resource "aws_instance" "prometheus" {
-  count = "${var.number_of_availability_zones}"
+  count = "${var.number_of_apps}"
 
   ami                  = "${data.aws_ami.ubuntu_bionic.id}"
   instance_type        = "t3.medium"
@@ -329,7 +329,7 @@ resource "aws_instance" "prometheus" {
 }
 
 resource "aws_ebs_volume" "prometheus" {
-  count = "${var.number_of_availability_zones}"
+  count = "${var.number_of_apps}"
 
   size      = 100
   encrypted = true
@@ -345,7 +345,7 @@ resource "aws_ebs_volume" "prometheus" {
 }
 
 resource "aws_volume_attachment" "prometheus_prometheus" {
-  count = "${var.number_of_availability_zones}"
+  count = "${var.number_of_apps}"
 
   device_name = "/dev/xvdp"
   volume_id   = "${element(aws_ebs_volume.prometheus.*.id, count.index)}"
@@ -353,7 +353,7 @@ resource "aws_volume_attachment" "prometheus_prometheus" {
 }
 
 resource "aws_lb_target_group" "prometheus" {
-  count = "${var.number_of_availability_zones}"
+  count = "${var.number_of_apps}"
 
   name     = "${var.deployment}-prometheus-${count.index}"
   port     = 9090
@@ -369,7 +369,7 @@ resource "aws_lb_target_group" "prometheus" {
 }
 
 resource "aws_lb_target_group_attachment" "prometheus" {
-  count = "${var.number_of_availability_zones}"
+  count = "${var.number_of_apps}"
 
   target_group_arn = "${element(aws_lb_target_group.prometheus.*.arn, count.index)}"
   target_id        = "${element(aws_instance.prometheus.*.id, count.index)}"
@@ -377,7 +377,7 @@ resource "aws_lb_target_group_attachment" "prometheus" {
 }
 
 resource "aws_lb_listener_rule" "prometheus_https" {
-  count        = "${var.number_of_availability_zones}"
+  count        = "${var.number_of_apps}"
   listener_arn = "${aws_lb_listener.mgmt_https.arn}"
   priority     = "${100 + count.index}"
 

--- a/terraform/modules/hub/redis.tf
+++ b/terraform/modules/hub/redis.tf
@@ -5,7 +5,7 @@ resource "aws_elasticache_replication_group" "policy_session_store" {
   replication_group_description = "Replication group for the ${var.deployment} Policy session store"
   maintenance_window            = "tue:02:00-tue:04:00"
   node_type                     = "${var.redis_cache_size}"
-  number_cache_clusters         = "${var.number_of_availability_zones}"
+  number_cache_clusters         = "${local.number_of_availability_zones}"
   parameter_group_name          = "${aws_elasticache_parameter_group.policy_session_store.name}"
   security_group_ids            = ["${aws_security_group.policy_redis.id}"]
   subnet_group_name             = "${aws_elasticache_subnet_group.policy_session_store.name}"

--- a/terraform/modules/hub/routing.tf
+++ b/terraform/modules/hub/routing.tf
@@ -14,19 +14,19 @@ resource "aws_route" "public" {
 }
 
 resource "aws_route_table_association" "public_ingress" {
-  count          = "${var.number_of_availability_zones}"
+  count          = "${local.number_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.ingress.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.public.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "public_egress" {
-  count          = "${var.number_of_availability_zones}"
+  count          = "${local.number_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.egress.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.public.*.id, count.index)}"
 }
 
 resource "aws_route_table" "private" {
-  count = "${var.number_of_availability_zones}"
+  count = "${local.number_of_availability_zones}"
 
   vpc_id = "${aws_vpc.hub.id}"
 
@@ -37,7 +37,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "private_egress" {
-  count = "${var.number_of_availability_zones}"
+  count = "${local.number_of_availability_zones}"
 
   destination_cidr_block = "0.0.0.0/0"
 
@@ -53,7 +53,7 @@ resource "aws_route" "private_egress" {
 }
 
 resource "aws_route_table_association" "internal_private" {
-  count          = "${var.number_of_availability_zones}"
+  count          = "${local.number_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.internal.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -6,7 +6,7 @@ module "static_ingress_ecs_asg" {
   cluster             = "static-ingress"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_availability_zones}"
+  number_of_instances = "${var.number_of_apps}"
   use_egress_proxy    = true
   domain              = "${local.root_domain}"
 
@@ -166,6 +166,11 @@ resource "aws_lb" "static_ingress" {
   subnet_mapping {
     subnet_id     = "${element(aws_subnet.ingress.*.id, 1)}"
     allocation_id = "${element(aws_eip.ingress.*.id, 1)}"
+  }
+
+  subnet_mapping {
+    subnet_id     = "${element(aws_subnet.ingress.*.id, 2)}"
+    allocation_id = "${element(aws_eip.ingress.*.id, 2)}"
   }
 }
 

--- a/terraform/modules/hub/subnets.tf
+++ b/terraform/modules/hub/subnets.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 resource "aws_subnet" "ingress" {
-  count             = "${var.number_of_availability_zones}"
+  count             = "${local.number_of_availability_zones}"
   vpc_id            = "${aws_vpc.hub.id}"
   availability_zone = "${element(local.azs, count.index)}"
 
@@ -26,7 +26,7 @@ resource "aws_subnet" "ingress" {
 }
 
 resource "aws_subnet" "internal" {
-  count             = "${var.number_of_availability_zones}"
+  count             = "${local.number_of_availability_zones}"
   vpc_id            = "${aws_vpc.hub.id}"
   availability_zone = "${element(local.azs, count.index)}"
 
@@ -43,7 +43,7 @@ resource "aws_subnet" "internal" {
 }
 
 resource "aws_subnet" "egress" {
-  count             = "${var.number_of_availability_zones}"
+  count             = "${local.number_of_availability_zones}"
   vpc_id            = "${aws_vpc.hub.id}"
   availability_zone = "${element(local.azs, count.index)}"
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -10,7 +10,7 @@ variable "tools_account_id" {
   description = "AWS account id of the tools account, where docker images will be pulled from"
 }
 
-variable "number_of_availability_zones" {
+variable "number_of_apps" {
   default = 2
 }
 
@@ -25,7 +25,8 @@ variable "redis_cache_size" {
 variable "truststore_password" {}
 
 locals {
-  root_domain = "${replace(var.signin_domain, "/www[.]/", "")}"
+  root_domain                  = "${replace(var.signin_domain, "/www[.]/", "")}"
+  number_of_availability_zones = 3
 }
 
 variable "wildcard_cert_arn" {


### PR DESCRIPTION
We shouldn't have different network topologies, what affects cost is the
number of boxes/apps, the additional subnet/nat gateway is not expensive

Network load balancers have weird config which cannot change which
forces us to have 3 IPs but we cannot have two IPs in the same subnet.

This makes the network consistent in all environments, and is
terraformed everywhere

---

In non-prodlike environments we will have 2 boxes and 2 apps instead of 3, but
running across 3 AZs.