### PR TITLE
AUTO-220: Add DOMAIN environment variable to task

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -60,6 +60,10 @@
         "Value": "${deployment}"
       },
       {
+        "Name": "DOMAIN",
+        "Value": "${domain}"
+      },
+      {
         "Name": "EVENT_EMITTER_API_GATEWAY_URL",
         "Value": "${event_emitter_api_gateway_url}"
       },

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -60,6 +60,10 @@
         "Value": "${deployment}"
       },
       {
+        "Name": "DOMAIN",
+        "Value": "${domain}"
+      },
+      {
         "Name": "EVENT_EMITTER_API_GATEWAY_URL",
         "Value": "${event_emitter_api_gateway_url}"
       },


### PR DESCRIPTION
SAML Proxy and SAML SOAP Proxy are using www.${DEPLOYMENT}.signin.service.gov.uk for all environments. Unfortunately, in production, www.prod.signin.service.gov.uk does not exist. This commit adds DOMAIN environment variable to SAML Proxy and SAML SOAP Proxy tasks so that these applications can use www.${DOMAIN} for all environments including production.

Author: @adityapahuja