### PR TITLE
Really really upgrade kernels when we provision instances

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -18,7 +18,7 @@ Acquire::https::Proxy "${egress_proxy_url_with_protocol}/";
 EOF
 fi
 apt-get update  --yes
-apt-get upgrade --yes
+apt-get dist-upgrade --yes
 
 # AWS SSM Agent
 # Installed by default on Ubuntu Bionic AMIs via Snap

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -79,6 +79,7 @@ EOF
 # Reload systemctl daemon to pick up new override files
 systemctl stop docker
 systemctl daemon-reload
+systemctl enable docker
 systemctl start docker
 
 # Journalbeat for log shipping
@@ -128,7 +129,8 @@ output.elasticsearch:
   headers:
     Apikey: ${logit_api_key}
 EOF
-systemctl restart journalbeat
+systemctl enable journalbeat
+systemctl start journalbeat
 
 # ECS
 echo 'Installing awscli and running ECS using Docker'


### PR DESCRIPTION
`apt-get upgrade` won't install new kernels because it involves
installing new packages.

`apt-get dist-upgrade` will.

I considered that `dist-upgrade` is a bit of a sledgehammer and it
will also *remove* packages, which we don't want, but the risk of this
actually a) happening, and b) breaking something, feels relatively
small on a freshly-minted machine from an official AMI.