### PR TITLE
Remove unneeded Hub outputs

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -9,12 +9,3 @@ output "vpc_id" {
 output "can_connect_to_container_vpc_endpoint" {
   value = "${aws_security_group.can_connect_to_container_vpc_endpoint.id}"
 }
-
-output "cloudwatch_vpc_endpoint" {
-  value = "${aws_security_group.cloudwatch_vpc_endpoint.id}"
-}
-
-output "hub_key_id" {
-  value     = "${aws_kms_key.hub_key.key_id}"
-  sensitive = true
-}


### PR DESCRIPTION
We no longer require these outputs for the self service app.
Alternatives were used in this PR: https://github.com/alphagov/verify-infrastructure/pull/256