### PR TITLE
allow beat-exporter to access host network

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -19,6 +19,7 @@ resource "aws_ecs_task_definition" "beat_exporter" {
   family                = "${var.deployment}-beat-exporter"
   container_definitions = "${data.template_file.beat_exporter_task_def.rendered}"
   execution_role_arn    = "${module.beat_exporter_ecs_roles.execution_role_arn}"
+  network_mode          = "host"
 }
 
 locals {


### PR DESCRIPTION
beat-exporter needs to access localhost:5066 on the host, because
journalbeat is running on the host.

this is already deployed 🤠 