### PR TITLE
EID-1422 Add splunk appender config to saml engine

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -47,6 +47,10 @@
       {
         "name": "SECONDARY_HUB_ENCRYPTION_PRIVATE_KEY",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}-secondary-hub-encryption-private-key"
+      },
+      {
+        "name": "SPLUNK_TOKEN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-engine/splunk-token"
       }
     ],
     "entryPoint": [
@@ -70,6 +74,22 @@
       {
         "Name": "REDIS_HOST",
         "Value": "${redis_host}"
+      },
+      {
+        "Name": "SPLUNK_URL",
+        "Value": "${splunk_url}"
+      },
+      {
+        "Name": "SPLUNK_SOURCE",
+        "Value": "verify-hub_saml-engine_${deployment}"
+      },
+      {
+        "Name": "SPLUNK_SOURCE_TYPE",
+        "Value": "${splunk_source_type}"
+      },
+      {
+        "Name": "SPLUNK_INDEX",
+        "Value": "verify_eidas_notification_saml"
       }
     ]
   }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -51,6 +51,8 @@ data "template_file" "saml_engine_task_def" {
     region                 = "${data.aws_region.region.id}"
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"
     redis_host             = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
+    splunk_url             = "${var.splunk_url}"
+    splunk_source_type     = "${var.splunk_source_type}"
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -66,6 +66,14 @@ variable "analytics_endpoint" {
   description = "Analytics endpoint"
 }
 
+variable "splunk_url" {
+  description = "Splunk http event collector endpoint, used by saml-engine"
+}
+
+variable "splunk_source_type" {
+  description = "Splunk source type for http event collector endpoint, used by saml-engine"
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
[There's a PR](https://github.com/alphagov/verify-hub/pull/268) to add a
Splunk appender to saml-engine. This appender needs config. This is that
config. [See this PR](https://github.com/alphagov/verify-infrastructure-config/pull/126) for the config that's stored in
verify-infrastructure-config.