### PR TITLE
EID-1422 Add Splunk to egress proxy whitelist

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -61,6 +61,7 @@ locals {
     "${replace(var.logit_elasticsearch_url, ".", "\\.")}",                          # Logit
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",                                 # Tools Sentry
     "${replace(local.event_emitter_api_gateway[0], ".", "\\.")}",                   # API Gateway
+    "${var.splunk_hostname}",                                                       # Splunk
   ]
 
   egress_proxy_whitelist = "${join(" ", local.egress_proxy_whitelist_list)}"

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -70,6 +70,10 @@ variable "splunk_url" {
   description = "Splunk http event collector endpoint, used by saml-engine"
 }
 
+variable "splunk_hostname" {
+  description "Splunk hostname, used by saml-engine's egress proxy"
+}
+
 variable "splunk_source_type" {
   description = "Splunk source type for http event collector endpoint, used by saml-engine"
 }


### PR DESCRIPTION
Saml-engine will be shipping logs to Splunk. The host needs adding to
the egress proxies whitelist.