### PR TITLE
Healthcheck a real frontend page

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -128,11 +128,11 @@ resource "aws_lb_target_group" "ingress_frontend" {
   slow_start           = 30
 
   health_check {
-    path     = "/"
+    path     = "/cookies"
     protocol = "HTTPS"
     interval = 10
     timeout  = 5
-    matcher  = "200,301"
+    matcher  = "200"
   }
 }
 


### PR DESCRIPTION
After #183 was deployed, frontend healthchecks stopped working.  This
is because:

 - We were healthchecking `/`
 - Rails formerly gave a 301 to an https URL
 - We accepted 301 as a healthy response
 - Then #183 was deployed
 - Now, a `GET /` returns a 404 (this is correct behaviour, there's
   nothing there)
 - So the load balancer thinks the task is unhealthy
 - So it kills it and starts another

The fix is to healthcheck an actual real URL.  I picked the cookies
page, because you don't need a session to see it.