### PR TITLE
hide the /metrics endpoint

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -207,6 +207,27 @@ resource "aws_lb_listener_rule" "ingress_analytics" {
   }
 }
 
+resource "aws_lb_listener_rule" "ingress_metrics" {
+  listener_arn = "${aws_lb_listener.ingress_https.arn}"
+  priority     = 130
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "www.gov.uk"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/metrics*"]
+  }
+}
+
 resource "aws_route53_zone" "ingress_www" {
   name = "www.${local.root_domain}."
 


### PR DESCRIPTION
We're planning to instrument the frontend app with prometheus.  We
don't want to expose these metrics to the outside world.  As a simple
solution, this commit introduces a 301 redirect to www.gov.uk if you
try to access /metrics through the front door.