### PR TITLE
AUTO-96: Use digests everywhere

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -11,7 +11,7 @@ data "template_file" "beat_exporter_task_def" {
   template = "${file("${path.module}/files/tasks/beat-exporter.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-beat-exporter:latest"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-beat-exporter@${var.beat_exporter_image_digest}"
   }
 }
 

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -11,8 +11,8 @@ data "template_file" "cloudwatch_exporter_task_def" {
   template = "${file("${path.module}/files/tasks/cloudwatch-exporter.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-cloudwatch-exporter:latest"
-    config_base64 = "${base64encode(file("${path.module}/files/prometheus/cloudwatch_exporter.yml"))}"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-cloudwatch-exporter@${var.cloudwatch_exporter_image_digest}"
+    config_base64    = "${base64encode(file("${path.module}/files/prometheus/cloudwatch_exporter.yml"))}"
   }
 }
 

--- a/terraform/modules/hub/ecr.tf
+++ b/terraform/modules/hub/ecr.tf
@@ -1,6 +1,6 @@
 locals {
   tools_account_ecr_url_prefix = "${var.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer"
 
-  ecs_agent_image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-ecs-agent:latest"
-  nginx_image_identifier  = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls@${var.nginx_image_digest}"
+  ecs_agent_image_identifier = "${local.tools_account_ecr_url_prefix}-verify-ecs-agent@${var.ecs_agent_image_digest}"
+  nginx_image_identifier     = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls@${var.nginx_image_digest}"
 }

--- a/terraform/modules/hub/ecr.tf
+++ b/terraform/modules/hub/ecr.tf
@@ -2,4 +2,5 @@ locals {
   tools_account_ecr_url_prefix = "${var.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer"
 
   ecs_agent_image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-ecs-agent:latest"
+  nginx_image_identifier  = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls@${var.nginx_image_digest}"
 }

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -9,8 +9,8 @@ module "egress_proxy_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   logit_api_key           = "${var.logit_api_key}"
   logit_elasticsearch_url = "${var.logit_elasticsearch_url}"

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -71,7 +71,7 @@ data "template_file" "egress_proxy_task_def" {
 
   vars {
     whitelist_base64 = "${base64encode(local.egress_proxy_whitelist)}"
-    image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-squid:latest"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-squid@${var.squid_image_digest}"
   }
 }
 

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -199,4 +199,4 @@ docker run \
   --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
   --env="ECS_LOGLEVEL=warn" \
-  ${ecs_agent_image_and_tag}
+  ${ecs_agent_image_identifier}

