### PR TITLE
Allow prometheus to scrape frontend

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -65,6 +65,13 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Cluster]
         replacement: $${1}_journalbeat
         target_label: job
+  - job_name: frontend
+    scheme: 'https'
+    tls_config:
+      insecure_skip_verify: true
+    dns_sd_configs:
+      - names:
+          - 'frontend.hub.local'
   - job_name: apps
     scheme: 'https'
     metrics_path: '/prometheus/metrics'

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -110,7 +110,7 @@ resource "aws_ecs_service" "frontend" {
 }
 
 resource "aws_ecs_service" "frontend_v2" {
-  name            = "${var.deployment}-frontend"
+  name            = "${var.deployment}-frontend-v2"
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.frontend.arn}"
 

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -89,7 +89,7 @@ resource "aws_ecs_service" "frontend" {
   cluster         = "${aws_ecs_cluster.ingress.id}"
   task_definition = "${aws_ecs_task_definition.frontend.arn}"
 
-  desired_count                      = "${var.number_of_apps}"
+  desired_count                      = "${var.number_of_apps/2}"
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
 
@@ -106,6 +106,36 @@ resource "aws_ecs_service" "frontend" {
       "${aws_security_group.frontend_task.id}",
       "${aws_security_group.can_connect_to_container_vpc_endpoint.id}",
     ]
+  }
+}
+
+resource "aws_ecs_service" "frontend_v2" {
+  name            = "${var.deployment}-frontend"
+  cluster         = "${aws_ecs_cluster.ingress.id}"
+  task_definition = "${aws_ecs_task_definition.frontend.arn}"
+
+  desired_count                      = "${var.number_of_apps/2 + var.number_of_apps%2}"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.ingress_frontend.arn}"
+    container_name   = "nginx"
+    container_port   = "8443"
+  }
+
+  network_configuration {
+    subnets = ["${aws_subnet.internal.*.id}"]
+
+    security_groups = [
+      "${aws_security_group.frontend_task.id}",
+      "${aws_security_group.can_connect_to_container_vpc_endpoint.id}",
+    ]
+  }
+
+  service_registries {
+    registry_arn = "${aws_service_discovery_service.frontend.arn}"
+    port         = 8443
   }
 }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -75,6 +75,15 @@ module "prometheus_can_talk_to_egress_proxy_beat_exporter" {
   port = 9479
 }
 
+module "prometheus_can_talk_to_frontend_task" {
+  source = "modules/microservice_connection"
+
+  source_sg_id      = "${aws_security_group.prometheus.id}"
+  destination_sg_id = "${aws_security_group.frontend_task.id}"
+
+  port = 8443
+}
+
 module "prometheus_can_talk_to_policy" {
   source = "modules/microservice_connection"
 

--- a/terraform/modules/hub/service_discovery.tf
+++ b/terraform/modules/hub/service_discovery.tf
@@ -1,0 +1,26 @@
+resource "aws_service_discovery_private_dns_namespace" "hub_apps" {
+  name        = "hub.local"
+  description = "Hub app instances"
+  vpc         = "${aws_vpc.hub.id}"
+}
+
+resource "aws_service_discovery_service" "frontend" {
+  name = "frontend"
+
+  description = "A service to allow Prometheus to discover frontend instances"
+
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.hub_apps.id}"
+
+    dns_records {
+      ttl  = 60
+      type = "SRV"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 2
+  }
+}


### PR DESCRIPTION
This is the same as #179 (plus #180, ahem), but fixing a couple of
problems:

  1. #179 wasn't a zero-downtime deployment.  Adding
     service_registries to an ecs_service forces a new resource, and
     terraform wou destroy the old frontend service before creating
     the new one, with an intermediate period of downtime.
  2. #179 didn't specify a health check for service discovery, which
     caused ECS to not be able to check that tasks were coming up
     correctly and we saw tasks in the
     [weird undocumented ACTIVATING state][1]

This commit fixes problem 1 by explicitly creating a new frontend
ecs_service and allowing the two to coexist.  A followup PR will
delete the old one.  I split the number of tasks between the two
services.

This commit fixes problem 2 by... specifying a healthcheck.  We don't
have to do much, I think the mere presence of a
health_check_custom_config block causes AWS Service Discovery and ECS
to join up their health checking.

[1]: https://forums.aws.amazon.com/thread.jspa?threadID=283572

Original commit message below, for reference:

----

This commit allows prometheus to scrape frontend metrics (which were
added in alphagov/verify-frontend#674).

This is a bit different from how we scrape the other apps.  Other apps
expose their ports as ports on the host, but frontend uses `awsvpc`
networking, which means that the frontend task gets its own Elastic
Network Interface (ENI), and so is accessed on a separate IP address
from the host itself.

This means that we can't use prometheus's ec2_sd_configs to find
frontend apps like we do for the dropwizard apps.  Instead, we use AWS
Service Discovery.  Service Discovery is a powerful set of tools but
the bits we care about are:

 - we create a private DNS zone for discovering hub apps. This is the
   aws_service_discovery_private_dns_namespace.
 - we create a "service" to represent the frontend instances.  This is
   the aws_service_discovery_service.  You can register instances into
   this service manually if you like, and they will appear in DNS. Howver:
 - we configure the frontend ECS service to automatically register
   tasks as instances of the service discovery service.

We use SRV records for this, which prometheus supports by default in
its `dns_sd_configs` configuration block.  This means that prometheus
can look at the SRV record at `frontend.hub.local` and get a list of
service instance records, which give a hostname and port in the form:
210a00f0-5c70-4a6e-87e9-db440c7dab51.frontend.hub.local:8443

Finally, we need to open the security groups so that prometheus has
permission to access frontend.

I've tested most of this by manually applying to joint, and verified
that the ECS service registers itself and prometheus can discover the
instances.  The one bit I haven't tested is the security group rule -
but I think this PR is good to merge and see if it works rather than
continuing to mess around outside the pipeline.