### PR TITLE
use `puma` to start puma, not `rails server`

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -31,12 +31,11 @@
       }
     ],
     "entryPoint": [
-      "rails",
-      "server",
+      "puma",
       "-p",
       "8080",
       "-b",
-      "0.0.0.0"
+      "tcp://0.0.0.0"
     ],
     "secrets": [
       {


### PR DESCRIPTION
This is the recommended way to start puma.

We suspect that this is why the DirectFileStore thing hasn't been
working.

Co-authored-by: Toby_lornewelch-richards <toby.lornewelch-richards@digital.cabinet-office.gov.uk>