### PR TITLE
Increase number of instances for ingress everywhere

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -238,7 +238,7 @@ module "ingress_ecs_asg" {
   cluster             = "ingress"
   vpc_id              = "${aws_vpc.hub.id}"
   instance_subnets    = ["${aws_subnet.internal.*.id}"]
-  number_of_instances = "${var.number_of_apps + 2}"
+  number_of_instances = "${var.number_of_apps * 2}"
   domain              = "${local.root_domain}"
 
   ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"


### PR DESCRIPTION
We run into the situation where things running on ingress (md,
analytic, frontend) cannot be scheduled because there are not enough
networking interfaces (our current instance supports 3 NIs)

We should add one more

Co-authored-by: Stephen Grier <stephen.grier@digital.cabinet-office.gov.uk>