### PR TITLE
Use 15 minute `rate` alerting thresholds instead of 1 minute

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -26,9 +26,9 @@ groups:
         95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[15m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[15m]))
       < 0.95
   - alert: HubSamlProxyErrorsReceivingResponse
     labels:
@@ -42,9 +42,9 @@ groups:
         has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[15m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[15m]))
       < 0.95
   - alert: HubSamlProxyErrorsSendingRequest
     labels:
@@ -58,9 +58,9 @@ groups:
         rate of 2xx responses has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[15m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[15m]))
       < 0.95
   - alert: HubSamlProxyErrorsSendingResponse
     labels:
@@ -75,9 +75,9 @@ groups:
         of 2xx responses has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[15m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[1m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[15m]))
       < 0.95
   - alert: EveryMsaIsUnhealthy
     labels:


### PR DESCRIPTION
- Traffic will drop at night and we'll get constantly paged otherwise.