### PR TITLE
Expose Hub public subnet IDs

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -9,3 +9,7 @@ output "vpc_id" {
 output "can_connect_to_container_vpc_endpoint" {
   value = "${aws_security_group.can_connect_to_container_vpc_endpoint.id}"
 }
+
+output "public_subnet_ids" {
+  value = "${aws_subnet.ingress.*.id}"
+}


### PR DESCRIPTION
These will needed in order to route incoming traffic to the Self Service app.

https://trello.com/c/dyefKxUx/548-add-public-route-to-the-aws-instance

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>