### PR TITLE
Tune frontend task memory

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -22,7 +22,7 @@
     "name": "frontend",
     "image": "${image_identifier}",
     "cpu": 0,
-    "memory": 3500,
+    "memory": 3000,
     "essential": true,
     "portMappings": [
       {


### PR DESCRIPTION
nginx 250mb + frontend 3500mb = 3750mb which means it cannot be
scheduled effectively

nginx 250mb + frontend 3000mb = 3250mb which can be scheduled on our
boxes effectively

Ingress cluster table:

```
tasks running | cpu avail | mem avail
-------------------------------------
3             | 2048      | 3321
2             | 2048      | 71
2             | 2048      | 71
2             | 2048      | 3571
3             | 2048      | 3321
2             | 2048      | 3571
```

This should have no negative performance impact compared to old hub,
given our perf test was fine with 1 instance, we now have 3