### PR TITLE
Add config metadata bucket to Hub Staging for self service

### DIFF
--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -1,0 +1,3 @@
+variable "deployment" {
+  description = "Name of the deployment; {staging,prod,integration}"
+}


### PR DESCRIPTION
- The self-service app will publish metadata to this s3 bucket, which hub config will then read from

Co-authored-by: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>