### PR TITLE
AUTO-96: Parameterise app image tags

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -42,7 +42,7 @@ data "template_file" "config_task_def" {
   template = "${file("${path.module}/files/tasks/hub-config.json")}"
 
   vars {
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-config:latest"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-config:${var.hub_config_image_tag}"
     nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -31,7 +31,7 @@ data "template_file" "frontend_task_def" {
   vars {
     account_id                 = "${data.aws_caller_identity.account.account_id}"
     deployment                 = "${var.deployment}"
-    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:latest"
+    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:${var.hub_frontend_image_tag}"
     nginx_image_and_tag        = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     domain                     = "${local.root_domain}"
     region                     = "${data.aws_region.region.id}"

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -14,7 +14,7 @@ data "template_file" "metadata_task_def" {
 
   vars {
     deployment    = "${var.deployment}"
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata:latest"
+    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata:${var.hub_metadata_image_tag}"
   }
 }
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -42,7 +42,7 @@ data "template_file" "policy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-policy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-policy:latest"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-policy:${var.hub_policy_image_tag}"
     nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -45,7 +45,7 @@ data "template_file" "saml_engine_task_def" {
     account_id             = "${data.aws_caller_identity.account.account_id}"
     deployment             = "${var.deployment}"
     domain                 = "${local.root_domain}"
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:latest"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:${var.hub_saml_engine_image-tag}"
     nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     region                 = "${data.aws_region.region.id}"
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -41,7 +41,7 @@ data "template_file" "saml_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-proxy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:latest"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:${var.hub_saml_proxy_image_tag}"
     nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -41,7 +41,7 @@ data "template_file" "saml_soap_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-soap-proxy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:latest"
+    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:${var.hub_saml_soap_proxy_image_tag}"
     nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -52,3 +52,11 @@ variable "zendesk_url" {
 variable "zendesk_username" {
   description = "Username (email address) for Zendesk access"
 }
+
+variable "hub_config_image_tag" {}
+variable "hub_policy_image_tag" {}
+variable "hub_saml_proxy_image_tag" {}
+variable "hub_saml_soap_proxy_image_tag" {}
+variable "hub_saml_engine_image_tag" {}
+variable "hub_frontend_image_tag" {}
+variable "hub_metadata_image_tag" {}


### PR DESCRIPTION
- We want to be able to trace exactly what image went into a task
  definition so that we can reproduce issues etc. and for audit
- Create new variables and interpolate them into the taskdef
- Variable names are fairly descriptive so didn't put and description to
  keep the `variables.tf` file easier to read
- As these will have to be provided by the pipeline, they will come as
  variables to the `site.tf` so don't default anything here