### PR TITLE
Use Self Service app healthcheck endpoint

### DIFF
--- a/terraform/modules/self-service/lb.tf
+++ b/terraform/modules/self-service/lb.tf
@@ -25,11 +25,11 @@ resource "aws_lb_target_group" "task" {
   slow_start           = 30
 
   health_check {
-    path     = "/"
+    path     = "/healthcheck"
     protocol = "HTTP"
-    interval = "30"
+    interval = "120"
     timeout  = "15"
-    matcher  = "200-401"
+    matcher  = "200-299"
   }
 
   depends_on = [


### PR DESCRIPTION
## What

A healthcheck endpoint was added in [this PR](alphagov/verify-self-service#105) to the Self Service app.

This changes the load balancer to hit that endpoint when doing its' healthchecks.

https://trello.com/c/GsiYpDJI/591-create-a-healtheck-endpoint-on-the-app

### Sneaky Diff

<img width="379" alt="Screen Shot 2019-08-12 at 10 28 52" src="https://user-images.githubusercontent.com/3466862/62856326-80c1d080-bcec-11e9-83c8-c76cbcb890c6.png">
