### PR TITLE
Port grafana ticket alerts to prometheus

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -94,3 +94,76 @@ groups:
         with the hub rather than with any corresponding MSA.
     expr: |
       sum(verify_saml_soap_proxy_msa_health_status) < 1
+- name: infra
+  rules:
+  - alert: TargetDown
+    labels: &infraticket
+      layer: infra
+      severity: ticket
+    annotations:
+      message: |
+        A prometheus scrape target is down.
+    expr: |
+      up == 0
+    for: 15m
+  - alert: JournalbeatDown
+    labels: *infraticket
+    annotations:
+      message: |
+        beat-exporter couldn't find a running journalbeat.
+    expr: |
+      journalbeat_up == 0
+    for: 15m
+  - alert: RebootRequired
+    labels: *infraticket
+    annotations:
+      message: |
+        An instance has installed an upgrade which requires a reboot to take effect.
+    expr: |
+      node_reboot_required == 1
+  - alert: NtpOffsetTooGreat
+    labels: *infraticket
+    annotations:
+      message: |
+        The system time is more than a second out of sync with the ntp reference server
+    expr: |
+      abs(node_ntp_offset_seconds) >= 1
+    for: 5m
+  - alert: DiskPredictedToFill
+    labels: *infraticket
+    annotations:
+      message: |
+        The instance's disk is predicted to fill within 3 days.
+    expr: |
+      predict_linear(
+        node_filesystem_avail{
+          fstype!~"squashfs|fuse[.]lxcfs"
+        }[24h],
+        3 * 86400) <= 0
+      and on (instance) (time() - node_creation_time) > 86400
+  - alert: AnalyticsHighErrorRate
+    labels: *infraticket
+    annotations:
+      message: |
+        We're seeing an elevated error rate in the analytics target group.
+    expr: |
+      sum(
+        rate({
+          __name__=~"aws_applicationelb_httpcode_target_[23]_xx_count_sum",
+          target_group=~"targetgroup/.*-ingress-analytics/.*"
+        }[60m]))
+      / sum(
+        rate({
+          __name__=~"aws_applicationelb_httpcode_target_[2345]_xx_count_sum",
+          target_group=~"targetgroup/.*-ingress-analytics/.*"
+        }[60m])) < 0.95
+    for: 15m
+  - alert: NoJournalbeatLogs
+    labels: *infraticket
+    annotations:
+      message: |
+        We haven't seen any journalbeat logs for 20 minutes.
+    expr: |
+      rate(journalbeat_libbeat_output_events{type="acked"}[20m]) == 0
+
+


### PR DESCRIPTION
These alerts currently exist on the grafana infra ticket dashboard but
they all go into verify 2ndline slack, causing noise.  Also the
TargetDown alert doesn't work well in grafana, because currently it
alerts if any instances have been down for a period of 15 minutes,
even if no single instance was down for that long.

It's worth re-documenting some of the alerts here as well:

NtpOffsetTooGreat was ported over from the old infrastructure.  We
might be able to do a better alert based on the node_ntp_sanity
metric.

DiskPredictedToFill was noisy when we first created it.  The
node_creation_time guard means we only alert for instances that have
existed for a day or more, because for instances younger than that it
was very trigger-happy.

DO NOT MERGE BEFORE
https://github.com/alphagov/prometheus-aws-configuration-beta/pull/292
or you will ring the observe pagerduty a lot