### PR TITLE
Add Self Service app secret key base to Parameter Store

### DIFF
--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -1,7 +1,7 @@
 [
     {
       "essential": true,
-      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service",
+      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service:latest",
       "memory": 1024,
       "name": "self-service",
       "portMappings": [
@@ -28,7 +28,7 @@
       "secrets": [
         {
           "name": "SECRET_KEY_BASE",
-          "valueFrom": "arn:aws:ssm:eu-west-2:${aws_account_id}:parameter/self-service/rails-secret-key-base"
+          "valueFrom": "${rails_secret_key_base}"
         }
       ],
       "logConfiguration": {

--- a/terraform/modules/self-service/kms.tf
+++ b/terraform/modules/self-service/kms.tf
@@ -1,0 +1,13 @@
+resource "aws_kms_key" "self_service_key" {
+  description = "Used for encrypting and decrypting self service private keys"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  deletion_window_in_days = 7
+
+  policy = "${data.aws_iam_policy_document.kms_policy_document.json}"
+}
+
+resource "aws_kms_alias" "self_service_key" {
+  name          = "alias/${var.deployment}-${local.service}-key"
+  target_key_id = "${aws_kms_key.self_service_key.key_id}"
+}

--- a/terraform/modules/self-service/outputs.tf
+++ b/terraform/modules/self-service/outputs.tf
@@ -1,0 +1,4 @@
+output "rails_secet_key_base" {
+  value     = "${aws_ssm_parameter.rails_secret_key_base.value}"
+  sensitive = true
+}

--- a/terraform/modules/self-service/security_groups.tf
+++ b/terraform/modules/self-service/security_groups.tf
@@ -45,3 +45,16 @@ resource "aws_security_group" "self_service" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "egress_over_https" {
+  name        = "${local.service}-egress-over-https"
+  description = "${local.service} security group to allow egress over https"
+  vpc_id      = "${data.terraform_remote_state.hub.vpc_id}"
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
This will now generate a random string for rails secret key and save it to the Parameter Store.

Also update the self service app task definition to use that generated secret key.

This saves us from manually generating a key and adding it to the Parameter Store.

There is currently a rails secret key in the staging account that was manually created. This will be removed a little later.
