### PR TITLE
Tighten up vpc endpoint

### DIFF
--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -34,7 +34,8 @@ resource "aws_vpc_endpoint" "s3" {
             "Resource": [
                 "arn:aws:s3:::prod-eu-west-2-starport-layer-bucket",
                 "arn:aws:s3:::prod-eu-west-2-starport-layer-bucket/*",
-                "*"
+                "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store",
+                "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store/*"
             ]
         }
     ]


### PR DESCRIPTION
We only need s3 endpoint for starport (ECR) and SSM logs