### PR TITLE
run multiple tasks

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -63,7 +63,7 @@ locals {
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
     "std-ocsp\\.trustwise\\.com",                                                   # OCSP check URI
     "${replace(local.event_emitter_api_gateway[0], ".", "\\.")}",                   # API Gateway
-    "govuk\\.zendesk\\.com"                                                         # Zendesk
+    "govuk\\.zendesk\\.com",                                                        # Zendesk
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"
@@ -168,7 +168,7 @@ resource "aws_ecs_service" "egress_proxy" {
   name            = "${var.deployment}-egress-proxy"
   cluster         = "${aws_ecs_cluster.egress_proxy.id}"
   task_definition = "${aws_ecs_task_definition.egress_proxy.arn}"
-  desired_count   = 1
+  desired_count   = "${var.number_of_tasks}"
 
   load_balancer {
     elb_name       = "${aws_elb.egress_proxy.name}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -49,16 +49,16 @@ data "template_file" "frontend_task_def" {
   template = "${file("${path.module}/files/tasks/frontend.json")}"
 
   vars {
-    account_id                 = "${data.aws_caller_identity.account.account_id}"
-    deployment                 = "${var.deployment}"
-    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:${var.hub_frontend_image_tag}"
-    nginx_image_and_tag        = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
-    domain                     = "${local.root_domain}"
-    region                     = "${data.aws_region.region.id}"
-    location_blocks_base64     = "${local.location_blocks_base64}"
-    zendesk_username           = "${var.zendesk_username}"
-    zendesk_url                = "${var.zendesk_url}"
-    matomo_site_id             = "${var.matomo_site_id}"
+    account_id             = "${data.aws_caller_identity.account.account_id}"
+    deployment             = "${var.deployment}"
+    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-frontend:${var.hub_frontend_image_tag}"
+    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    domain                 = "${local.root_domain}"
+    region                 = "${data.aws_region.region.id}"
+    location_blocks_base64 = "${local.location_blocks_base64}"
+    zendesk_username       = "${var.zendesk_username}"
+    zendesk_url            = "${var.zendesk_url}"
+    matomo_site_id         = "${var.matomo_site_id}"
   }
 }
 
@@ -82,7 +82,7 @@ resource "aws_ecs_service" "frontend" {
   name            = "${var.deployment}-frontend"
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.frontend.arn}"
-  desired_count   = 1
+  desired_count   = "${var.number_of_tasks}"
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_frontend.arn}"
@@ -91,7 +91,8 @@ resource "aws_ecs_service" "frontend" {
   }
 
   network_configuration {
-    subnets         = ["${aws_subnet.internal.*.id}"]
+    subnets = ["${aws_subnet.internal.*.id}"]
+
     security_groups = [
       "${aws_security_group.frontend_task.id}",
       "${aws_security_group.can_connect_to_container_vpc_endpoint.id}",

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_service" "metadata" {
   name            = "${var.deployment}-metadata"
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.metadata.arn}"
-  desired_count   = 1
+  desired_count   = "${var.number_of_tasks}"
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_metadata.arn}"
@@ -47,7 +47,8 @@ resource "aws_ecs_service" "metadata" {
   }
 
   network_configuration {
-    subnets         = ["${aws_subnet.internal.*.id}"]
+    subnets = ["${aws_subnet.internal.*.id}"]
+
     security_groups = [
       "${aws_security_group.metadata_task.id}",
       "${aws_security_group.can_connect_to_container_vpc_endpoint.id}",

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -150,7 +150,7 @@ resource "aws_ecs_service" "static_ingress_http" {
   name            = "${var.deployment}-static-ingress-http"
   cluster         = "${aws_ecs_cluster.static-ingress.id}"
   task_definition = "${aws_ecs_task_definition.static_ingress_http.arn}"
-  desired_count   = 1
+  desired_count   = "${var.number_of_tasks}"
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_http.arn}"
@@ -163,7 +163,7 @@ resource "aws_ecs_service" "static_ingress_https" {
   name            = "${var.deployment}-static-ingress-https"
   cluster         = "${aws_ecs_cluster.static-ingress.id}"
   task_definition = "${aws_ecs_task_definition.static_ingress_https.arn}"
-  desired_count   = 1
+  desired_count   = "${var.number_of_tasks}"
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_https.arn}"


### PR DESCRIPTION
some of our ECS services were hardcoded to a single task.  This sets
them to ${var.number_of_tasks}.

Also, appease terraform fmt.

The services edited are:

 - egress-proxy
 - frontend
 - metadata
 - static-ingress (http and https)