### PR TITLE
AUTO: Reduce max healthy %age for static ingress

### DIFF
--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -156,7 +156,7 @@ resource "aws_ecs_service" "static_ingress_http" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_http.arn}"
@@ -172,7 +172,7 @@ resource "aws_ecs_service" "static_ingress_https" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.static_ingress_https.arn}"


### PR DESCRIPTION
- These tasks bind to a host port so it doesn't make any sense to be
  able to scale beyond 1 per host
- By limiting the maximum to 100% and the minimum to 50% this will mean
  that ECS will remove an old task before trying to place a new one
- The minimum healthy percent means that there will always be 1 (or 2 in
  prod-like envs) tasks available so this is fine

This has been causing our "wait for ecs" task to timeout waiting for these to be placed which is causing unnecessary build failures