### PR TITLE
AUTO-94: Allow Policy, SAML Proxy and SAML SOAP Proxy to send events

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -51,6 +51,10 @@ resource "aws_security_group_rule" "egress_proxy_instance_egress_to_internet_ove
 }
 
 locals {
+  event_emitter_api_gateway = "${split("/", replace(var.event_emitter_api_gateway_url, "https://", ""))}"
+}
+
+locals {
   egress_proxy_whitelist_list = [
     "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com",                                     # Apt
     "security\\.ubuntu\\.com",                                                      # Apt
@@ -59,6 +63,7 @@ locals {
     "${replace(var.logit_elasticsearch_url, ".", "\\.")}",                          # Logit
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
     "std-ocsp\\.trustwise\\.com",                                                   # OCSP check URI
+    "${replace(local.event_emitter_api_gateway[0], ".", "\\.")}"                    # API Gateway
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -40,6 +40,18 @@
       {
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      },
+      {
+        "name": "EVENT_EMITTER_ACCESS_KEY_ID",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/policy/event-emitter-access-key-id"
+      },
+      {
+        "name": "EVENT_EMITTER_SECRET_ACCESS_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/policy/event-emitter-secret-access-key"
+      },
+      {
+        "name": "EVENT_EMITTER_ENCRYPTION_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/policy/event-emitter-encryption-key"
       }
     ],
     "environment": [
@@ -54,6 +66,10 @@
       {
         "Name": "REDIS_HOST",
         "Value": "${redis_host}"
+      },
+      {
+        "Name": "EVENT_EMITTER_API_GATEWAY_URL",
+        "Value": "${event_emitter_api_gateway_url}"
       },
       {
         "Name": "JAVA_OPTS",

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -40,12 +40,28 @@
       {
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      },
+      {
+        "name": "EVENT_EMITTER_ACCESS_KEY_ID",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-proxy/event-emitter-access-key-id"
+      },
+      {
+        "name": "EVENT_EMITTER_SECRET_ACCESS_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-proxy/event-emitter-secret-access-key"
+      },
+      {
+        "name": "EVENT_EMITTER_ENCRYPTION_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-proxy/event-emitter-encryption-key"
       }
     ],
     "environment": [
       {
         "Name": "DEPLOYMENT",
         "Value": "${deployment}"
+      },
+      {
+        "Name": "EVENT_EMITTER_API_GATEWAY_URL",
+        "Value": "${event_emitter_api_gateway_url}"
       },
       {
         "Name": "JAVA_OPTS",

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -40,12 +40,28 @@
       {
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
+      },
+      {
+        "name": "EVENT_EMITTER_ACCESS_KEY_ID",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-soap-proxy/event-emitter-access-key-id"
+      },
+      {
+        "name": "EVENT_EMITTER_SECRET_ACCESS_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-soap-proxy/event-emitter-secret-access-key"
+      },
+      {
+        "name": "EVENT_EMITTER_ENCRYPTION_KEY",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-soap-proxy/event-emitter-encryption-key"
       }
     ],
     "environment": [
       {
         "Name": "DEPLOYMENT",
         "Value": "${deployment}"
+      },
+      {
+        "Name": "EVENT_EMITTER_API_GATEWAY_URL",
+        "Value": "${event_emitter_api_gateway_url}"
       },
       {
         "Name": "JAVA_OPTS",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -42,13 +42,14 @@ data "template_file" "policy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-policy.json")}"
 
   vars {
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-policy:latest"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
-    domain                 = "${local.root_domain}"
-    deployment             = "${var.deployment}"
-    location_blocks_base64 = "${local.nginx_policy_location_blocks_base64}"
-    region                 = "${data.aws_region.region.id}"
-    account_id             = "${data.aws_caller_identity.account.account_id}"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-policy:latest"
+    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                        = "${local.root_domain}"
+    deployment                    = "${var.deployment}"
+    location_blocks_base64        = "${local.nginx_policy_location_blocks_base64}"
+    region                        = "${data.aws_region.region.id}"
+    account_id                    = "${data.aws_caller_identity.account.account_id}"
+    event_emitter_api_gateway_url = "${var.event_emitter_api_gateway_url}"
 
     redis_host = "rediss://${
       aws_elasticache_replication_group.policy_session_store.primary_endpoint_address

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -75,6 +75,30 @@ module "policy" {
   certificate_arn            = "${local.wildcard_cert_arn}"
 }
 
+resource "aws_iam_policy" "policy_parameter_execution" {
+  name = "${var.deployment}-policy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-policy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "policy_parameter_execution" {
+  role       = "${var.deployment}-policy-execution"
+  policy_arn = "${aws_iam_policy.policy_parameter_execution.arn}"
+}
+
 module "policy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -41,13 +41,14 @@ data "template_file" "saml_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-proxy.json")}"
 
   vars {
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:latest"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
-    domain                 = "${local.root_domain}"
-    deployment             = "${var.deployment}"
-    location_blocks_base64 = "${local.nginx_saml_proxy_location_blocks_base64}"
-    region                 = "${data.aws_region.region.id}"
-    account_id             = "${data.aws_caller_identity.account.account_id}"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:latest"
+    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                        = "${local.root_domain}"
+    deployment                    = "${var.deployment}"
+    location_blocks_base64        = "${local.nginx_saml_proxy_location_blocks_base64}"
+    region                        = "${data.aws_region.region.id}"
+    account_id                    = "${data.aws_caller_identity.account.account_id}"
+    event_emitter_api_gateway_url = "${var.event_emitter_api_gateway_url}"
   }
 }
 
@@ -87,6 +88,11 @@ resource "aws_iam_policy" "saml_proxy_parameter_execution" {
     }]
   }
   EOF
+}
+
+resource "aws_iam_role_policy_attachment" "saml_proxy_parameter_execution" {
+  role       = "${var.deployment}-saml-proxy-execution"
+  policy_arn = "${aws_iam_policy.saml_proxy_parameter_execution.arn}"
 }
 
 module "saml_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -70,6 +70,25 @@ module "saml_proxy" {
   image_name                 = "verify-saml-proxy"
 }
 
