### PR TITLE
Add Self Service config metadata bucket to Hub VPC endpoint

### DIFF
--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -35,7 +35,9 @@ resource "aws_vpc_endpoint" "s3" {
                 "arn:aws:s3:::prod-eu-west-2-starport-layer-bucket",
                 "arn:aws:s3:::prod-eu-west-2-starport-layer-bucket/*",
                 "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store",
-                "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store/*"
+                "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store/*",
+                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata",
+                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata/*"
             ]
         }
     ]

--- a/terraform/modules/self-service/self_service_app.tf
+++ b/terraform/modules/self-service/self_service_app.tf
@@ -1,9 +1,14 @@
 data "aws_iam_policy_document" "self_service_user_write_to_bucket" {
   statement {
-    sid       = "AllowPutObject"
+    sid       = "AllowGetAndPutObject"
     effect    = "Allow"
     resources = ["${aws_s3_bucket.config_metadata.arn}/*"]
-    actions   = ["s3:PutObject"]
+    actions   = [
+      "s3:GetO*",
+      "s3:PutO*",
+      "s3:DeleteO*",
+      "s3:ListBucket",
+    ]
   }
 }
 


### PR DESCRIPTION
The Self Service app will be uploading metadata to an S3 bucket in the hub's vpc and therefore needs to be added as a resource.

https://trello.com/c/3VTpnx6M/466-create-user-and-roles-for-s3-access-in-staging