### PR TITLE
Use `var.wildcard_cert_arn` everywhere

### DIFF
--- a/terraform/modules/hub/data.tf
+++ b/terraform/modules/hub/data.tf
@@ -15,7 +15,6 @@ data "aws_caller_identity" "account" {}
 data "aws_region" "region" {}
 
 locals {
-  wildcard_cert_arn              = "${var.wildcard_cert_arn}"
   egress_proxy_url               = "egress-proxy.${local.root_domain}:8080"
   egress_proxy_url_with_protocol = "http://${local.egress_proxy_url}"
 }

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -88,5 +88,5 @@ module "config" {
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-config"
   instance_security_group_id = "${module.config_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  certificate_arn            = "${var.wildcard_cert_arn}"
 }

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -92,7 +92,7 @@ module "policy" {
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-policy"
   instance_security_group_id = "${module.policy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  certificate_arn            = "${var.wildcard_cert_arn}"
 }
 
 resource "aws_iam_policy" "policy_parameter_execution" {

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -70,7 +70,7 @@ module "saml_engine" {
   tools_account_id           = "${var.tools_account_id}"
   image_name                 = "verify-saml-engine"
   instance_security_group_id = "${module.saml_engine_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  certificate_arn            = "${var.wildcard_cert_arn}"
 }
 
 module "saml_engine_can_connect_to_config" {

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -86,7 +86,7 @@ module "saml_proxy" {
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  certificate_arn            = "${var.wildcard_cert_arn}"
   image_name                 = "verify-saml-proxy"
 }
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -86,7 +86,7 @@ module "saml_soap_proxy" {
   health_check_path          = "/service-status"
   tools_account_id           = "${var.tools_account_id}"
   instance_security_group_id = "${module.saml_soap_proxy_ecs_asg.instance_sg_id}"
-  certificate_arn            = "${local.wildcard_cert_arn}"
+  certificate_arn            = "${var.wildcard_cert_arn}"
   image_name                 = "verify-saml-soap-proxy"
 }
 

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -169,7 +169,7 @@ resource "aws_lb_listener" "ingress_https" {
   load_balancer_arn = "${aws_lb.ingress.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = "${local.wildcard_cert_arn}"
+  certificate_arn   = "${var.wildcard_cert_arn}"
 
   default_action {
     type             = "forward"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -234,7 +234,7 @@ resource "aws_lb_listener" "static_ingress_https" {
   load_balancer_arn = "${aws_lb.static_ingress.arn}"
   protocol          = "TCP"
   port              = 443
-  certificate_arn   = "${local.wildcard_cert_arn}"
+  certificate_arn   = "${var.wildcard_cert_arn}"
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
- We had `local.wildcard_cert_arn` that had a value of
  `var.wildcard_cert_arn`. Simplify the code by using
  `var.wildcard_cert_arn` everywhere as the value of the `local` never
  seems to be different from it.
- This is a no-op change _in terms of what the value of the variable
  is_. Since the rebase on top of master after the HAProxy stuff, that
  needs deploying first before this is "No changes", but conceptually it
  works.