### PR TITLE
Use role name instead of arn in config policy attachment

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -96,7 +96,7 @@ resource "aws_iam_policy" "can_read_config_metadata_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "config_task_can_read_metadata_bucket" {
-  role       = "${module.config.task_role_arn}"
+  role       = "${module.config.task_role_name}"
   policy_arn = "${aws_iam_policy.can_read_config_metadata_bucket.arn}"
 }
 

--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -23,8 +23,8 @@ resource "aws_ecs_task_definition" "cluster" {
   network_mode          = "bridge"
 }
 
-output "task_role_arn" {
-  value = "${module.cluster_ecs_roles.task_role_arn}"
+output "task_role_name" {
+  value = "${module.cluster_ecs_roles.task_role_name}"
 }
 
 resource "aws_ecs_service" "cluster" {

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/task_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/task_role.tf
@@ -23,3 +23,7 @@ resource "aws_iam_role" "task" {
 output "task_role_arn" {
   value = "${aws_iam_role.task.arn}"
 }
+
+output "task_role_name" {
+  value = "${aws_iam_role.task.name}"
+}


### PR DESCRIPTION
The policy attachment for the config metadata bucket required the role task name not the arn.