### PR TITLE
Reboot at instance creation time in order to pick up new kernels

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -148,7 +148,7 @@ docker run \
   --privileged \
   --name ecs-agent \
   --detach=true \
-  --restart=on-failure:10 \
+  --restart=always \
   --volume=/etc/ecs:/etc/ecs \
   --volume=/lib64:/lib64 \
   --volume=/lib:/lib \
@@ -208,3 +208,5 @@ crontab - <<EOF
 $(crontab -l | grep -v 'no crontab')
 */5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
 EOF
+
+reboot


### PR DESCRIPTION
Canonical do not bake new AMIs as frequently as they release kernel
patches.  Therefore, when we launch an instance, it may not have the
latest kernel.  This causes alert noise because we see lots of
RebootRequired alerts.

We need to ensure that everything we want to run will survive the
reboot.  We run most things as systemd services, so that will be
fine.  The ECS agent is run via docker.  If we set `--restart=always`,
then the docker daemon will restart the ECS agent on daemon start --
even after a reboot.

#How to review

- Check to see that I haven't missed any important services
- Merge at the start of a day and destroy a few instances in staging to ensure they pick up the new cloud init
