### PR TITLE
Segregate accessible cidr variable

### DIFF
--- a/terraform/modules/hub/mgmt.tf
+++ b/terraform/modules/hub/mgmt.tf
@@ -21,7 +21,7 @@ resource "aws_security_group_rule" "mgmt_lb_ingress_from_internet_over_http" {
   to_port   = 80
 
   security_group_id = "${aws_security_group.mgmt_lb.id}"
-  cidr_blocks       = ["${var.publically_accessible_from_cidrs}"]
+  cidr_blocks       = ["${var.mgmt_accessible_from_cidrs}"]
 }
 
 resource "aws_security_group_rule" "mgmt_lb_ingress_from_internet_over_https" {
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "mgmt_lb_ingress_from_internet_over_https" {
   to_port   = 443
 
   security_group_id = "${aws_security_group.mgmt_lb.id}"
-  cidr_blocks       = ["${var.publically_accessible_from_cidrs}"]
+  cidr_blocks       = ["${var.mgmt_accessible_from_cidrs}"]
 }
 
 locals {

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -15,7 +15,11 @@ variable "number_of_apps" {
 }
 
 variable "publically_accessible_from_cidrs" {
-  default = ["0.0.0.0/0"]
+  type    = "list"
+}
+
+variable "mgmt_accessible_from_cidrs" {
+  type    = "list"
 }
 
 variable "redis_cache_size" {


### PR DESCRIPTION
Our prod environment should be world accessible but the mgmt lb shouldnt
be, we need separate variables for this