### PR TITLE
BAU: Update analytics nginx to not to add its ip address

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -14,7 +14,7 @@ locals {
 
   set $analytics "${var.analytics_endpoint}";
   location /analytics {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_pass $analytics/matomo.php?$args;
   }
 


### PR DESCRIPTION
This commit updates analytics nginx to not to add its ip address to http_x_forwarded_for. This will reduce the size of its log file and make it easier for Matomo log analytics to identify the source ip address.

Author: @adityapahuja