### PR TITLE
Ensure logs do not fill up the disks

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -29,6 +29,21 @@ systemctl stop snap.amazon-ssm-agent.amazon-ssm-agent
 systemctl daemon-reload
 systemctl start snap.amazon-ssm-agent.amazon-ssm-agent
 
+# We want to make sure that the journal does not write to syslog
+# This would fill up the disk, with logs we already have in the journal
+echo "Ensure journal does not write to syslog"
+mkdir -p /etc/systemd/journald.conf.d/
+cat <<JOURNAL > /etc/systemd/journald.conf.d/override.conf
+[Journal]
+SystemMaxUse=2G
+RuntimeMaxUse=2G
+ForwardToSyslog=no
+ForwardToWall=no
+JOURNAL
+
+systemctl daemon-reload
+systemctl restart systemd-journald
+
 # Use Amazon NTP
 echo 'Installing and configuring chrony'
 apt-get install --yes chrony

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -92,8 +92,10 @@ journalbeat.inputs:
 - paths: []
   seek: cursor
 
+logging.level: warning
 logging.to_files: false
-logging.to_syslog: true
+logging.to_syslog: false
+logging.json: true
 
 processors:
 - add_cloud_metadata: ~

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -40,6 +40,10 @@ resource "aws_launch_configuration" "cluster" {
     "${aws_security_group.instance.id}",
   ]
 
+  root_block_device {
+    volume_size = 20
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -109,7 +109,8 @@ journalbeat.inputs:
 
 logging.level: warning
 logging.to_files: false
-logging.to_syslog: true
+logging.to_syslog: false
+logging.json: true
 
 processors:
 - add_cloud_metadata: ~

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -42,6 +42,21 @@ systemctl stop snap.amazon-ssm-agent.amazon-ssm-agent
 systemctl daemon-reload
 systemctl start snap.amazon-ssm-agent.amazon-ssm-agent
 
+# We want to make sure that the journal does not write to syslog
+# This would fill up the disk, with logs we already have in the journal
+echo "Ensure journal does not write to syslog"
+mkdir -p /etc/systemd/journald.conf.d/
+cat <<JOURNAL > /etc/systemd/journald.conf.d/override.conf
+[Journal]
+SystemMaxUse=2G
+RuntimeMaxUse=2G
+ForwardToSyslog=no
+ForwardToWall=no
+JOURNAL
+
+systemctl daemon-reload
+systemctl restart systemd-journald
+
 # Use Amazon NTP
 echo 'Installing and configuring chrony'
 apt-get install --yes chrony


### PR DESCRIPTION
What
----

- Stop duplicating log lines (669804f)
- Increase ecs_asg / disk to 20G (07f0bff)
- Log as json and not to syslog (fd838b4b7e27fdfc3e3ddf766a32be954f8aa0b6)

Why
---

So our disks do not fill up, then things will break

How to review
-------------

- Code review
- Log into `i-0fa8aa673f760530f` in staging and observe that syslog does not change in size and is not getting updated

---

Co-authored-by: Dean Wilson <dean.wilson@digital.cabinet-office.gov.uk> 
Co-authored-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>