### PR TITLE
add $deployment as tag to dashboard

### DIFF
--- a/terraform/modules/dashboards/tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/tickets_dashboard.json.tpl
@@ -1078,7 +1078,7 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
-    "verify"
+    "verify", "${deployment}"
   ],
   "templating": {
     "list": []


### PR DESCRIPTION
so that we can display prod alerts separately from non-prod