### PR TITLE
Re-enable logs for journalbeat

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -94,7 +94,7 @@ journalbeat.inputs:
 
 logging.level: warning
 logging.to_files: false
-logging.to_syslog: false
+logging.to_syslog: true
 logging.json: true
 
 processors:

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -109,7 +109,7 @@ journalbeat.inputs:
 
 logging.level: warning
 logging.to_files: false
-logging.to_syslog: false
+logging.to_syslog: true
 logging.json: true
 
 processors:


### PR DESCRIPTION
If you set `to_syslog: false` you don't get logs

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>

Co-authored-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>
Co-authored-by: Athanasios Voutsadakis <athanasios.voutsadakis@digital.cabinet-office.gov.uk>
Co-authored-by: Dean Wilson <dean.wilson@digital.cabinet-office.gov.uk>