### PR TITLE
Journalbeat needs to be restarted frequently.

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -185,4 +185,5 @@ apt-get install --yes moreutils
 crontab - <<EOF
 $(crontab -l | grep -v 'no crontab')
 */5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
+*/5 * * * * /usr/sbin/service journalbeat restart
 EOF


### PR DESCRIPTION
Journalbeat appears to have a fault that causes it to stop delivering
logs. This is hard to detect since it does not error and also remains
running. The simple, quick and dirty fix is to restart the service on a
regular basis.

Logs back up and are not lost but are resent after the service has been
restarted.

Single: matthewcullum-gds