### PR TITLE
AUTO-240: Update nginx to choose log format for access log

### DIFF
--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -5,7 +5,7 @@ location_blocks="${LOCATION_BLOCKS:?LOCATION_BLOCKS not set}"
 location_blocks="$(echo "$location_blocks" | base64 -d)"
 export location_blocks
 
-log_format="${LOG_FORMAT:-I2xvZ19mb3JtYXQgaXMgbm90IGRlZmluZWQK}"
+log_format="${LOG_FORMAT:-YWNjZXNzX2xvZyAgIC90bXAvc3Rkb3V0Ow==}"
 log_format="$(echo "$log_format" | base64 -d)"
 export log_format
 

--- a/dockerfiles/nginx-tls/nginx.conf.tpl
+++ b/dockerfiles/nginx-tls/nginx.conf.tpl
@@ -7,7 +7,6 @@ events {
 }
 
 http {
-  access_log   /tmp/stdout;
   sendfile     on;
   tcp_nopush   on;
   server_names_hash_bucket_size 128;


### PR DESCRIPTION
Update log_format to use the default value `access_log /tmp/stdout;` which means that the nginx will use its default log format. If log_format is defined then nginx will write its output to the access log in its defined log format.

Author: @adityapahuja