### PR TITLE
Add self service environment config

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -62,6 +62,18 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+      },
+      {
+        "Name": "SELF_SERVICE_ENABLED",
+        "Value": "${self_service_enabled}"
+      },
+      {
+        "Name": "SERVICES_METADATA_BUCKET",
+        "Value": "${services_metadata_bucket}"
+      },
+      {
+        "Name": "METADATA_OBJECT_KEY",
+        "Value": "${metadata_object_key}"
       }
     ]
   }

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -55,20 +55,25 @@ locals {
   LOCATIONS
 
   nginx_config_location_blocks_base64 = "${base64encode(local.config_location_blocks)}"
+  services_metadata_bucket            = "govukverify-self-service-${var.deployment}-config-metadata"
+  metadata_object_key                 = "verify_services_metadata.json"
 }
 
 data "template_file" "config_task_def" {
   template = "${file("${path.module}/files/tasks/hub-config.json")}"
 
   vars {
-    image_identifier       = "${local.tools_account_ecr_url_prefix}-verify-config@${var.hub_config_image_digest}"
-    nginx_image_identifier = "${local.nginx_image_identifier}"
-    domain                 = "${local.root_domain}"
-    deployment             = "${var.deployment}"
-    truststore_password    = "${var.truststore_password}"
-    location_blocks_base64 = "${local.nginx_config_location_blocks_base64}"
-    region                 = "${data.aws_region.region.id}"
-    account_id             = "${data.aws_caller_identity.account.account_id}"
+    image_identifier         = "${local.tools_account_ecr_url_prefix}-verify-config@${var.hub_config_image_digest}"
+    nginx_image_identifier   = "${local.nginx_image_identifier}"
+    domain                   = "${local.root_domain}"
+    deployment               = "${var.deployment}"
+    truststore_password      = "${var.truststore_password}"
+    location_blocks_base64   = "${local.nginx_config_location_blocks_base64}"
+    region                   = "${data.aws_region.region.id}"
+    account_id               = "${data.aws_caller_identity.account.account_id}"
+    self_service_enabled     = "${var.self_service_enabled}"
+    services_metadata_bucket = "${local.services_metadata_bucket}"
+    metadata_object_key      = "${local.metadata_object_key}"
   }
 }
 
@@ -86,8 +91,8 @@ resource "aws_iam_policy" "can_read_config_metadata_bucket" {
                 "s3:GetO*"
             ],
             "Resource": [
-                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata",
-                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata/*"
+                "arn:aws:s3:::${local.services_metadata_bucket}",
+                "arn:aws:s3:::${local.services_metadata_bucket}/*"
             ]
         }
     ]

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -79,6 +79,11 @@ variable "ab_test_file" {
   default      = "deactivated_ab_test.yml"
 }
 
+variable "self_service_enabled" {
+  description = "Enable the use of the Self Service generated metadata"
+  default     = "false"
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
We are now ready to connect up the config service use of the new self service metadata in Staging.

Set the required environment variables required by the config app to read the metadata.

Corresponding PRs:
https://github.com/alphagov/verify-infrastructure-config/pull/158
https://github.com/alphagov/verify-hub/pull/314

https://trello.com/c/glz5vLuk/485-update-the-config-in-hub-to-enable-the-e2e-journey