### PR TITLE
AUTO: Add redirect to GOV.UK when accessing /

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -177,6 +177,27 @@ resource "aws_lb_listener" "ingress_https" {
   }
 }
 
+resource "aws_lb_listener_rule" "ingress_root" {
+  listener_arn = "${aws_lb_listener.ingress_https.arn}"
+  priority     = 140
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "www.gov.uk"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/"]
+  }
+}
+
 resource "aws_lb_listener_rule" "ingress_metadata" {
   listener_arn = "${aws_lb_listener.ingress_https.arn}"
   priority     = 110


### PR DESCRIPTION
- We used to do this redirect as per the service manual
- The service manual has since updated to suggest that this is not
  needed anymore but we will have that discussion later
- Restore old behaviour

Co-authored-by: Matthew Cullum <matthew.cullum@digital.cabinet-office.gov.uk>