### PR TITLE
Multiple backends for haproxy

### DIFF
--- a/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-tls/haproxy.cfg.tpl
@@ -37,4 +37,10 @@ backend alb
     option forwardfor
     http-request add-header x-client-ip %[src]
     http-request add-header hub-forwarded-for %[src]
-    server alb $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 100 fastinter 100
+
+    timeout check   250ms
+    timeout connect 250ms
+
+    server alb1 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100
+    server alb2 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100
+    server alb3 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100


### PR DESCRIPTION
Context
---

We were seeing KOs in gatling. We traced this to HAProxy, we found it
serving 503s and "NOSRV" before requests even got to the frontend. We
think this is due to timeouts when HAProxy is healthchecking the ALB.
And we think we can improve the situation by:

- fiddling with intervals
- increasing the length of timeouts
- having multiple backends

Fiddle with intervals
---

Set downinter to 100: downinter is the interval between healthchecks
when a service is down. We want to do this at a high frequency when a
backend is down.

Keep fastinter to 100: fastinter is the interval between healthchecks
when it was UP and is now DOWN or was DOWN and is now UP. We want to
health check at a high frequency during transition.

Set inter to 1000: inter is used when the backend state is UP, and so we
don't need to healthcheck it as often.

Be explicit about timeouts
---

If we do not set timeouts explicitly it will set the timeout values to
the same values as inter. We would like our timeouts to be around 250ms
(internal network in amazon). Previously this value was functionally
100ms, which is probably too low under high load.

Have multiple backends
---

Previously if we had a single server and there was a timeout, then
503 ("NOSRV" in logs) would be served to the user. This is because
HAProxy only stores one IP address for a server even though the DNS
record contained multiple IP addresses.  To make use of multiple IP
addresses, we must declare multiple servers.

HAProxy will assign the different backends different IPs from the same
DNS record (by default even without `resolve-opts allow-dup-ips`). This
means if the ALB IP addresses change we will be less likely to serve
5xxs to users.

Co-authored-by: Toby <toby.lornewelch-richards@digital.cabinet-office.gov.uk>
Co-authored-by: Phil <philip.potter@digital.cabinet-office.gov.uk>