### PR TITLE
bump prometheus retention to 60 days

### DIFF
--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -26,7 +26,7 @@
     "entryPoint": [
       "sh",
       "-c",
-      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
+      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=60d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
     ]
   }
 ]


### PR DESCRIPTION
This bumps the prometheus retention period to 60 days.

No, I haven't done any deep thinking about this, I've just whacked the
number up so we can delay thinking deeply about what the retention
period should be.

We're running prometheus 2.7.1.  In this version, the old setting of
`--storage.tsdb.retention` has been deprecated in favour of
`--storage.tsdb.retention.time`.  There is also an experimental option
`--storage.tsdb.retention.size` which we might want to consider using
in future.