### PR TITLE
set journalbeat logging level to info on prometheus

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -85,7 +85,7 @@ journalbeat.inputs:
 - paths: []
   seek: cursor
 
-logging.level: warning
+logging.level: info
 logging.to_files: false
 logging.to_syslog: true
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -88,6 +88,8 @@ dpkg -i journalbeat-6.6.0-amd64.deb
 cat <<EOF > /etc/journalbeat/journalbeat.yml
 http.enabled: true
 
+flush.timeout: 30s
+
 journalbeat.inputs:
 - paths: []
   seek: cursor


### PR DESCRIPTION
We're seeing random journalbeat failures, where journalbeat keeps
running but stops sending logs, but we don't see anything in the
journalbeat logs that suggests why this might be happening.

I'm hoping that if we set the logging level to `info` instead of
`warning`, we might get to the bottom of this.  However, `info` level
is incredibly chatty.  For example, here are 15 seconds worth of logs
from a not-terribly-busy server:

    Feb 11 15:48:44 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 11 events
    Feb 11 15:48:47 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 1 events
    Feb 11 15:48:50 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 3 events
    Feb 11 15:48:53 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 3 events
    Feb 11 15:48:53 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 6 events
    Feb 11 15:48:56 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 2 events
    Feb 11 15:48:59 ip-10-0-30-141 journalbeat[8669]: INFO [input] input/input.go:133 journalbeat successfully published 4 events

As a result, this commit *only* enables info logging on the prometheus
servers, as a temporary thing while we try to diagnose the problem.  I
chose the prometheus servers because they will be instantly rebuilt
rather than needing to faff around with the ASGs.