### PR TITLE
set prometheus web.external-url flag

### DIFF
--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -30,7 +30,7 @@
     "entryPoint": [
       "sh",
       "-c",
-      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; echo $ALERTS_BASE64 | base64 -d > /etc/prometheus/alerts.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=60d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
+      "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; echo $ALERTS_BASE64 | base64 -d > /etc/prometheus/alerts.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=60d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles --web.external-url=${external_url}"
     ]
   }
 ]


### PR DESCRIPTION
This sets the prometheus --web.external-url flag, so that when we
raise alerts to alertmanager (and on to pagerduty and slack), the
alerts have metadata and links that link back to the original
prometheus that raised them.

This is troublesome because we need to specify the external URL
differently for different prometheus instances, which means they need
different container definitions, which means they need different task
definitions, which means we need separate ECS services for each
prometheus.

To make as few changes as possible, I still run the services as DAEMON
services, but I put placement constraints on the task definitions so
that each task (and hence each service) is pinned to a specific AZ.