### PR TITLE
AUTO-240: Fix analytics nginx

### DIFF
--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -5,6 +5,10 @@ location_blocks="${LOCATION_BLOCKS:?LOCATION_BLOCKS not set}"
 location_blocks="$(echo "$location_blocks" | base64 -d)"
 export location_blocks
 
+log_format="${LOG_FORMAT:-I2xvZ19mb3JtYXQgaXMgbm90IGRlZmluZWQK}"
+log_format="$(echo "$log_format" | base64 -d)"
+export log_format
+
 resolver="${RESOLVER:-10.0.0.2}"
 export resolver
 

--- a/dockerfiles/nginx-tls/nginx.conf.tpl
+++ b/dockerfiles/nginx-tls/nginx.conf.tpl
@@ -17,6 +17,8 @@ http {
 
   resolver     "$resolver";
 
+  $log_format
+
   server {
     listen       8443 ssl;
     ssl_protocols       TLSv1.1 TLSv1.2;

--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -14,6 +14,7 @@ locals {
 
   set $analytics "${var.analytics_endpoint}";
   location /analytics {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass $analytics/matomo.php?$args;
   }
 


### PR DESCRIPTION
This commit updates analytics nginx to forward http_x_forwarded_for to matomo so that matomo can use it to identify visitor's location and to filter out unwanted matomo requests.
This commit adds an optional field called log_format which allows nginx to specify log format. If log_format is not defined, nginx config file will have the following comment '#log_format is not defined' and will use nginx's default log format.

Author: @adityapahuja