### PR TITLE
AUTO-172: Parameterize matomo site ID

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -109,7 +109,7 @@
       "Value": "https://www.${domain}:443/piwik.php"
     }, {
       "Name": "PIWIK_SITE_ID",
-      "Value": "1"
+      "Value": "${matomo_site_id}"
     }, {
       "Name": "ZENDESK_URL",
       "Value": "${zendesk_url}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -39,6 +39,7 @@ data "template_file" "frontend_task_def" {
     egress_proxy_url_with_port = "${local.egress_proxy_url_with_protocol}"
     zendesk_username           = "${var.zendesk_username}"
     zendesk_url                = "${var.zendesk_url}"
+    matomo_site_id             = "${var.matomo_site_id}"
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -53,6 +53,11 @@ variable "zendesk_username" {
   description = "Username (email address) for Zendesk access"
 }
 
+variable "matomo_site_id" {
+  description = "Site ID to use for Matomo"
+  default = 1
+}
+
 variable "hub_config_image_tag" {}
 variable "hub_policy_image_tag" {}
 variable "hub_saml_proxy_image_tag" {}


### PR DESCRIPTION
- We want to send all analytics data to a single Matomo instance so each
  environment needs a different site ID
- Named things Matomo as far as possible but need to use `PIWIK_SITE_ID`
  in the frontend config
- Defaulted so as to allow us to migrate each site individually