### PR TITLE
back out journalbeat logging changes

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -85,9 +85,6 @@ journalbeat.inputs:
 - paths: []
   seek: cursor
 
-flush.timeout: 30s
-
-logging.level: info
 logging.to_files: false
 logging.to_syslog: true
 


### PR DESCRIPTION
introduced in 8a1a47, it didn't teach us very much.