### PR TITLE
Connect Self Service app to DB

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -7,9 +7,10 @@ data "template_file" "task_def" {
 
   vars = {
     deployment            = "${var.deployment}"
+    aws_bucket            = "${aws_s3_bucket.config_metadata.bucket}"
     rails_secret_key_base = "${aws_ssm_parameter.rails_secret_key_base.arn}"
     database_username     = "${var.db_username}"
-    database_password_arn = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/db-self-service-user-password"
+    database_password_arn = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/db-master-password"
     database_host         = "${aws_db_instance.self_service.endpoint}"
     database_name         = "${aws_db_instance.self_service.name}"
   }

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -1,7 +1,7 @@
 [
     {
       "essential": true,
-      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service:latest",
+      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service:latest-${deployment}",
       "memory": 1024,
       "name": "self-service",
       "portMappings": [
@@ -22,7 +22,11 @@
       "environment": [
         {
           "name": "RAILS_ENV",
-          "value": "development"
+          "value": "production"
+        },
+        {
+          "name": "AWS_BUCKET",
+          "value": "${aws_bucket}"
         },
         {
           "name": "DATABASE_HOST",

--- a/terraform/modules/self-service/lb.tf
+++ b/terraform/modules/self-service/lb.tf
@@ -29,7 +29,7 @@ resource "aws_lb_target_group" "task" {
     protocol = "HTTP"
     interval = "30"
     timeout  = "15"
-    matcher  = "200-399"
+    matcher  = "200-401"
   }
 
   depends_on = [


### PR DESCRIPTION
Adjust Fargate task definition to enable the self service app to connect to the RDS DB.

- Change image to use the `latest-staging`. This is a temporary change
until we roll out the use of SHA's.
- RAILS_ENV is now production
- Add config metadata bucket name required on app startup
- Allow 401's as part of healthcheck. This is temporary until we
complete moving cognito for self service over.

https://trello.com/c/hwOQiG8U/560-connect-self-service-app-to-db-in-staging