### PR TITLE
Use correct VPC endpoint ID from Hub

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -7,7 +7,7 @@ output "vpc_id" {
 }
 
 output "can_connect_to_container_vpc_endpoint" {
-  value = "${aws_security_group.container_vpc_endpoint.id}"
+  value = "${aws_security_group.can_connect_to_container_vpc_endpoint.id}"
 }
 
 output "cloudwatch_vpc_endpoint" {


### PR DESCRIPTION
We previously chose the wrong VPC endpoint ID. Use the right one.