### PR TITLE
Correct predict-linear alert.

### DIFF
--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -608,7 +608,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "predict_linear(node_filesystem_avail{fstype!=\"squashfs\",mountpoint!=\"fuse[.]lxcfs"}[24h], 3 * 86400) and on (instance) (time() - node_creation_time) > 86400\n",
+          "expr": "predict_linear(node_filesystem_avail{fstype!=\"squashfs\",mountpoint!=\"fuse[.]lxcfs\"}[24h], 3 * 86400) and on (instance) (time() - node_creation_time) > 86400\n",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,


### PR DESCRIPTION
There was a missing \ from the new filesystem exclusion query that hadn't been deployed. This now plans correctly and will apply.

Single: matthewcullum-gds