### PR TITLE
Beat exporter

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -1,0 +1,47 @@
+module "beat_exporter_ecs_roles" {
+  source = "modules/ecs_iam_role_pair"
+
+  deployment       = "${var.deployment}"
+  service_name     = "beat-exporter"
+  image_name       = "verify-beat-exporter"
+  tools_account_id = "${var.tools_account_id}"
+}
+
+data "template_file" "beat_exporter_task_def" {
+  template = "${file("${path.module}/files/tasks/beat-exporter.json")}"
+
+  vars {
+    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-beat-exporter:latest"
+  }
+}
+
+resource "aws_ecs_task_definition" "beat_exporter" {
+  family                = "${var.deployment}-beat-exporter"
+  container_definitions = "${data.template_file.beat_exporter_task_def.rendered}"
+  execution_role_arn    = "${module.beat_exporter_ecs_roles.execution_role_arn}"
+}
+
+locals {
+  # FIXME is there a better way of doing this?
+  clusters = [
+    "prometheus",
+    "egress-proxy",
+    "ingress",
+    "static-ingress",
+    "saml-proxy",
+    "saml-engine",
+    "policy",
+    "config",
+    "saml-soap-proxy",
+  ]
+}
+
+resource "aws_ecs_service" "beat_exporter" {
+  count   = "${length(local.clusters)}"
+  name    = "${var.deployment}-beat-exporter"
+  cluster = "arn:aws:ecs:${data.aws_region.region.name}:${data.aws_caller_identity.account.account_id}:cluster/${var.deployment}-${element(local.clusters, count.index)}"
+
+  #  cluster             = "${element(local.clusters, count.index)}"
+  task_definition     = "${aws_ecs_task_definition.beat_exporter.arn}"
+  scheduling_strategy = "DAEMON"
+}

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -79,6 +79,8 @@ dpkg -i journalbeat-6.6.0-amd64.deb
 )
 
 cat <<EOF > /etc/journalbeat/journalbeat.yml
+http.enabled: true
+
 journalbeat.inputs:
 - paths: []
   seek: cursor

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -34,6 +34,24 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Cluster]
         replacement: $${1}_node
         target_label: job
+  - job_name: beat_exporter
+    ec2_sd_configs:
+      - region: eu-west-2
+        refresh_interval: 30s
+        port: 9479
+    relabel_configs:
+      - source_labels: [__meta_ec2_instance_id]
+        target_label: instance
+      - source_labels: [__meta_ec2_tag_Role]
+        target_label: role
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '^${deployment}$'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Team]
+        target_label: team
+      - source_labels: [__meta_ec2_tag_Cluster]
+        replacement: $${1}_journalbeat
+        target_label: job
   - job_name: apps
     scheme: 'https'
     metrics_path: '/prometheus/metrics'

--- a/terraform/modules/hub/files/tasks/beat-exporter.json
+++ b/terraform/modules/hub/files/tasks/beat-exporter.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "beat-exporter",
+    "image": "${image_and_tag}",
+    "cpu": 0,
+    "memory": 64,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 9479,
+        "hostPort": 9479
+      }
+    ]
+  }
+]

--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -2,6 +2,10 @@ resource "aws_ecs_cluster" "cluster" {
   name = "${local.identifier}"
 }
 
+output "cluster_id" {
+  value = "${aws_ecs_cluster.cluster.id}"
+}
+
 module "cluster_ecs_roles" {
   source = "../ecs_iam_role_pair"
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -86,6 +86,8 @@ dpkg -i journalbeat-6.6.0-amd64.deb
 )
 
 cat <<EOF > /etc/journalbeat/journalbeat.yml
+http.enabled: true
+
 journalbeat.inputs:
 - paths: []
   seek: cursor

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -37,6 +37,24 @@ module "prometheus_can_talk_to_egress_proxy_node_exporter" {
   port = 9100
 }
 
+module "prometheus_can_talk_to_prometheus_beat_exporter" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${aws_security_group.prometheus.id}"
+
+  port = 9479
+}
+
+module "prometheus_can_talk_to_egress_proxy_beat_exporter" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.egress_proxy_ecs_asg.instance_sg_id}"
+
+  port = 9479
+}
+
 module "prometheus_can_talk_to_policy" {
   source = "modules/microservice_connection"
 
@@ -120,6 +138,15 @@ module "scraped_by_prometheus_can_be_scraped_by_prometheus" {
   destination_sg_id = "${aws_security_group.scraped_by_prometheus.id}"
 
   port = 9100
+}
+
+module "scraped_by_prometheus_beat_can_be_scraped_by_prometheus" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${aws_security_group.scraped_by_prometheus.id}"
+
+  port = 9479
 }
 
 resource "aws_iam_role" "prometheus" {


### PR DESCRIPTION
(depends on alphagov/verify-infrastructure-config#49)

This adds beat-exporter to each host to expose journalbeat metrics to prometheus.