### PR TITLE
move flush.timeout to prometheus cloud-init

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -85,6 +85,8 @@ journalbeat.inputs:
 - paths: []
   seek: cursor
 
+flush.timeout: 30s
+
 logging.level: info
 logging.to_files: false
 logging.to_syslog: true

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -88,8 +88,6 @@ dpkg -i journalbeat-6.6.0-amd64.deb
 cat <<EOF > /etc/journalbeat/journalbeat.yml
 http.enabled: true
 
-flush.timeout: 30s
-
 journalbeat.inputs:
 - paths: []
   seek: cursor


### PR DESCRIPTION
oops

i meant to put this into prometheus in the first place, not the asg cloud init