### PR TITLE
Make Prometheus disk alert less noisy

### DIFF
--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -608,7 +608,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "predict_linear(node_filesystem_avail{fstype!=\"squashfs\",mountpoint!=\"/snap/core/6130\",mountpoint!=\"/snap/amazon-ssm-agent/930\",mountpoint!=\"/var/lib/lxcfs\"}[24h], 3 * 86400) and on (instance) (time() - node_creation_time) > 86400\n",
+          "expr": "predict_linear(node_filesystem_avail{fstype!=\"squashfs\",mountpoint!=\"fuse[.]lxcfs"}[24h], 3 * 86400) and on (instance) (time() - node_creation_time) > 86400\n",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,


### PR DESCRIPTION
We don't want to monitor ANY squashfs filesystems, these are read only
and do not change.

We don't want to monitor ANY fuse.lxcfs filesystems, these are for
containers. These use the host filesystem anyway