### PR TITLE
Send alerts to observe's alertmanager

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -4,6 +4,14 @@ global:
   external_labels:
     product: verify
     deployment: ${deployment}
+alerting:
+  alertmanagers:
+  - scheme: https
+    static_configs:
+    - targets:
+      - 'alerts-1.monitoring.gds-reliability.engineering'
+      - 'alerts-2.monitoring.gds-reliability.engineering'
+      - 'alerts-3.monitoring.gds-reliability.engineering'
 rule_files:
   - "alerts.yml"
 scrape_configs:

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -1,6 +1,9 @@
 global:
   scrape_interval:     15s
   evaluation_interval: 15s
+  external_labels:
+    product: verify
+    deployment: ${deployment}
 rule_files:
   - "alerts.yml"
 scrape_configs:


### PR DESCRIPTION
This is possible since alphagov/prometheus-aws-configuration-beta#272 and won't cause alert noise because of alphagov/prometheus-aws-configuration-beta#273

We use external labels to label all of our alerts. External labels are a
feature of prometheus where extra labels are added whenever prometheus
interacts with an external system.  In particular, when alerts are
generated, they will be given these external labels so that
alertmanager can tell where the alerts came from (and, if desired,
route production alerts differently from joint alerts)