### PR TITLE
Prevent Rails from trying to upgrade to https

### DIFF
--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -44,6 +44,7 @@ locals {
   location / {
     proxy_pass http://localhost:8080;
     proxy_set_header Host ${var.signin_domain};
+    proxy_set_header X-Forwarded-Proto https;
   }
   LOCATIONS
 


### PR DESCRIPTION
Rails's config.force_ssl feature will cause it to 301 redirect you to
an https:// URL.

This prevents Prometheus from trying to scrape verify-frontend.  This
is because:

 - prometheus hits nginx
 - nginx hits rails
 - nothing adds the X-Forwarded-Proto header, so rails thinks that
   it's an http request
 - rails returns a 301 to https://localhost:8080/metrics
 - nginx rewrites this as a 301 to
   https://www.signin.service.gov.uk/metrics
 - prometheus tries to hit that URL, gets *another* redirect to
   https://www.gov.uk
 - everyone is sad

I don't want to disable config.force_ssl, because that also gives us
secure cookies and Strict-Transport-Security.

I don't see any downside to forcing X-Forwarded-Proto to https here,
because requests that come in from the public internet must be on
https.  The ALB handles the http->https upgrade for us.