### PR TITLE
BAU: Reduce number of desired Fargate tasks

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_service" "service" {
   name            = "${local.service}"
   task_definition = "${aws_ecs_task_definition.task_def.arn}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
-  desired_count   = 2
+  desired_count   = 1
   launch_type     = "FARGATE"
 
   load_balancer {


### PR DESCRIPTION
We're currently not handling large traffic, so we don't need 2 instances.
This will also speed up deployments.

Related to https://github.com/alphagov/verify-self-service/pull/101