### PR TITLE
AUTO: Alert on instance age instead of reboots

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -5,7 +5,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Apt
 apt-get update  --yes
-apt-get upgrade --yes
 
 # AWS SSM Agent
 # Installed by default on Ubuntu Bionic AMIs via Snap
@@ -156,28 +155,6 @@ apt-get install --yes awscli
 
 #Initialise a node_creation_time metric to enable the predict_linear function to handle new nodes
 echo "node_creation_time `date +%s`" > /var/lib/prometheus/node-exporter/node-creation-time.prom
-
-cat <<EOF > /usr/bin/instance-reboot-required-metric.sh
-#!/usr/bin/env bash
-
-echo '# HELP node_reboot_required Node reboot is required for software updates.'
-echo '# TYPE node_reboot_required gauge'
-if [[ -f '/run/reboot-required' ]] ; then
-  echo 'node_reboot_required 1'
-else
-  echo 'node_reboot_required 0'
-fi
-EOF
-
-chmod +x /usr/bin/instance-reboot-required-metric.sh
-
-apt-get install --yes moreutils
-
-crontab - <<EOF
-$(crontab -l | grep -v 'no crontab')
-*/5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
-EOF
-
 # ECS
 echo 'Running ECS using Docker'
 mkdir -p /etc/ecs

--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -114,13 +114,6 @@ groups:
     expr: |
       journalbeat_up == 0
     for: 15m
-  - alert: RebootRequired
-    labels: *infraticket
-    annotations:
-      message: |
-        An instance has installed an upgrade which requires a reboot to take effect.
-    expr: |
-      node_reboot_required == 1
   - alert: NtpOffsetTooGreat
     labels: *infraticket
     annotations:
@@ -141,6 +134,12 @@ groups:
         }[24h],
         3 * 86400) <= 0
       and on (instance) (time() - node_creation_time) > 86400
+  - alert: InstanceTooOld
+    labels: *infraticket
+    annotations:
+      message: |
+        An instance is older than 2 days.
+    expr: (time() - node_creation_time) > 172800
   - alert: AnalyticsHighErrorRate
     labels: *infraticket
     annotations:

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -18,7 +18,6 @@ Acquire::https::Proxy "${egress_proxy_url_with_protocol}/";
 EOF
 fi
 apt-get update  --yes
-apt-get upgrade --yes
 
 # AWS SSM Agent
 # Installed by default on Ubuntu Bionic AMIs via Snap
@@ -187,24 +186,3 @@ systemctl restart prometheus-node-exporter
 
 #Initialise a node_creation_time metric to enable the predict_linear function to handle new nodes
 echo "node_creation_time `date +%s`" > /var/lib/prometheus/node-exporter/node-creation-time.prom
-
-cat <<EOF > /usr/bin/instance-reboot-required-metric.sh
-#!/usr/bin/env bash
-
-echo '# HELP node_reboot_required Node reboot is required for software updates.'
-echo '# TYPE node_reboot_required gauge'
-if [[ -f '/run/reboot-required' ]] ; then
-  echo 'node_reboot_required 1'
-else
-  echo 'node_reboot_required 0'
-fi
-EOF
-
-chmod +x /usr/bin/instance-reboot-required-metric.sh
-
-apt-get install --yes moreutils
-
-crontab - <<EOF
-$(crontab -l | grep -v 'no crontab')
-*/5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
-EOF


### PR DESCRIPTION
- We run the ECS agent using docker run in cloud-init rather than
  putting it into systemd
- If we were to reboot a box, it would not bring the ECS agent back up
  so we shouldn't alert anyone telling them to reboot
- To get the unattended upgrades, we can just wait for a new AMI since
  we roll the instances every day anyway
- Instead of alerting on the reboot required file, let's use the
  node_creation_time metric we already have to detect the last time an
instance was rolled as this is an automated process
- This probably doubles up on alerting since the jobs on Concourse fail
  if the instances don't roll but they aren't cronitored so this catches
the case when they never run at all