### PR TITLE
Rename zendesk token ssm param name

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -47,7 +47,7 @@
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/sentry-dsn"
       }, {
         "name": "ZENDESK_TOKEN",
-        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/prod-zendesk-token"
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/zendesk-token"
       }
     ],
     "environment": [{


### PR DESCRIPTION
It would be prod-zendesk-token in all envs which is confusing

I have put this param in staging and joint ssm