### PR TITLE
AUTO-245: Fix analytics lb healthcheck's protocol

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -95,6 +95,7 @@ resource "aws_lb_target_group" "ingress_analytics" {
 
   health_check {
     path     = "/healthcheck"
+    protocol = "HTTPS"
     interval = 10
     timeout  = 5
   }


### PR DESCRIPTION
The healthcheck is using the wrong protocol (HTTP) and is getting responses (400 = Bad Request error). This commit updates the protocol to use HTTPS since nginx is using HTTPS.

Author: @adityapahuja