### PR TITLE
implement alerts in prometheus

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -1,0 +1,31 @@
+---
+groups:
+- name: prometheus_base
+  rules:
+  - alert: Watchdog
+    annotations:
+      message: |
+        This is an alert meant to ensure that the entire alerting pipeline is functional.
+        This alert is always firing, therefore it should always be firing in Alertmanager
+        and always fire against a receiver.  We use cronitor to alert us if this ever
+        *doesn't* fire, because this indicates a problem with our alerting pipeline
+    expr: vector(1)
+    labels:
+      severity: "constant"
+- name: service
+  rules:
+  - alert: HubSamlProxyErrorsReceivingRequest
+    annotations:
+      message: |
+        It looks like users are having trouble starting sessions at
+        the hub.  We expect that the saml-proxy handleRequestPost
+        endpoint should return a 2xx response under normal conditions.
+        We are observing the rate of 2xx responses has dropped below
+        95%.
+    expr: |
+      sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[1m]))
+      / sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[1m]))
+      < 0.95
+

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -1,6 +1,8 @@
 global:
   scrape_interval:     15s
   evaluation_interval: 15s
+rule_files:
+  - "alerts.yml"
 scrape_configs:
   - job_name: prometheus
     ec2_sd_configs:

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -19,6 +19,10 @@
     ],
     "environment": [
       {
+        "Name": "ALERTS_BASE64",
+        "Value": "${alerts_base64}"
+      },
+      {
         "Name": "CONFIG_BASE64",
         "Value": "${config_base64}"
       }
@@ -26,7 +30,7 @@
     "entryPoint": [
       "sh",
       "-c",
-      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=60d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
+      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; echo $ALERTS_BASE64 | base64 -d > /etc/prometheus/alerts.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=60d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
     ]
   }
 ]

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -315,14 +315,14 @@ data "template_file" "prometheus_cloud_init" {
   template = "${file("${path.module}/files/cloud-init/prometheus.sh")}"
 
   vars {
-    prometheus_config              = "${data.template_file.prometheus_config.rendered}"
-    deployment                     = "${var.deployment}"
-    domain                         = "${local.root_domain}"
-    logit_elasticsearch_url        = "${var.logit_elasticsearch_url}"
-    logit_api_key                  = "${var.logit_api_key}"
-    cluster                        = "${aws_ecs_cluster.prometheus.name}"
-    ecs_agent_image_identifier     = "${local.ecs_agent_image_identifier}"
-    tools_account_id               = "${var.tools_account_id}"
+    prometheus_config          = "${data.template_file.prometheus_config.rendered}"
+    deployment                 = "${var.deployment}"
+    domain                     = "${local.root_domain}"
+    logit_elasticsearch_url    = "${var.logit_elasticsearch_url}"
+    logit_api_key              = "${var.logit_api_key}"
+    cluster                    = "${aws_ecs_cluster.prometheus.name}"
+    ecs_agent_image_identifier = "${local.ecs_agent_image_identifier}"
+    tools_account_id           = "${var.tools_account_id}"
   }
 }
 
@@ -434,6 +434,7 @@ data "template_file" "prometheus_task_def" {
   vars {
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-prometheus@${var.prometheus_image_digest}"
     config_base64    = "${base64encode(data.template_file.prometheus_config.rendered)}"
+    alerts_base64    = "${base64encode(file("${path.module}/files/prometheus/alerts.yml"))}"
   }
 }
 


### PR DESCRIPTION
This creates an alerts.yml file which defines alerts for prometheus to
fire.  It sets up just 2 alerts for the moment: Watchdog, which will
go to cronitor, and HubSamlProxyErrorsReceivingRequest, which is one
of our page-type alerts.

Currently, they don't go anywhere, but future work will connect
prometheus to an alertmanager.

They use the same base64-encoded environment variable trick as the
main prometheus.yml file.