### PR TITLE
Add Sentry DSN secret to Self Service app

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -11,6 +11,7 @@ locals  {
     cognito_user_pool_id  = "${aws_cognito_user_pool.user_pool.id}"
     asset_host            = "${var.asset_host}"
     asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
+    sentry_dsn            = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -65,6 +65,10 @@
         {
           "name": "DATABASE_PASSWORD",
           "valueFrom": "${database_password_arn}"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "${sentry_dsn}"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
### What

We will be using Sentry with the Self Service app. We are happy for it to be bundled with the other hub apps.

The usual Sentry Raven gem change will need adding to the Self Service app itself as well.

https://trello.com/c/lKcAMBvI/528-plug-the-app-to-sentry