### PR TITLE
AUTO: Forward requests to /sp metadata to frontend

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -177,6 +177,21 @@ resource "aws_lb_listener" "ingress_https" {
   }
 }
 
+resource "aws_lb_listener_rule" "ingress_metadata_sp" {
+  listener_arn = "${aws_lb_listener.ingress_https.arn}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.ingress_frontend.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/SAML2/metadata/sp"]
+  }
+}
+
 resource "aws_lb_listener_rule" "ingress_root" {
   listener_arn = "${aws_lb_listener.ingress_https.arn}"
   priority     = 140


### PR DESCRIPTION
- Frontend serves a version of metadata that some services use, we
  should forward requests for that metadata to frontend

Co-authored-by: Matthew Cullum <matthew.cullum@digital.cabinet-office.gov.uk>