### PR TITLE
AUTO: Add Redis to SAML Engine

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -62,6 +62,10 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+      },
+      {
+        "Name": "REDIS_HOST",
+        "Value": "${redis_host}"
       }
     ]
   }

--- a/terraform/modules/hub/redis.tf
+++ b/terraform/modules/hub/redis.tf
@@ -29,3 +29,35 @@ resource "aws_security_group" "policy_redis" {
   description = "${var.deployment}-policy-redis"
   vpc_id      = "${aws_vpc.hub.id}"
 }
+
+resource "aws_elasticache_replication_group" "saml_engine_replay_cache" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["${local.azs}"]
+  replication_group_id          = "${var.deployment}-saml-engine"
+  replication_group_description = "Replication group for the ${var.deployment} SAML Engine replay cache"
+  maintenance_window            = "tue:02:00-tue:04:00"
+  node_type                     = "cache.t2.small"
+  number_cache_clusters         = "${var.number_of_availability_zones}"
+  parameter_group_name          = "${aws_elasticache_parameter_group.saml_engine_replay_cache.name}"
+  security_group_ids            = ["${aws_security_group.saml_engine_redis.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.saml_engine_replay_cache.name}"
+  at_rest_encryption_enabled    = true
+  transit_encryption_enabled    = true
+  port                          = 6379
+}
+
+resource "aws_elasticache_subnet_group" "saml_engine_replay_cache" {
+  name       = "${var.deployment}-saml-engine"
+  subnet_ids = ["${aws_subnet.internal.*.id}"]
+}
+
+resource "aws_elasticache_parameter_group" "saml_engine_replay_cache" {
+  name   = "${var.deployment}-saml-engine"
+  family = "redis5.0"
+}
+
+resource "aws_security_group" "saml_engine_redis" {
+  name        = "${var.deployment}-saml-engine-redis"
+  description = "${var.deployment}-saml-engine-redis"
+  vpc_id      = "${aws_vpc.hub.id}"
+}


### PR DESCRIPTION
- There is a PR to allow SAML Engine to use Redis for it's replay cache
- This creates the cluster and puts the address into the taskdef so that
  we can consume it in the app