### PR TITLE
Make task roles usable

### DIFF
--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -19,7 +19,12 @@ resource "aws_ecs_task_definition" "cluster" {
   family                = "${local.identifier}"
   container_definitions = "${var.task_definition}"
   execution_role_arn    = "${module.cluster_ecs_roles.execution_role_arn}"
+  task_role_arn         = "${module.cluster_ecs_roles.task_role_arn}"
   network_mode          = "bridge"
+}
+
+output "task_role_arn" {
+  value = "${module.cluster_ecs_roles.task_role_arn}"
 }
 
 resource "aws_ecs_service" "cluster" {

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -33,14 +33,6 @@ variable "deployment_max_percent" {
   default = 100
 }
 
-variable "additional_task_role_policy_arns" {
-  default = []
-}
-
-variable "additional_execution_role_policy_arns" {
-  default = []
-}
-
 variable "health_check_path" {
   default = "/"
 }

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/task_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/task_role.tf
@@ -19,3 +19,7 @@ resource "aws_iam_role" "task" {
   }
   EOF
 }
+
+output "task_role_arn" {
+  value = "${aws_iam_role.task.arn}"
+}

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
@@ -14,14 +14,6 @@ locals {
   }"
 }
 
-variable "additional_execution_role_policy_arns" {
-  default = []
-}
-
-variable "additional_task_role_policy_arns" {
-  default = []
-}
-
 data "aws_caller_identity" "account" {}
 
 locals {


### PR DESCRIPTION
@brenetic has a need to allow the Config service to pull from an S3 bucket.  We need to use a task role policy for this. However, the existing code didn't allow you to attach a policy to the exisitng role, and didn't attach the existing role to the task.  This fixes all that.

Once this is done, you can access the task role for an ecs_app like this: `"${module.my_app.task_role_arn}"`