### PR TITLE
Allow prometheus to scrape frontend

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -65,6 +65,13 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Cluster]
         replacement: $${1}_journalbeat
         target_label: job
+  - job_name: frontend
+    scheme: 'https'
+    tls_config:
+      insecure_skip_verify: true
+    dns_sd_configs:
+      - names:
+          - 'frontend.hub.local'
   - job_name: apps
     scheme: 'https'
     metrics_path: '/prometheus/metrics'

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -107,6 +107,11 @@ resource "aws_ecs_service" "frontend" {
       "${aws_security_group.can_connect_to_container_vpc_endpoint.id}",
     ]
   }
+
+  service_registries {
+    registry_arn = "${aws_service_discovery_service.frontend.arn}"
+    port         = 8443
+  }
 }
 
 module "frontend_can_connect_to_config" {

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -75,6 +75,15 @@ module "prometheus_can_talk_to_egress_proxy_beat_exporter" {
   port = 9479
 }
 
+module "prometheus_can_talk_to_frontend_task" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${module.frontend_task.instance_sg_id}"
+
+  port = 8443
+}
+
 module "prometheus_can_talk_to_policy" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/service_discovery.tf
+++ b/terraform/modules/hub/service_discovery.tf
@@ -1,0 +1,22 @@
+resource "aws_service_discovery_private_dns_namespace" "hub_apps" {
+  name        = "hub.local"
+  description = "Hub app instances"
+  vpc         = "${aws_vpc.hub.id}"
+}
+
+resource "aws_service_discovery_service" "frontend" {
+  name = "frontend"
+
+  description = "A service to allow Prometheus to discover frontend instances"
+
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.hub_apps.id}"
+
+    dns_records {
+      ttl  = 60
+      type = "SRV"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+}


### PR DESCRIPTION
This commit allows prometheus to scrape frontend metrics (which were
added in alphagov/verify-frontend#674).

This is a bit different from how we scrape the other apps.  Other apps
expose their ports as ports on the host, but frontend uses `awsvpc`
networking, which means that the frontend task gets its own Elastic
Network Interface (ENI), and so is accessed on a separate IP address
from the host itself.

This means that we can't use prometheus's ec2_sd_configs to find
frontend apps like we do for the dropwizard apps.  Instead, we use AWS
Service Discovery.  Service Discovery is a powerful set of tools but
the bits we care about are:

 - we create a private DNS zone for discovering hub apps. This is the
   aws_service_discovery_private_dns_namespace.
 - we create a "service" to represent the frontend instances.  This is
   the aws_service_discovery_service.  You can register instances into
   this service manually if you like, and they will appear in DNS. Howver:
 - we configure the frontend ECS service to automatically register
   tasks as instances of the service discovery service.

We use SRV records for this, which prometheus supports by default in
its `dns_sd_configs` configuration block.  This means that prometheus
can look at the SRV record at `frontend.hub.local` and get a list of
service instance records, which give a hostname and port in the form:
210a00f0-5c70-4a6e-87e9-db440c7dab51.frontend.hub.local:8443

Finally, we need to open the security groups so that prometheus has
permission to access frontend.

I've tested most of this by manually applying to joint, and verified
that the ECS service registers itself and prometheus can discover the
instances.  The one bit I haven't tested is the security group rule -
but I think this PR is good to merge and see if it works rather than
continuing to mess around outside the pipeline.