### PR TITLE
DI0DC6Dt: Run DB migration

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -1,0 +1,72 @@
+[
+    {
+      "essential": true,
+      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service@${image_digest}",
+      "memory": 1024,
+      "name": "self-service",
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080
+        }
+      ],
+      "entryPoint": [
+        "bundle",
+        "exec",
+        "rails",
+        "db:migrate"
+      ],
+      "environment": [
+        {
+          "name": "RAILS_ENV",
+          "value": "production"
+        },
+        {
+          "name": "AWS_BUCKET",
+          "value": "${aws_bucket}"
+        },
+        {
+          "name": "AWS_COGNITO_CLIENT_ID",
+          "value": "${cognito_client_id}"
+        },
+        {
+          "name": "DATABASE_HOST",
+          "value": "${database_host}"
+        },
+        {
+          "name": "DATABASE_NAME",
+          "value": "${database_name}"
+        },
+        {
+          "name": "DATABASE_USERNAME",
+          "value": "${database_username}"
+        },
+        {
+          "name": "ASSET_HOST",
+          "value": "${asset_host}"
+        },
+        {
+          "name": "ASSET_PREFIX",
+          "value": "${asset_prefix}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "SECRET_KEY_BASE",
+          "valueFrom": "${rails_secret_key_base}"
+        },
+        {
+          "name": "DATABASE_PASSWORD",
+          "valueFrom": "${database_password_arn}"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "self-service",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "self-service-migrations"
+        }
+      }
+    }
+  ]


### PR DESCRIPTION
Adding a new fargate task for running our DB migrations. It's almost identical, except
having a different entrypoint and
database hostname is in a different format (without port). And different logging prefix.

Co-Authored-By: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>