### PR TITLE
Don't reboot prometheus on startup for now

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -224,5 +224,3 @@ docker run \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald"]' \
   --env="ECS_LOGLEVEL=warn" \
   ${ecs_agent_image_identifier}
-
-reboot


### PR DESCRIPTION
We have discovered that when Prometheus is rebooted, its NVMe block
devices can be reordered.  On first boot, the root device is
/dev/nvme0n1, and the prometheus data volume is /dev/nvme1n1.
However, on reboot, these devices reappear in a nondeterministic
order.  If the devices get swapped, then prometheus will fail to start
because it can't access the data volume.

There is some documentation of this behaviour here:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html

and some suggestions for fixes here:

- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-using-volumes.html
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-booting-from-wrong-volume.html

but in the meantime, we should remove the `reboot` line from
prometheus's cloud-init because it currently can cause breakages.