--- a/terraform/modules/hub/files/tasks/beat-exporter.json
+++ b/terraform/modules/hub/files/tasks/beat-exporter.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "beat-exporter",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 64,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "cloudwatch-exporter",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 1024,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -20,7 +20,7 @@
   },
   {
     "name": "frontend",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "config",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "policy",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "saml-engine",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "saml-proxy",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "saml-soap-proxy",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${nginx_image_and_tag}",
+    "image": "${nginx_image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "metadata-exporter",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 1024,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "nginx",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 250,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "prometheus",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "squid",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": 3500,
     "essential": true,

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "static-ingress",
-    "image": "${image_and_tag}",
+    "image": "${image_identifier}",
     "cpu": 0,
     "memory": ${allocated_memory},
     "essential": true,

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -62,7 +62,7 @@ data "template_file" "config_task_def" {
 
   vars {
     image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-config:${var.hub_config_image_tag}"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier = "${local.nginx_image_identifier}"
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"
     truststore_password    = "${var.truststore_password}"

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -10,8 +10,8 @@ module "config_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.scraped_by_prometheus.id}",

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -61,7 +61,7 @@ data "template_file" "config_task_def" {
   template = "${file("${path.module}/files/tasks/hub-config.json")}"
 
   vars {
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-config:${var.hub_config_image_tag}"
+    image_identifier       = "${local.tools_account_ecr_url_prefix}-verify-config@${var.hub_config_image_digest}"
     nginx_image_identifier = "${local.nginx_image_identifier}"
     domain                 = "${local.root_domain}"
     deployment             = "${var.deployment}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -52,7 +52,7 @@ data "template_file" "frontend_task_def" {
     account_id                 = "${data.aws_caller_identity.account.account_id}"
     deployment                 = "${var.deployment}"
     image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:${var.hub_frontend_image_tag}"
-    nginx_image_and_tag        = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier     = "${local.nginx_image_identifier}"
     domain                     = "${local.root_domain}"
     region                     = "${data.aws_region.region.id}"
     location_blocks_base64     = "${local.location_blocks_base64}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -51,7 +51,7 @@ data "template_file" "frontend_task_def" {
   vars {
     account_id                 = "${data.aws_caller_identity.account.account_id}"
     deployment                 = "${var.deployment}"
-    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-frontend:${var.hub_frontend_image_tag}"
+    image_identifier           = "${local.tools_account_ecr_url_prefix}-verify-frontend@${var.hub_frontend_image_digest}"
     nginx_image_identifier     = "${local.nginx_image_identifier}"
     domain                     = "${local.root_domain}"
     region                     = "${data.aws_region.region.id}"

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -13,8 +13,8 @@ data "template_file" "metadata_task_def" {
   template = "${file("${path.module}/files/tasks/metadata.json")}"
 
   vars {
-    deployment    = "${var.deployment}"
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-metadata:${var.hub_metadata_image_tag}"
+    deployment       = "${var.deployment}"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-metadata@${var.hub_metadata_image_digest}"
   }
 }
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -10,8 +10,8 @@ module "policy_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.scraped_by_prometheus.id}",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -62,7 +62,7 @@ data "template_file" "policy_task_def" {
 
   vars {
     image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-policy:${var.hub_policy_image_tag}"
-    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"
     location_blocks_base64        = "${local.nginx_policy_location_blocks_base64}"

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -61,7 +61,7 @@ data "template_file" "policy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-policy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-policy:${var.hub_policy_image_tag}"
+    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-policy@${var.hub_policy_image_digest}"
     nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -46,7 +46,7 @@ data "template_file" "saml_engine_task_def" {
     account_id             = "${data.aws_caller_identity.account.account_id}"
     deployment             = "${var.deployment}"
     domain                 = "${local.root_domain}"
-    image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:${var.hub_saml_engine_image_tag}"
+    image_identifier       = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
     nginx_image_identifier = "${local.nginx_image_identifier}"
     region                 = "${data.aws_region.region.id}"
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -47,7 +47,7 @@ data "template_file" "saml_engine_task_def" {
     deployment             = "${var.deployment}"
     domain                 = "${local.root_domain}"
     image_and_tag          = "${local.tools_account_ecr_url_prefix}-verify-saml-engine:${var.hub_saml_engine_image_tag}"
-    nginx_image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier = "${local.nginx_image_identifier}"
     region                 = "${data.aws_region.region.id}"
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"
     redis_host             = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -11,8 +11,8 @@ module "saml_engine_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.egress_via_proxy.id}",

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -9,8 +9,8 @@ module "saml_proxy_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.scraped_by_prometheus.id}",

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -60,7 +60,7 @@ data "template_file" "saml_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-proxy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:${var.hub_saml_proxy_image_tag}"
+    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
     nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -61,7 +61,7 @@ data "template_file" "saml_proxy_task_def" {
 
   vars {
     image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy:${var.hub_saml_proxy_image_tag}"
-    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"
     location_blocks_base64        = "${local.nginx_saml_proxy_location_blocks_base64}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -60,7 +60,7 @@ data "template_file" "saml_soap_proxy_task_def" {
   template = "${file("${path.module}/files/tasks/hub-saml-soap-proxy.json")}"
 
   vars {
-    image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:${var.hub_saml_soap_proxy_image_tag}"
+    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
     nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -61,7 +61,7 @@ data "template_file" "saml_soap_proxy_task_def" {
 
   vars {
     image_and_tag                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy:${var.hub_saml_soap_proxy_image_tag}"
-    nginx_image_and_tag           = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls:latest"
+    nginx_image_identifier        = "${local.nginx_image_identifier}"
     domain                        = "${local.root_domain}"
     deployment                    = "${var.deployment}"
     location_blocks_base64        = "${local.nginx_saml_soap_proxy_location_blocks_base64}"

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -9,8 +9,8 @@ module "saml_soap_proxy_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.scraped_by_prometheus.id}",

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -221,8 +221,8 @@ module "ingress_ecs_asg" {
   number_of_instances = "${var.number_of_apps + 2}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.ingress.id}",

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -11,7 +11,7 @@ data "template_file" "metadata_exporter_task_def" {
   template = "${file("${path.module}/files/tasks/metadata-exporter.json")}"
 
   vars {
-    image_and_tag              = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter:latest"
+    image_identifier           = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter@${var.metadate_exporter_image_digest}"
     signin_domain              = "${var.signin_domain}"
     deployment                 = "${var.deployment}"
   }

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -23,7 +23,7 @@ data "template_file" "cloud_init" {
     journalbeat_egress_proxy_setting = "${local.journalbeat_egress_proxy_setting}"
     logit_elasticsearch_url          = "${var.logit_elasticsearch_url}"
     logit_api_key                    = "${var.logit_api_key}"
-    ecs_agent_image_and_tag          = "${var.ecs_agent_image_and_tag}"
+    ecs_agent_image_identifier       = "${var.ecs_agent_image_identifier}"
     tools_account_id                 = "${var.tools_account_id}"
   }
 }

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -146,7 +146,7 @@ docker run \
   --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
   --env="ECS_LOGLEVEL=warn" \
-  ${ecs_agent_image_and_tag}
+  ${ecs_agent_image_identifier}
 
 apt-get install --yes prometheus-node-exporter
 mkdir /etc/systemd/system/prometheus-node-exporter.service.d

--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -34,5 +34,5 @@ variable "use_egress_proxy" {
 
 variable "logit_api_key" {}
 variable "logit_elasticsearch_url" {}
-variable "ecs_agent_image_and_tag" {}
+variable "ecs_agent_image_identifier" {}
 variable "tools_account_id" {}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -432,8 +432,8 @@ data "template_file" "prometheus_task_def" {
   template = "${file("${path.module}/files/tasks/prometheus.json")}"
 
   vars {
-    image_and_tag = "${local.tools_account_ecr_url_prefix}-verify-prometheus:latest"
-    config_base64 = "${base64encode(data.template_file.prometheus_config.rendered)}"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-prometheus@${var.prometheus_image_digest}"
+    config_base64    = "${base64encode(data.template_file.prometheus_config.rendered)}"
   }
 }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -321,7 +321,7 @@ data "template_file" "prometheus_cloud_init" {
     logit_elasticsearch_url        = "${var.logit_elasticsearch_url}"
     logit_api_key                  = "${var.logit_api_key}"
     cluster                        = "${aws_ecs_cluster.prometheus.name}"
-    ecs_agent_image_and_tag        = "${local.ecs_agent_image_and_tag}"
+    ecs_agent_image_identifier     = "${local.ecs_agent_image_identifier}"
     tools_account_id               = "${var.tools_account_id}"
   }
 }

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -9,8 +9,8 @@ module "static_ingress_ecs_asg" {
   number_of_instances = "${var.number_of_apps}"
   domain              = "${local.root_domain}"
 
-  ecs_agent_image_and_tag = "${local.ecs_agent_image_and_tag}"
-  tools_account_id        = "${var.tools_account_id}"
+  ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+  tools_account_id           = "${var.tools_account_id}"
 
   additional_instance_security_group_ids = [
     "${aws_security_group.scraped_by_prometheus.id}",

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -103,7 +103,7 @@ data "template_file" "static_ingress_http_task_def" {
   template = "${file("${path.module}/files/tasks/static-ingress.json")}"
 
   vars {
-    image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-static-ingress:latest"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress@${var.static_ingress_image_digest}"
     backend          = "${var.signin_domain}"
     bind_port        = 80
     backend_port     = 80
@@ -115,7 +115,7 @@ data "template_file" "static_ingress_https_task_def" {
   template = "${file("${path.module}/files/tasks/static-ingress.json")}"
 
   vars {
-    image_and_tag    = "${local.tools_account_ecr_url_prefix}-verify-static-ingress:latest"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress@${var.static_ingress_image_digest}"
     backend          = "${var.signin_domain}"
     bind_port        = 443
     backend_port     = 443

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -69,4 +69,6 @@ variable "hub_saml_soap_proxy_image_digest" {}
 variable "hub_saml_engine_image_digest" {}
 variable "hub_frontend_image_digest" {}
 variable "hub_metadata_image_digest" {}
+
+variable "ecs_agent_image_digest" {}
 variable "nginx_image_digest" {}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -69,3 +69,4 @@ variable "hub_saml_soap_proxy_image_tag" {}
 variable "hub_saml_engine_image_tag" {}
 variable "hub_frontend_image_tag" {}
 variable "hub_metadata_image_tag" {}
+variable "nginx_image_digest" {}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -72,3 +72,9 @@ variable "hub_metadata_image_digest" {}
 
 variable "ecs_agent_image_digest" {}
 variable "nginx_image_digest" {}
+variable "static_ingress_image_digest" {}
+variable "beat_exporter_image_digest" {}
+variable "cloudwatch_exporter_image_digest" {}
+variable "squid_image_digest" {}
+variable "metadate_exporter_image_digest" {}
+variable "prometheus_image_digest" {}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -62,11 +62,11 @@ variable "matomo_site_id" {
   default = 1
 }
 
-variable "hub_config_image_tag" {}
-variable "hub_policy_image_tag" {}
-variable "hub_saml_proxy_image_tag" {}
-variable "hub_saml_soap_proxy_image_tag" {}
-variable "hub_saml_engine_image_tag" {}
-variable "hub_frontend_image_tag" {}
-variable "hub_metadata_image_tag" {}
+variable "hub_config_image_digest" {}
+variable "hub_policy_image_digest" {}
+variable "hub_saml_proxy_image_digest" {}
+variable "hub_saml_soap_proxy_image_digest" {}
+variable "hub_saml_engine_image_digest" {}
+variable "hub_frontend_image_digest" {}
+variable "hub_metadata_image_digest" {}
 variable "nginx_image_digest" {}


### PR DESCRIPTION
- `git grep latest` should show that we are now pegging the version of all our images
- Basically instead of assuming latest, ask for a digest to pull
- Renamed task variables to just reference an "identifier"