### PR TITLE
Change title of metadata expiry tile

### DIFF
--- a/dashboards/Hub-ECS.json
+++ b/dashboards/Hub-ECS.json
@@ -142,7 +142,7 @@
       "nullText": null,
       "postfix": "",
       "postfixFontSize": "50%",
-      "prefix": "in",
+      "prefix": "",
       "prefixFontSize": "50%",
       "rangeMaps": [
         {
@@ -169,7 +169,7 @@
         }
       ],
       "thresholds": "432000,604800",
-      "title": "Metadata expires",
+      "title": "Metadata expires in",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [],


### PR DESCRIPTION
otherwise we don't see when the metadata expiry unit

before
![screen shot 2019-02-27 at 09 33 37](https://user-images.githubusercontent.com/1482692/53480279-c9553c80-3a72-11e9-83cb-c9161505a81d.png)

after
![screen shot 2019-02-27 at 09 33 31](https://user-images.githubusercontent.com/1482692/53480287-cd815a00-3a72-11e9-96b4-36d492cce99a.png)
