### PR TITLE
Allow Self Service task access to config metadata bucket

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -1,32 +1,3 @@
-data "aws_iam_policy_document" "self_service_user_write_to_bucket" {
-  statement {
-    sid       = "AllowGetAndPutObject"
-    effect    = "Allow"
-    resources = ["${aws_s3_bucket.config_metadata.arn}/*"]
-
-    actions = [
-      "s3:GetO*",
-      "s3:PutO*",
-      "s3:DeleteO*",
-      "s3:ListBucket",
-    ]
-  }
-}
-
-resource "aws_iam_policy" "self_service_user_write_to_bucket" {
-  name   = "${local.service}-iam-policy"
-  policy = "${data.aws_iam_policy_document.self_service_user_write_to_bucket.json}"
-}
-
-resource "aws_iam_user" "self_service_user" {
-  name = "${local.service}-user"
-}
-
-resource "aws_iam_user_policy_attachment" "self_service_user_policy_attachment" {
-  user       = "${aws_iam_user.self_service_user.name}"
-  policy_arn = "${aws_iam_policy.self_service_user_write_to_bucket.arn}"
-}
-
 resource "aws_iam_role_policy_attachment" "self_service_execution_write_to_logs_attachment" {
   role       = "${aws_iam_role.self_service_execution.name}"
   policy_arn = "${aws_iam_policy.can_write_to_logs.arn}"

--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -184,3 +184,28 @@ resource "aws_iam_role_policy_attachment" "execution_execution" {
   role       = "${aws_iam_role.self_service_execution.name}"
   policy_arn = "${aws_iam_policy.execution.arn}"
 }
+
+data "aws_iam_policy_document" "access_config_metadata" {
+  statement {
+    sid       = "AllowGetAndPutObject"
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.config_metadata.arn}/*"]
+
+    actions = [
+      "s3:GetO*",
+      "s3:PutO*",
+      "s3:DeleteO*",
+      "s3:ListBucket",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "access_config_metadata" {
+  name   = "${local.service}-access-config-metadata"
+  policy = "${data.aws_iam_policy_document.access_config_metadata.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "task_access_metadata_bucket_attachment" {
+  role       = "${aws_iam_role.self_service_task.name}"
+  policy_arn = "${aws_iam_policy.access_config_metadata.arn}"
+}


### PR DESCRIPTION
### Remove Self Service IAM user

This was used by the instance of the self service app that was deployed to the PaaS. It's no longer needed as the app is living in Hub Staging.

### Give Self Service Fargate task config metadata access

The entire purpose for the Self Service app to exist is to talk to the config metadata bucket. I guess we should allow this.

### Diff

<img width="692" alt="Screen Shot 2019-08-09 at 10 54 48" src="https://user-images.githubusercontent.com/3466862/62771474-372b7880-ba95-11e9-8427-18df2d3640fc.png">


https://trello.com/c/vJ5YZedB/589-add-missing-s3-permissions-to-the-self-service-task-role

