### PR TITLE
lower journalbeat alert threshold

### DIFF
--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -796,7 +796,7 @@
           {
             "evaluator": {
               "params": [
-                0.01
+                0.001
               ],
               "type": "lt"
             },
@@ -874,7 +874,7 @@
           "fill": true,
           "line": true,
           "op": "lt",
-          "value": 0.01
+          "value": 0.001
         }
       ],
       "timeFrom": null,


### PR DESCRIPTION
We really want to alert when <= 0, but we only get a less-than
operator so I've been choosing a really small nonzero number instead.
But 0.01 isn't low enough to avoid false positives so we're getting a
steady stream of noise.