### PR TITLE
Go back to old behaviour for SAML proxy metric alerts

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -14,31 +14,71 @@ groups:
       severity: "constant"
 - name: service
   rules:
-  - alert: HubSamlProxyNonEidasErrorRate
+  - alert: HubSamlProxyErrorsReceivingRequest
     labels:
       severity: "p1"
     annotations:
       message: |
-        It looks like users are having trouble with SAML interactions
-        in their journeys at the hub.  This means that they will be
-        unable to complete their journeys.  We expect that the
-        saml-proxy endpoints should return a 2xx response under normal
-        conditions.  We are observing the rate of 2xx responses has
-        dropped below 95%.
+        It looks like users are having trouble starting sessions at
+        the hub.  We expect that the saml-proxy handleRequestPost
+        endpoint should return a 2xx response under normal conditions.
+        We are observing the rate of 2xx responses has dropped below
+        95%.
     expr: |
       sum without(instance)(
-            rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[15m]))
       / sum without(instance)(
-            rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[15m])
-          + rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[15m]))
-
-          < 0.95
-
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[15m]))
+      < 0.95
+  - alert: HubSamlProxyErrorsReceivingResponse
+    labels:
+      severity: "p1"
+    annotations:
+      message: |
+        It looks like users are having trouble returning to the hub
+        having verified at an IDP.  We expect that the saml-proxy
+        handleResponsePost endpoint should return a 2xx response under
+        normal conditions.  We are observing the rate of 2xx responses
+        has dropped below 95%.
+    expr: |
+      sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[15m]))
+      / sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[15m]))
+      < 0.95
+  - alert: HubSamlProxyErrorsSendingRequest
+    labels:
+      severity: "p1"
+    annotations:
+      message: |
+        It looks like users are hitting errors when we try to redirect
+        users to an IDP that they have chosen.  We expect that the
+        saml-proxy sendJsonAuthnRequestFromHub endpoint should return
+        a 2xx response under normal conditions.  We are observing the
+        rate of 2xx responses has dropped below 95%.
+    expr: |
+      sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[15m]))
+      / sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[15m]))
+      < 0.95
+  - alert: HubSamlProxyErrorsSendingResponse
+    labels:
+      severity: "p1"
+    annotations:
+      message: |
+        It looks like users are hitting errors when we try to finish
+        their journey and redirect them back to the service they want
+        to use.  We expect that the saml-proxy
+        sendJsonAuthResponseFromHub endpoint should return a 2xx
+        response under normal conditions.  We are observing the rate
+        of 2xx responses has dropped below 95%.
+    expr: |
+      sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[15m]))
+      / sum without(instance)(
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[15m]))
+      < 0.95
   - alert: EveryMsaIsUnhealthy
     labels:
       severity: "p1"

--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -26,10 +26,11 @@ groups:
         95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_2xx_responses_total[1m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleRequestPost_count[1m]))
       < 0.95
+    for: 15m
   - alert: HubSamlProxyErrorsReceivingResponse
     labels:
       severity: "p1"
@@ -42,10 +43,11 @@ groups:
         has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_2xx_responses_total[1m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[1m]))
       < 0.95
+    for: 15m
   - alert: HubSamlProxyErrorsSendingRequest
     labels:
       severity: "p1"
@@ -58,10 +60,11 @@ groups:
         rate of 2xx responses has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_2xx_responses_total[1m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[1m]))
       < 0.95
+    for: 15m
   - alert: HubSamlProxyErrorsSendingResponse
     labels:
       severity: "p1"
@@ -75,10 +78,11 @@ groups:
         of 2xx responses has dropped below 95%.
     expr: |
       sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_2xx_responses_total[1m]))
       / sum without(instance)(
-          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[15m]))
+          rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnResponseFromHub_count[1m]))
       < 0.95
+    for: 15m
   - alert: EveryMsaIsUnhealthy
     labels:
       severity: "p1"


### PR DESCRIPTION
Use 1m window and `for: 15m` in hub saml alerts

We want to be alerted if in the last 15 minutes if our reliability is <
95%

Andy and I went through the old behaviour with phil and phil applied
prometheus brain to the problem. There is probably a better
behaviour/config which requires discussion with verify