### PR TITLE
EID-1422 Remove splunk sourceType and index

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -82,14 +82,6 @@
       {
         "Name": "SPLUNK_SOURCE",
         "Value": "verify-hub_saml-engine_${deployment}"
-      },
-      {
-        "Name": "SPLUNK_SOURCE_TYPE",
-        "Value": "${splunk_source_type}"
-      },
-      {
-        "Name": "SPLUNK_INDEX",
-        "Value": "verify_eidas_notification_saml"
       }
     ]
   }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -52,7 +52,6 @@ data "template_file" "saml_engine_task_def" {
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"
     redis_host             = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
     splunk_url             = "${var.splunk_url}"
-    splunk_source_type     = "${var.splunk_source_type}"
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -74,10 +74,6 @@ variable "splunk_hostname" {
   description = "Splunk hostname, used by saml-engine's egress proxy"
 }
 
-variable "splunk_source_type" {
-  description = "Splunk source type for http event collector endpoint, used by saml-engine"
-}
-
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
[Related PR in infra-config](https://github.com/alphagov/verify-infrastructure-config/pull/129)

These variables are actually the same across all environments and so
don't need to injected as env variables. They have been moved to the
config yaml for saml-engine in the hub.