### PR TITLE
Remove Principal from config metadata policy

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -81,7 +81,6 @@ resource "aws_iam_policy" "can_read_config_metadata_bucket" {
         {
             "Sid": "BucketCanBeReadFrom",
             "Effect": "Allow",
-            "Principal": "*",
             "Action": [
                 "s3:ListBucket",
                 "s3:GetO*"


### PR DESCRIPTION
This should not be specified in a aws_iam_policy