### PR TITLE
Remove things from egress proxy safelist

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -58,12 +58,9 @@ locals {
     "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com",                                     # Apt
     "security\\.ubuntu\\.com",                                                      # Apt
     "artifacts\\.elastic\\.co",                                                     # Journalbeat
-    "test-rp-msa-stub-${var.deployment}\\.ida.digital\\.cabinet-office\\.gov\\.uk", # Test RP
     "${replace(var.logit_elasticsearch_url, ".", "\\.")}",                          # Logit
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
-    "std-ocsp\\.trustwise\\.com",                                                   # OCSP check URI
     "${replace(local.event_emitter_api_gateway[0], ".", "\\.")}",                   # API Gateway
-    "govuk\\.zendesk\\.com"                                                         # Zendesk
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"


### PR DESCRIPTION
We only use the egress proxy for saml engine which only needs:

- to download packages
- access to sentry
- access to logit
- to send events to the api gateway