### PR TITLE
Don't reboot on startup for now

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -210,5 +210,3 @@ crontab - <<EOF
 $(crontab -l | grep -v 'no crontab')
 */5 * * * * /usr/bin/instance-reboot-required-metric.sh | sponge /var/lib/prometheus/node-exporter/reboot-required.prom
 EOF
-
-reboot


### PR DESCRIPTION
We have a problem where journalbeat doesn't start properly after a
reboot, so we lose logs :sadpanda:

This just stops the reboot for now while we investigate the issue.