### PR TITLE
Reduce cloudwatch metrics even more

### DIFF
--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -5,16 +5,28 @@ metrics:
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_2XX_Count
   aws_dimensions: [TargetGroup, LoadBalancer]
+  aws_dimension_select_regex:
+    LoadBalancer:
+      - 'app/.*-ingress'
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_3XX_Count
   aws_dimensions: [TargetGroup, LoadBalancer]
+  aws_dimension_select_regex:
+    LoadBalancer:
+      - 'app/.*-ingress'
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_4XX_Count
   aws_dimensions: [TargetGroup, LoadBalancer]
+  aws_dimension_select_regex:
+    LoadBalancer:
+      - 'app/.*-ingress'
   aws_statistics: [Sum]
 - aws_namespace: AWS/ApplicationELB
   aws_metric_name: HTTPCode_Target_5XX_Count
   aws_dimensions: [TargetGroup, LoadBalancer]
+  aws_dimension_select_regex:
+    LoadBalancer:
+      - 'app/.*-ingress'
   aws_statistics: [Sum]

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -100,6 +100,7 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Cluster]
         target_label: job
   - job_name: cloudwatch_exporter
+    scrape_interval: 60s
     metrics_path: '/metrics'
     scheme: 'http'
     static_configs:


### PR DESCRIPTION
Request only metrics for the ingress load balancer, not all the
others (there are 8 more loadbalancer/targetgroup combinations, so
this will reduce our metrics to 3/11 of their current amount)