### PR TITLE
Fix the Terraform 0.11.13 download SHA

### DIFF
--- a/dockerfiles/aws-terraform/Dockerfile
+++ b/dockerfiles/aws-terraform/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update  --yes && \
 WORKDIR /tmp
 
 RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip > terraform.zip && \
-    echo '94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c  terraform.zip'  > terraform.sha && \
+    echo '5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2  terraform.zip'  > terraform.sha && \
     sha256sum -c terraform.sha && unzip terraform.zip && mv terraform /usr/bin/terraform                    && \
     rm terraform.zip && rm terraform.sha
 


### PR DESCRIPTION
This should match the new ZIP file downloaded for the new version.

```
$ curl https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip > terraform.zip
$ gsha256sum terraform.zip
5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2  terraform.zip
$ echo '5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2  terraform.zip' > terraform.sha && gsha256sum -c terraform.sha
terraform.zip: OK
```