### PR TITLE
AUTO-240: Reduce max_depth from 5 to 1 for decode JSON fields

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -102,7 +102,7 @@ processors:
 - decode_json_fields:
     fields: ["message"]
     process_array: false
-    max_depth: 5
+    max_depth: 1
     target: "log"
     overwrite_keys: false
 


### PR DESCRIPTION
Journalbeat parses a message field containing Event Emitter's non-JSON formatted message taken from SAML Proxy log file successfully. However, it fails to parse a message field containing Event Emitter's JSON formatted message taken from SAML Proxy Log file. This commit updates max_depth from 5 to 1 to prevent Journalbeat from trying to parse JSON formatted message inside the message field.

I have tested the change in Joint environment and it is working fine.

Author: @adityapahuja