### PR TITLE
Add explicit prevent_destroy to aws_eip resources

### DIFF
--- a/terraform/modules/hub/eips.tf
+++ b/terraform/modules/hub/eips.tf
@@ -1,11 +1,19 @@
 resource "aws_eip" "ingress" {
   count = "${local.number_of_availability_zones}"
   vpc   = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_eip" "egress" {
   count = "${local.number_of_availability_zones}"
   vpc   = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 output "ingress_eip_public_ips" {


### PR DESCRIPTION
We have Deny on destroying EIPs in our IAM policies, however Concourse
does not.

If someone did a bad then Concourse might be able to destroy the EIPs,
our tests should catch this in joint but then cleanup would be a pain.

This commit adds the prevent_destroy annotation which will make
terraform reject any config which accidentally destroys this