### PR TITLE
reduce the number of CloudWatch metrics we collect

### DIFF
--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -4,30 +4,17 @@ delay_seconds: 120
 metrics:
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_2XX_Count
-  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_3XX_Count
-  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_4XX_Count
-  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
+  aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_5XX_Count
-  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
-  aws_statistics: [Sum]
-- aws_namespace: AWS/ApplicationELB
-  aws_metric_name: RequestCount
-  aws_dimensions: [TargetGroup, AvailabilityZone, LoadBalancer]
-  aws_statistics: [Sum]
-- aws_namespace: AWS/ApplicationELB
-  aws_metric_name: TargetResponseTime
-  aws_dimensions: [AvailabilityZone, LoadBalancer]
-  aws_statistics: [Sum, Average, Minimum, Maximum, Average]
-  aws_extended_statistics: [p50, p75, p90]
-- aws_namespace: AWS/ApplicationELB
-  aws_metric_name: RequestCountPerTarget
   aws_dimensions: [TargetGroup, LoadBalancer]
   aws_statistics: [Sum]


### PR DESCRIPTION
We're spending quite a bit on GetMetricsStatistics API calls.  We can
reduce that by requesting fewer metrics.

For this commit, I focussed on retaining only those metrics required
to support existing alerts.

We don't use the RequestCount or RequestCountPerTarget or
TargetResponseTime metrics in any alerts, so they can go.

We use the Target_[2345]xx_Count metrics, but our alerting rules
aggregate away the AvailabilityZone label.  So we can just not request
it in the first place and reduce our bill on these metrics by a factor
of 3.