### PR TITLE
prometheus cloud-init: Remount prometheus disk after reboot using label - take 2

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -145,14 +145,17 @@ if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
   fi
   echo "volume /dev/$vol is formatted"
 
+  e2label /dev/$vol srv-prometheus
+
   if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
     echo "volume /dev/$vol is not mounted ; mounting"
     mount "/dev/$vol" /srv/prometheus
   fi
-    echo "volume /dev/$vol is mounted ; mounting"
+
+  echo "volume /dev/$vol is mounted ; writing fstab entry"
 
   if grep -qv "/dev/$vol" /etc/fstab ; then
-    echo "/dev/$vol /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
+    echo "LABEL=srv-prometheus /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
   fi
 fi
 


### PR DESCRIPTION
This reverts commit d6e268449e476e51746a96f9defff40a5e5988de.

Take 2: Run e2label *before* mounting as it seems you can't label it while mounted.