### PR TITLE
FIREBREAK: Added the new verify-sentry dockerfile

### DIFF
--- a/dockerfiles/verify-sentry/Dockerfile
+++ b/dockerfiles/verify-sentry/Dockerfile
@@ -1,0 +1,1 @@
+FROM sentry:9.0-onbuild

--- a/dockerfiles/verify-sentry/requirements.txt
+++ b/dockerfiles/verify-sentry/requirements.txt
@@ -1,0 +1,1 @@
+https://github.com/getsentry/sentry-auth-github/archive/43f6b270b3fac32326518a78be77562ebe5abacf.zip


### PR DESCRIPTION
In order to use GitHub as a SSO provider for logging in to Sentry we need to install an additional plugin using `pip`.
This docker image is going to get build by our pipeline and put into ECR from which it will get deployed.