### PR TITLE
rename Watchdog to AlwaysAlert

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -2,7 +2,7 @@
 groups:
 - name: prometheus_base
   rules:
-  - alert: Watchdog
+  - alert: AlwaysAlert
     annotations:
       message: |
         This is an alert meant to ensure that the entire alerting pipeline is functional.


### PR DESCRIPTION
Ronseal naming for the win

also consistency with
https://github.com/alphagov/prometheus-aws-configuration-beta/pull/278