### PR TITLE
Add additional outputs required for the self service app

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -6,6 +6,10 @@ output "vpc_id" {
   value = "${aws_vpc.hub.id}"
 }
 
-output "aws_lb_listener_ingress_https" {
-  value = "${aws_lb_listener.ingress_https.arn}"
+output "can_connect_to_container_vpc_endpoint" {
+  value = "${aws_security_group.container_vpc_endpoint}"
+}
+
+output "cloudwatch_vpc_endpoint" {
+  value = "${aws_security_group.cloudwatch_vpc_endpoint}"
 }


### PR DESCRIPTION
These outputs are needed for the self service app to use via hub's
remote state.

We no longer need the listener https output as we took a different
approach.

https://trello.com/c/QsDuRhZK/496-define-ecs-fargate-task-in-staging-deploying-to-staging-vpc

Co-authored-by: Jakub Miarka <jakub.miarka@digtal.cabinet-office.gov.uk>