### PR TITLE
Add Self Service Cognito User Pool

### DIFF
--- a/terraform/modules/self-service/cognito.tf
+++ b/terraform/modules/self-service/cognito.tf
@@ -1,0 +1,72 @@
+resource "aws_cognito_user_pool" "user_pool" {
+  name = "${local.service}-user-pool"
+
+  username_attributes = [
+    "email",
+  ]
+
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+  }
+
+  password_policy {
+    minimum_length    = 8
+    require_uppercase = true
+    require_lowercase = true
+    require_numbers   = true
+    require_symbols   = false
+  }
+
+  schema {
+    name                = "email"
+    attribute_data_type = "String"
+    mutable             = false
+    required            = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 320
+    }
+  }
+
+  schema {
+    name                = "family_name"
+    attribute_data_type = "String"
+    required            = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 512
+    }
+  }
+
+  schema {
+    name                = "given_name"
+    attribute_data_type = "String"
+    required            = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 512
+    }
+  }
+
+  schema {
+    name                = "role"
+    attribute_data_type = "String"
+    mutable             = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 512
+    }
+  }
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  name                         = "${local.service}-user-pool-client"
+  user_pool_id                 = "${aws_cognito_user_pool.user_pool.id}"
+  explicit_auth_flows          = ["USER_PASSWORD_AUTH"]
+  supported_identity_providers = ["COGNITO"]
+  refresh_token_validity       = 1
+}

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -13,6 +13,7 @@ data "template_file" "task_def" {
     database_password_arn = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/db-master-password"
     database_host         = "${aws_db_instance.self_service.endpoint}"
     database_name         = "${aws_db_instance.self_service.name}"
+    cognito_client_id     = "${aws_cognito_user_pool_client.client.id}"
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -29,6 +29,10 @@
           "value": "${aws_bucket}"
         },
         {
+          "name": "AWS_COGNITO_CLIENT_ID",
+          "value": "${cognito_client_id}"
+        },
+        {
           "name": "DATABASE_HOST",
           "value": "${database_host}"
         },

--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -154,6 +154,30 @@ resource "aws_iam_role" "self_service_task" {
   EOF
 }
 
+resource "aws_iam_policy" "self_service_cognito_policy" {
+  name = "${local.service}-cognito-policy"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["*"],
+        "Resource": [
+          "arn:aws:cognito-idp:${data.aws_region.region.name}:${data.aws_caller_identity.account.account_id}:userpool/${aws_cognito_user_pool.user_pool.id}"
+        ]
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "self_service_cognito_policy_attachment" {
+  role       = "${aws_iam_role.self_service_task.name}"
+  policy_arn = "${aws_iam_policy.self_service_cognito_policy.arn}"
+}
+
 resource "aws_iam_policy" "execution" {
   name = "${var.deployment}-${local.service}-execution"
 


### PR DESCRIPTION
The Self Service app will be managing its' users via AWS Cognito. This adds the config for it.

MFA config is off by default. We will be controlling this flow through the API via the app so this is fine.

Also add the iam policy for the self service fargate task to talk to cognito.

https://trello.com/c/0SGwOSTk/550-terraform-cognito-staging-for-self-service-in-hub

The role custom field is added at the same time in this PR.

https://trello.com/c/o8zwOVZO/567-update-cognito-terraform-for-user-role-custom-field