### PR TITLE
Make NoJournalbeatLogs less noisy

### DIFF
--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -163,7 +163,8 @@ groups:
     annotations:
       message: |
         We haven't seen any journalbeat logs for 20 minutes.
+    for: 20m
     expr: |
-      rate(journalbeat_libbeat_output_events{type="acked"}[20m]) == 0
+      rate(journalbeat_libbeat_output_events{type="acked"}[1m]) == 0
 
 


### PR DESCRIPTION
This alert was firing for new instances, because if there is less
than 20 minutes' worth of data, `rate` will extrapolate from the small
amount of data that it does have.  If there are no logs from the first
beat-exporter datapoint to the second, we will have a `rate` of 0 and
so we will alert.

The fix is to use `for:` to only alert if we have actually seen
consistently zero logs for 20 minutes.