### PR TITLE
Mark verify-tech-team-infrastructure as owning this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://help.github.com/en/articles/about-code-owners
+* @alphagov/verify-tech-team-infrastructure


### PR DESCRIPTION
This will mean that:

 - @alphagov/verify-tech-team-infrastructure will be notified of any
   PRs on this repo
 - members of that team can use the [review-requested][] feature to
   see outstanding PRs in one place rather than visiting each repo
   individually

There is an optional feature that would mean that only
verify-tech-team-infrastructure can submit reviews on this repo.  I
do *not* intend using this; my goal for CODEOWNERS is just to improve
the visibility of code that teams ought to have their eyes on.

[review-requested]: https://github.com/pulls/review-requested