### PR TITLE
AUTO-229: Update SSM to send logs to S3 bucket

### DIFF
--- a/terraform/modules/account/data.tf
+++ b/terraform/modules/account/data.tf
@@ -1,0 +1,22 @@
+data "aws_caller_identity" "account" {}
+
+data "aws_instances" "instances" {
+  instance_tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+data "aws_instance" "instance" {
+  count       = "${length(data.aws_instances.instances.ids)}"
+  instance_id = "${data.aws_instances.instances.ids[count.index]}"
+}
+
+data "aws_iam_instance_profile" "instance_profile" {
+  count = "${data.aws_instance.instance.count}"
+  name  = "${data.aws_instance.instance.*.iam_instance_profile[count.index]}"
+}
+
+data "aws_iam_role" "instance_role" {
+  count = "${data.aws_iam_instance_profile.instance_profile.count}"
+  name  = "${data.aws_iam_instance_profile.instance_profile.*.role_name[count.index]}"
+}

--- a/terraform/modules/account/ssm.tf
+++ b/terraform/modules/account/ssm.tf
@@ -1,0 +1,104 @@
+resource "aws_s3_bucket" "ssm_session_logs_store" {
+  bucket = "${var.deployment}-ssm-session-logs-store"
+  acl    = "private"
+  region = "eu-west-2"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ssm_session_logs_store" {
+  statement {
+    sid    = "ReadAndWriteToSSMSessionLogsStoreBucket"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${data.aws_iam_role.instance_role.*.arn}",
+      ]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.ssm_session_logs_store.arn}",
+      "${aws_s3_bucket.ssm_session_logs_store.arn}/*",
+    ]
+  }
+
+  statement {
+    sid    = "ExplicitDeny"
+    effect = "Deny"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "*",
+      ]
+    }
+
+    actions = [
+      "s3:Delete*",
+      "s3:PutBucketPolicy",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:PutAnalyticsConfiguration",
+      "s3:PutBucketAcl",
+      "s3:PutBucketCORS",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketRequestPayment",
+      "s3:PutBucketVersioning",
+      "s3:PutBucketWebsite",
+      "s3:PutEncryptionConfiguration",
+      "s3:PutInventoryConfiguration",
+      "s3:PutReplicationConfiguration",
+      "s3:ReplicateDelete",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.ssm_session_logs_store.arn}",
+      "${aws_s3_bucket.ssm_session_logs_store.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "ssm_session_logs_store" {
+  bucket = "${aws_s3_bucket.ssm_session_logs_store.bucket}"
+  policy = "${data.aws_iam_policy_document.ssm_session_logs_store.json}"
+}
+
+resource "aws_ssm_document" "ssm_log" {
+  name            = "SSM-SessionManagerRunShell"
+  document_type   = "Session"
+  document_format = "JSON"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+      "s3BucketName": "${aws_s3_bucket.ssm_session_logs_store.bucket}",
+      "s3KeyPrefix": "",
+      "s3EncryptionEnabled": false,
+      "cloudWatchLogGroupName": "",
+      "cloudWatchEncryptionEnabled": false
+    }
+  }
+DOC
+}

--- a/terraform/modules/account/ssm.tf
+++ b/terraform/modules/account/ssm.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "ssm_session_logs_store" {
-  bucket = "${var.deployment}-ssm-session-logs-store"
+  bucket = "gds-${var.deployment}-ssm-session-logs-store"
   acl    = "private"
   region = "eu-west-2"
 


### PR DESCRIPTION
This commit creates a new private S3 bucket with its native server side encryption enabled and its versioning is enabled. It has a bucket policy which allows instances to write session log files to the bucket and denies everyone from deleting the files from the bucket. It also updates AWS Systems Manager to start sending session log files to the bucket.

Co-authored-by: Athanasios Voutsadakis <athanasios.voutsadakis@digital.cabinet-office.gov.uk>