### PR TITLE
specify path on metrics redirect

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -238,6 +238,7 @@ resource "aws_lb_listener_rule" "ingress_metrics" {
     redirect {
       host        = "www.gov.uk"
       port        = "443"
+      path        = "/"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
     }


### PR DESCRIPTION
if we don't do this, it forwards to https://www.gov.uk/metrics which
is not what we want