### PR TITLE
add another P1 alert

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -79,4 +79,14 @@ groups:
       / sum without(instance)(
           rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[1m]))
       < 0.95
-
+  - alert: EveryMsaIsUnhealthy
+    labels:
+      severity: "p1"
+    annotations:
+      message: |
+        We run regular MSA healthchecks.  It looks like every single
+        MSA is unhealthy.  This will mean that users are unable to
+        complete journeys at the hub and probably indicates a problem
+        with the hub rather than with any corresponding MSA.
+    expr: |
+      sum(verify_saml_soap_proxy_msa_health_status) < 1


### PR DESCRIPTION
We have a P1 alert in grafana for if every single MSA is unhealthy.

This ports the alert over to Prometheus.