### PR TITLE
AUTO: Reboot Prometheus on startup

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -198,7 +198,7 @@ docker run \
   --privileged \
   --name ecs-agent \
   --detach=true \
-  --restart=on-failure:10 \
+  --restart=always \
   --volume=/etc/ecs:/etc/ecs \
   --volume=/lib64:/lib64 \
   --volume=/lib:/lib \
@@ -219,3 +219,5 @@ docker run \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
   --env="ECS_LOGLEVEL=warn" \
   ${ecs_agent_image_identifier}
+
+reboot


### PR DESCRIPTION
- This also makes the ECS agent restart always so that when the box
  reboots, the agent comes up again afterwards

Co-authored-by: Aditya Pahuja <aditya.pahuja@digital.cabinet-office.gov.uk>