### PR TITLE
Add asset config for self-service

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -6,7 +6,7 @@ data "template_file" "task_def" {
   template = "${file("${path.module}/files/task-def.json")}"
 
   vars = {
-    deployment            = "${var.deployment}"
+    image_digest          = "${var.image_digest}"
     aws_bucket            = "${aws_s3_bucket.config_metadata.bucket}"
     rails_secret_key_base = "${aws_ssm_parameter.rails_secret_key_base.arn}"
     database_username     = "${var.db_username}"
@@ -14,6 +14,8 @@ data "template_file" "task_def" {
     database_host         = "${aws_db_instance.self_service.endpoint}"
     database_name         = "${aws_db_instance.self_service.name}"
     cognito_client_id     = "${aws_cognito_user_pool_client.client.id}"
+    asset_host            = "${var.asset_host}"
+    asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -1,7 +1,7 @@
 [
     {
       "essential": true,
-      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service:latest-${deployment}",
+      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service@${image_digest}",
       "memory": 1024,
       "name": "self-service",
       "portMappings": [
@@ -43,6 +43,14 @@
         {
           "name": "DATABASE_USERNAME",
           "value": "${database_username}"
+        },
+        {
+          "name": "ASSET_HOST",
+          "value": "${asset_host}"
+        },
+        {
+          "name": "ASSET_PREFIX",
+          "value": "${asset_prefix}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -41,3 +41,10 @@ variable "db_username" {
   description = "Self Service DB username"
   default     = "postgres"
 }
+
+variable "asset_host" {
+  description = "Host where the static assets are hosted"
+  default     = "gds-verify-self-service-assets.s3.amazonaws.com"
+}
+
+variable "image_digest" {}


### PR DESCRIPTION
We're now hosting assets in S3 and therefore we need to let the app know.
This adds options for asset host and asset prefix to the environment variable.
Also we're moving to using image digests instead of tags.