### PR TITLE
Use bundle exec for frontend tasks

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -31,6 +31,8 @@
       }
     ],
     "entryPoint": [
+      "bundle",
+      "exec",
       "puma",
       "-p",
       "8080",


### PR DESCRIPTION
With bundler 2.0 puma will not start without prepending bundle exec

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>

Co-authored-by: Toby <toby.lornewelch-richards@digital.cabinet-office.gov.uk>
Co-authored-by: Jakub <jakub.miarka@digital.cabinet-office.gov.uk>
Co-authored-by: Phil <philip.miller@digital.cabinet-office.gov.uk>