### PR TITLE
speed up deploys with less http memory

### DIFF
--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -107,7 +107,7 @@ data "template_file" "static_ingress_http_task_def" {
     backend          = "${var.signin_domain}"
     bind_port        = 80
     backend_port     = 80
-    allocated_memory = 500
+    allocated_memory = 250
   }
 }
 


### PR DESCRIPTION
This reduces the size of the memory for http static ingress which only
serves 301s.

This is a little tweak to make it fit under the 321mb remaining on each
box during a roll which should speed things up a bit