### PR TITLE
Set Self Service cognito user pool ID in task definition

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -14,6 +14,7 @@ data "template_file" "task_def" {
     database_host         = "${aws_db_instance.self_service.endpoint}"
     database_name         = "${aws_db_instance.self_service.name}"
     cognito_client_id     = "${aws_cognito_user_pool_client.client.id}"
+    cognito_user_pool_id  = "${aws_cognito_user_pool.user_pool.id}"
     asset_host            = "${var.asset_host}"
     asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
   }

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -33,6 +33,10 @@
           "value": "${cognito_client_id}"
         },
         {
+          "name": "AWS_COGNITO_USER_POOL_ID",
+          "value": "${cognito_user_pool_id}"
+        },
+        {
           "name": "DATABASE_HOST",
           "value": "${database_host}"
         },


### PR DESCRIPTION
The Cognito User Pool ID is required when creating groups via the SDK, so pass this into the environment for the app to use on start up.

https://trello.com/c/MqjCqcyS/578-create-a-group-in-cognito-when-a-team-is-created