### PR TITLE
Make Self Service load balancer use public subnets

### DIFF
--- a/terraform/modules/self-service/lb.tf
+++ b/terraform/modules/self-service/lb.tf
@@ -8,7 +8,7 @@ resource "aws_lb" "self_service_edge" {
     "${aws_security_group.egress.id}"
   ]
 
-  subnets = ["${data.terraform_remote_state.hub.internal_subnet_ids}"]
+  subnets = ["${data.terraform_remote_state.hub.public_subnet_ids}"]
 
   tags {
     Deployment = "${var.deployment}"


### PR DESCRIPTION
In order for the load balancer to be able to receive traffic from the
internet it needs to be part of the public subnets which have access to
the internet gateway.

https://trello.com/c/dyefKxUx/548-add-public-route-to-the-aws-instance

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>