### PR TITLE
Make deployment maximum percent = 100 (everywhere)

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -68,7 +68,7 @@ resource "aws_ecs_service" "analytics" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_analytics.arn}"

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -168,7 +168,7 @@ resource "aws_ecs_service" "egress_proxy" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     elb_name       = "${aws_elb.egress_proxy.name}"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -95,7 +95,7 @@ resource "aws_ecs_service" "frontend_v2" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_frontend.arn}"

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_service" "metadata" {
 
   desired_count                      = "${var.number_of_apps}"
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = 100
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.ingress_metadata.arn}"

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -30,7 +30,7 @@ variable "deployment_min_healthy_percent" {
 }
 
 variable "deployment_max_percent" {
-  default = 200
+  default = 100
 }
 
 variable "additional_task_role_policy_arns" {


### PR DESCRIPTION
`deployment_maximum_percent` determines what percentage of
`desired_count` ECS will attempt to schedule. Because we pin one app to
one EC2 instance we do not really have capacity for > 1 app per EC2
instance.

Explicitly setting 100% as the max will ensure ECS gets rid of a single
old app and schedule a new one. This was done for static-ingress tasks
in acacb08 and has reduced the amount of time taken to deploy changes to
static-ingress

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>