### PR TITLE
Change the ELBSecurityPolicy to not include TLSv1.0

### DIFF
--- a/terraform/modules/hub/modules/ecs_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_app/lb.tf
@@ -53,7 +53,7 @@ resource "aws_lb_listener" "cluster_https" {
   load_balancer_arn = "${aws_lb.cluster.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-1-2017-01"
   certificate_arn   = "${var.certificate_arn}"
 
   default_action {


### PR DESCRIPTION
- TLSv1.0 is considered legacy, so update to the newer one that excludes
  it but still includes TLSv1.1 and TLSv1.2.

Co-authored-by: Matthew Cullum <matthew.cullum@digital.cabinet-office.gov.uk>

https://trello.com/c/IIj0ha7B/201-secure-cipher-suites