+resource "aws_iam_policy" "saml_proxy_parameter_execution" {
+  name = "${var.deployment}-saml-proxy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-proxy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
 module "saml_proxy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -70,6 +70,25 @@ module "saml_soap_proxy" {
   image_name                 = "verify-saml-soap-proxy"
 }
 
+resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
+  name = "${var.deployment}-saml-soap-proxy-parameter-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-soap-proxy-key"
+      ]
+    }]
+  }
+  EOF
+}
+
 module "saml_soap_proxy_can_connect_to_config" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -41,13 +41,14 @@ data "template_file" "saml_soap_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-soap-proxy.json")}"
 
   vars {
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:latest"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
-    domain                 = "${local.root_domain}"
-    deployment             = "${var.deployment}"
-    location_blocks_base64 = "${local.nginx_saml_soap_proxy_location_blocks_base64}"
-    region                 = "${data.aws_region.region.id}"
-    account_id             = "${data.aws_caller_identity.account.account_id}"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:latest"
+    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                        = "${local.root_domain}"
+    deployment                    = "${var.deployment}"
+    location_blocks_base64        = "${local.nginx_saml_soap_proxy_location_blocks_base64}"
+    region                        = "${data.aws_region.region.id}"
+    account_id                    = "${data.aws_caller_identity.account.account_id}"
+    event_emitter_api_gateway_url = "${var.event_emitter_api_gateway_url}"
   }
 }
 
@@ -87,6 +88,11 @@ resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
     }]
   }
   EOF
+}
+
+resource "aws_iam_role_policy_attachment" "saml_soap_proxy_parameter_execution" {
+  role       = "${var.deployment}-saml-soap-proxy-execution"
+  policy_arn = "${aws_iam_policy.saml_soap_proxy_parameter_execution.arn}"
 }
 
 module "saml_soap_proxy_can_connect_to_config" {

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -73,3 +73,117 @@ resource "aws_kms_alias" "frontend" {
   name          = "alias/${var.deployment}-frontend-key"
   target_key_id = "${aws_kms_key.frontend.key_id}"
 }
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-policy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "policy" {
+  description = "Used for encrypting and decrypting policy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.policy.json}"
+}
+
+resource "aws_kms_alias" "policy" {
+  name          = "alias/${var.deployment}-policy-key"
+  target_key_id = "${aws_kms_key.policy.key_id}"
+}
+
+data "aws_iam_policy_document" "saml_proxy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "saml_proxy" {
+  description = "Used for encrypting and decrypting saml-proxy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.saml_proxy.json}"
+}
+
+resource "aws_kms_alias" "saml_proxy" {
+  name          = "alias/${var.deployment}-saml-proxy-key"
+  target_key_id = "${aws_kms_key.saml_proxy.key_id}"
+}
+
+data "aws_iam_policy_document" "saml_soap_proxy" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-soap-proxy-execution",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_kms_key" "saml_soap_proxy" {
+  description = "Used for encrypting and decrypting saml-soap-proxy secret parameters"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.saml_soap_proxy.json}"
+}
+
+resource "aws_kms_alias" "saml_soap_proxy" {
+  name          = "alias/${var.deployment}-saml-soap-proxy-key"
+  target_key_id = "${aws_kms_key.saml_soap_proxy.key_id}"
+}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -40,3 +40,7 @@ variable "logit_api_key" {
 variable "logit_elasticsearch_url" {
   description = "URL for logit.io elasticsearch, format: $guid-es.logit.io"
 }
+
+variable "event_emitter_api_gateway_url" {
+  description = "URL for Event Emitter API Gateway"
+}


### PR DESCRIPTION
This pull request contains two commits.

1. The first commit creates KMS keys for Policy, SAML Proxy and SAML SOAP Proxy to decrypt secret parameters.

2. The second commit adds event emitter environment variables to Policy, SAML Proxy and SAML SOAP Proxy applications so that they can use them to send events to new Audit and Billing system.

Author: @adityapahuja 