### PR TITLE
Add ruby aws image for the pipeline

### DIFF
--- a/dockerfiles/aws-ruby/Dockerfile
+++ b/dockerfiles/aws-ruby/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.6.1
+
+LABEL ruby="2.6.1"
+LABEL aws="3.0.1"
+LABEL user="gdsre"
+LABEL repo="aws-ruby"
+
+RUN gem install aws-sdk:3.0.1
+
+ENTRYPOINT ["ruby"]


### PR DESCRIPTION
I've built and pushed this into `gdsre` (rather than `governmentpaas`)

Ultimately we should have a separate pipeline for these publicly accessible utility pipeline images.