### PR TITLE
remove journalbeat cron for prometheus

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -159,7 +159,6 @@ apt-get install --yes moreutils
 crontab - <<EOF
 $(crontab -l | grep -v 'no crontab')
 */5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
-*/5 * * * * /usr/sbin/service journalbeat restart
 EOF
 
 # ECS


### PR DESCRIPTION
This removes the journalbeat restart cron job for prometheus only.

My goal is to let it run for a bit and observe if we're actually
hitting this issue: https://github.com/elastic/beats/issues/9533

ie I plan to see if we stop sending logs, and see if it coincides with
journal rotation

I picked prometheus for this because a) it has a different cloudinit
file, and b) it's less critical than everything else