### PR TITLE
HAProxy TLS termination

### DIFF
--- a/dockerfiles/haproxy-static-ingress-tls/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-tls/Dockerfile
@@ -1,0 +1,15 @@
+FROM haproxy:1.9.4-alpine
+
+EXPOSE 4500
+
+RUN addgroup -S haproxy && \
+    adduser  -S -G haproxy haproxy && \
+    apk add --no-cache gettext openssl ca-certificates
+
+WORKDIR /tmp
+
+USER haproxy
+
+COPY . /tmp
+
+ENTRYPOINT ["/tmp/docker-entrypoint.sh"]

--- a/dockerfiles/haproxy-static-ingress-tls/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress-tls/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env ash
+set -ueo pipefail
+
+: "${BACKEND:?BACKEND not set}"
+: "${BACKEND_PORT:?BACKEND_PORT not set}"
+: "${BIND_PORT:?BIND_PORT not set}"
+: "${RESOLVER:?RESOLVER not set}"
+
+envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl
+
+mkdir -p /tmp/tls
+
+openssl req -x509 \
+            -nodes \
+            -newkey rsa:2048 \
+            -keyout /tmp/tls/key.pem \
+            -out    /tmp/tls/cert.pem \
+            -days   365 \
+            -subj "/C=GB/O=GDS"
+
+cat /tmp/tls/key.pem /tmp/tls/cert.pem > /tmp/tls/chain.pem
+
+echo /tmp/tls/chain.pem
+
+haproxy -f /tmp/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
@@ -35,5 +35,5 @@ backend alb
     balance roundrobin
     option forwardfor
     http-request add-header x-client-ip %[src]
-    http-request add-header ida-forward-for %[src]
+    http-request add-header hub-forwarded-for %[src]
     server alb $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 100 fastinter 100

--- a/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
@@ -1,0 +1,39 @@
+global
+    ca-base /etc/ssl/certs
+    maxconn 10000
+    log stdout local0 info
+    user haproxy
+    group haproxy
+
+defaults
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+    log global
+    option httplog
+    maxconn 10000
+
+resolvers vpcdns
+    nameserver vpc ${RESOLVER}
+    resolve_retries 3
+    timeout resolve 1s
+    timeout retry   1s
+    hold valid 1s
+    hold timeout 0s
+    hold nx 0s
+    hold other 0s
+    hold refused 0s
+    hold obsolete 0s
+
+frontend nlb
+    mode http
+    bind *:$BIND_PORT ssl crt /tmp/tls/chain.pem
+    default_backend alb
+
+backend alb
+    mode http
+    balance roundrobin
+    option forwardfor
+    http-request add-header x-client-ip %[src]
+    http-request add-header ida-forward-for %[src]
+    server alb $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 100 fastinter 100

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -129,7 +129,7 @@ module "static_ingress_ecs_roles" {
   deployment       = "${var.deployment}"
   tools_account_id = "${var.tools_account_id}"
   service_name     = "static-ingress"
-  image_name       = "verify-static-ingress"
+  image_name       = "verify-static-ingress*"
 }
 
 resource "aws_ecs_task_definition" "static_ingress_http" {

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -115,7 +115,7 @@ data "template_file" "static_ingress_https_task_def" {
   template = "${file("${path.module}/files/tasks/static-ingress.json")}"
 
   vars {
-    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress@${var.static_ingress_image_digest}"
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress-tls@${var.static_ingress_tls_image_digest}"
     backend          = "${var.signin_domain}"
     bind_port        = 443
     backend_port     = 443
@@ -213,7 +213,7 @@ resource "aws_lb_target_group" "static_ingress_http" {
 resource "aws_lb_target_group" "static_ingress_https" {
   name                 = "${var.deployment}-static-ingress-https"
   port                 = 443
-  protocol             = "TCP"
+  protocol             = "TLS"
   vpc_id               = "${aws_vpc.hub.id}"
   deregistration_delay = 30
 }
@@ -233,6 +233,7 @@ resource "aws_lb_listener" "static_ingress_https" {
   load_balancer_arn = "${aws_lb.static_ingress.arn}"
   protocol          = "TCP"
   port              = 443
+  certificate_arn   = "${local.wildcard_cert_arn}"
 
   default_action {
     type             = "forward"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -129,6 +129,7 @@ module "static_ingress_ecs_roles" {
   deployment       = "${var.deployment}"
   tools_account_id = "${var.tools_account_id}"
   service_name     = "static-ingress"
+  # This is used in an IAM Policy document, so wildcards are ok
   image_name       = "verify-static-ingress*"
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -77,6 +77,7 @@ variable "hub_metadata_image_digest" {}
 variable "ecs_agent_image_digest" {}
 variable "nginx_image_digest" {}
 variable "static_ingress_image_digest" {}
+variable "static_ingress_tls_image_digest" {}
 variable "beat_exporter_image_digest" {}
 variable "cloudwatch_exporter_image_digest" {}
 variable "squid_image_digest" {}


### PR DESCRIPTION
Context
-------

We need to present the user's source IP to frontend and analytics in order for the billing and audit system, as well as the analytics system.

HAProxy currently proxies the TCP connection it receives from the NLB to the ALB (in order for us to have managed static IP at ingress). However this means the source IP is the IP of HAproxy and not the user.

What
----

- New Docker image static-ingress-tls which is HAProxy but does TLS and HTTP (we still use the other one for forwarding to the ALB for 301s).

- Use the new static-ingress-tls image for HTTPS ingress

- Configure the NLB to treat static-ingress-https target group as a TLS upstream (rather than TCP)

- Configure the NLB to terminate TLS on port 443

How to review
------------

- Code review