### PR TITLE
Output Hub KMS key ID

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -13,3 +13,8 @@ output "can_connect_to_container_vpc_endpoint" {
 output "cloudwatch_vpc_endpoint" {
   value = "${aws_security_group.cloudwatch_vpc_endpoint.id}"
 }
+
+output "hub_key_id" {
+  value     = "${aws_kms_key.hub_key.key_id}"
+  sensitive = true
+}


### PR DESCRIPTION
The hub key ID needs to be outputted as the Self Service app will access it via remote state in order to encrypt and decrypt various sensitive things.