### PR TITLE
Alert for down services

### DIFF
--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -50,7 +50,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "name": "Servers needing reboot alert",
+        "name": "[${deployment}] Servers needing reboot alert",
         "noDataState": "ok",
         "notifications": []
       },
@@ -176,7 +176,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "name": "Certificate Expiry is Less than 14 days",
+        "name": "[${deployment}] Certificate Expiry is Less than 14 days",
         "noDataState": "no_data",
         "notifications": [
           {
@@ -309,7 +309,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "name": "NTP Time Drift alert",
+        "name": "[${deployment}] NTP Time Drift alert",
         "noDataState": "no_data",
         "notifications": []
       },
@@ -695,7 +695,7 @@
         "for": "30m",
         "frequency": "1m",
         "handler": 1,
-        "name": "Certificates failed OCSP alert",
+        "name": "[${deployment}] Certificates failed OCSP alert",
         "noDataState": "no_data",
         "notifications": []
       },

--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -916,6 +916,162 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${source}",
+      "fill": 1,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "up",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "refId": "B",
+          "expr": "journalbeat_up",
+          "intervalFactor": 1,
+          "format": "time_series"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Up targets & services",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      },
+      "thresholds": [
+        {
+          "value": 1,
+          "op": "lt",
+          "fill": true,
+          "line": true,
+          "colorMode": "critical"
+        }
+      ],
+      "alert": {
+        "conditions": [
+          {
+            "type": "query",
+            "query": {
+              "params": [
+                "A",
+                "1m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "type": "last",
+              "params": []
+            },
+            "evaluator": {
+              "type": "lt",
+              "params": [
+                1
+              ]
+            },
+            "operator": {
+              "type": "and"
+            }
+          },
+          {
+            "type": "query",
+            "query": {
+              "params": [
+                "B",
+                "1m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "type": "last",
+              "params": []
+            },
+            "evaluator": {
+              "type": "lt",
+              "params": [
+                1
+              ]
+            },
+            "operator": {
+              "type": "or"
+            }
+          }
+        ],
+        "noDataState": "no_data",
+        "executionErrorState": "alerting",
+        "frequency": "1m",
+        "handler": 1,
+        "notifications": [],
+        "for": "15m",
+        "name": "[${deployment}] Service down"
+      }
     }
   ],
   "refresh": false,


### PR DESCRIPTION
This adds an alert which fires if `up` or `journalbeat_up` is 0 for 15
minutes or more.
