### PR TITLE
prometheus cloud-init: Remount prometheus disk after reboot using label

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -152,7 +152,8 @@ if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
     echo "volume /dev/$vol is mounted ; mounting"
 
   if grep -qv "/dev/$vol" /etc/fstab ; then
-    echo "/dev/$vol /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
+    e2label /dev/$vol srv-prometheus
+    echo "LABEL=srv-prometheus /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
   fi
 fi
 


### PR DESCRIPTION
Rather than device names, which do not persist across reboots.

We considered using UUID, however:
* This is neater
* This is going to be static anyway
* The label is just nicer for humans than the UUID