### PR TITLE
Use number_of_apps variable

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -168,7 +168,10 @@ resource "aws_ecs_service" "egress_proxy" {
   name            = "${var.deployment}-egress-proxy"
   cluster         = "${aws_ecs_cluster.egress_proxy.id}"
   task_definition = "${aws_ecs_task_definition.egress_proxy.arn}"
-  desired_count   = 1
+
+  desired_count                      = "${var.number_of_apps}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
 
   load_balancer {
     elb_name       = "${aws_elb.egress_proxy.name}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -82,7 +82,10 @@ resource "aws_ecs_service" "frontend" {
   name            = "${var.deployment}-frontend"
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.frontend.arn}"
-  desired_count   = 1
+
+  desired_count                      = "${var.number_of_apps}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_frontend.arn}"

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -38,7 +38,10 @@ resource "aws_ecs_service" "metadata" {
   name            = "${var.deployment}-metadata"
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.metadata.arn}"
-  desired_count   = 1
+
+  desired_count                      = "${var.number_of_apps}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_metadata.arn}"

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -218,7 +218,7 @@ module "ingress_ecs_asg" {
   cluster             = "ingress"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_apps + 1}"
+  number_of_instances = "${var.number_of_apps + 2}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -150,7 +150,10 @@ resource "aws_ecs_service" "static_ingress_http" {
   name            = "${var.deployment}-static-ingress-http"
   cluster         = "${aws_ecs_cluster.static-ingress.id}"
   task_definition = "${aws_ecs_task_definition.static_ingress_http.arn}"
-  desired_count   = 1
+
+  desired_count                      = "${var.number_of_apps}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_http.arn}"
@@ -163,7 +166,10 @@ resource "aws_ecs_service" "static_ingress_https" {
   name            = "${var.deployment}-static-ingress-https"
   cluster         = "${aws_ecs_cluster.static-ingress.id}"
   task_definition = "${aws_ecs_task_definition.static_ingress_https.arn}"
-  desired_count   = 1
+
+  desired_count                      = "${var.number_of_apps}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_https.arn}"


### PR DESCRIPTION
Previously we had desired_count set to 1 in a bunch of places

This should be set to the number of apps we have configured globally

However we also need to override the min healthy to be 50 so when doing
a rolling update it can remove one of the instances (this is not
possible when minimum healthy is 100%)

Increase number of ingress instances because increase number of apps that run on ingress

How to review
---

Code review