### PR TITLE
AUTO-94: Create KMS keys for policy, saml-proxy and saml-soap-proxy

### DIFF
--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -75,6 +75,30 @@ module "policy" {
   certificate_arn            = "${local.wildcard_cert_arn}"
 }
 
+resource "aws_iam_policy" "policy_parameter_execution" {
+  name = "${var.deployment}-policy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-policy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "policy_parameter_execution" {
+  role       = "${var.deployment}-policy-execution"
+  policy_arn = "${aws_iam_policy.policy_parameter_execution.arn}"
+}
+
 module "policy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -70,6 +70,25 @@ module "saml_proxy" {
   image_name                 = "verify-saml-proxy"
 }
 
+resource "aws_iam_policy" "saml_proxy_parameter_execution" {
+  name = "${var.deployment}-saml-proxy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-proxy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
 module "saml_proxy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -70,6 +70,25 @@ module "saml_soap_proxy" {
   image_name                 = "verify-saml-soap-proxy"
 }
 
+resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
+  name = "${var.deployment}-saml-soap-proxy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-soap-proxy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
 module "saml_soap_proxy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -73,3 +73,117 @@ resource "aws_kms_alias" "frontend" {
   name          = "alias/${var.deployment}-frontend-key"
   target_key_id = "${aws_kms_key.frontend.key_id}"
 }
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-policy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "policy" {
+  description = "Used for encrypting and decrypting policy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.policy.json}"
+}
+
+resource "aws_kms_alias" "policy" {
+  name          = "alias/${var.deployment}-policy-key"
+  target_key_id = "${aws_kms_key.policy.key_id}"
+}
+
+data "aws_iam_policy_document" "saml_proxy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "saml_proxy" {
+  description = "Used for encrypting and decrypting saml-proxy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.saml_proxy.json}"
+}
+
+resource "aws_kms_alias" "saml_proxy" {
+  name          = "alias/${var.deployment}-saml-proxy-key"
+  target_key_id = "${aws_kms_key.saml_proxy.key_id}"
+}
+
+data "aws_iam_policy_document" "saml_soap_proxy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-soap-proxy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "saml_soap_proxy" {
+  description = "Used for encrypting and decrypting saml-soap-proxy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.saml_soap_proxy.json}"
+}
+
+resource "aws_kms_alias" "saml_soap_proxy" {
+  name          = "alias/${var.deployment}-saml-soap-proxy-key"
+  target_key_id = "${aws_kms_key.saml_soap_proxy.key_id}"
+}


### PR DESCRIPTION
Policy, SAML Proxy and SAML SOAP Proxy containers will need their KMS keys to decrypt secret parameters.

Author: @adityapahuja