### PR TITLE
AUTO-187: Update nginx to include mime types

### DIFF
--- a/dockerfiles/nginx-tls/nginx.conf.tpl
+++ b/dockerfiles/nginx-tls/nginx.conf.tpl
@@ -11,6 +11,10 @@ http {
   sendfile     on;
   tcp_nopush   on;
   server_names_hash_bucket_size 128;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
   resolver     "$resolver";
 
   server {


### PR DESCRIPTION
Web browsers are not able to render images (e.g. Matomo logo) correctly. This commit updates nginx template config file to include mime types so that web browsers can render images correctly.

Author: @adityapahuja