### PR TITLE
Set debian frontend to be noninteractive

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
+export DEBIAN_FRONTEND=noninteractive
+
 CURL="curl"
 if [ -n "${egress_proxy_url_with_protocol}" ]; then
   CURL="curl --proxy ${egress_proxy_url_with_protocol}"


### PR DESCRIPTION
Sometimes debian will install a package which will do something tragic
like ask for user input and thus boxes will not come up in a good state

setting it to `noninteractive` will stop this from happening