### PR TITLE
Add Integration config metadata bucket arn to Self Service policy

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -189,7 +189,10 @@ data "aws_iam_policy_document" "access_config_metadata" {
   statement {
     sid       = "AllowGetAndPutObject"
     effect    = "Allow"
-    resources = ["${aws_s3_bucket.config_metadata.arn}/*"]
+    resources = [
+      "${aws_s3_bucket.config_metadata.arn}/*",
+      "${data.aws_ssm_parameter.integration_metadata_bucket.value}/*"
+    ]
 
     actions = [
       "s3:GetO*",
@@ -208,4 +211,8 @@ resource "aws_iam_policy" "access_config_metadata" {
 resource "aws_iam_role_policy_attachment" "task_access_metadata_bucket_attachment" {
   role       = "${aws_iam_role.self_service_task.name}"
   policy_arn = "${aws_iam_policy.access_config_metadata.arn}"
+}
+
+data "aws_ssm_parameter" "integration_metadata_bucket" {
+  name = "/staging/${local.service}/integration-bucket-arn"
 }


### PR DESCRIPTION
When the Self Service app is in production it will also be reading and writing to a bucket in Integration.

Once we deploy out to production access will be limited only for the app running in that environment. For testing right now we're giving to the app running in staging.