### PR TITLE
Add reboot required metric and restart journalbeat

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -136,6 +136,31 @@ chown -R nobody /var/lib/prometheus
 echo 'Installing awscli'
 apt-get install --yes awscli
 
+#Initialise a node_creation_time metric to enable the predict_linear function to handle new nodes
+echo "node_creation_time `date +%s`" > /var/lib/prometheus/node-exporter/node-creation-time.prom
+
+cat <<EOF > /usr/bin/instance-reboot-required-metric.sh
+#!/usr/bin/env bash
+
+echo '# HELP node_reboot_required Node reboot is required for software updates.'
+echo '# TYPE node_reboot_required gauge'
+if [[ -f '/run/reboot-required' ]] ; then
+  echo 'node_reboot_required 1'
+else
+  echo 'node_reboot_required 0'
+fi
+EOF
+
+chmod +x /usr/bin/instance-reboot-required-metric.sh
+
+apt-get install --yes moreutils
+
+crontab - <<EOF
+$(crontab -l | grep -v 'no crontab')
+*/5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
+*/5 * * * * /usr/sbin/service journalbeat restart
+EOF
+
 # ECS
 echo 'Running ECS using Docker'
 mkdir -p /etc/ecs


### PR DESCRIPTION
Journalbeat requires frequent restarting to ensure log delivery. Added
reboot-required metric to make the protheus node in line with the rest
of the environment.

Single: matthewcullum-gds