### PR TITLE
Add Self Service Hub Environments variable

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -13,6 +13,7 @@ locals  {
     asset_host            = "${var.asset_host}"
     asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
     sentry_dsn            = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
+    hub_environments      = "${var.hub_environments}"
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -59,6 +59,10 @@
         {
           "name": "ASSET_PREFIX",
           "value": "${asset_prefix}"
+        },
+        {
+          "name": "HUB_ENVIRONMENTS",
+          "value": "${hub_environments}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -48,3 +48,7 @@ variable "asset_host" {
 }
 
 variable "image_digest" {}
+
+variable "hub_environments" {
+  description = "JSON string of hub environments and the config metadata buckets"
+}


### PR DESCRIPTION
In production we will be connecting to two buckets in different accounts. This environment variable makes it possible to pass more than one bucket name to the app.

https://trello.com/c/XwOTbGhG/622-when-a-change-is-made-and-the-publish-metadata-event-is-triggered-it-generates-the-correct-metadata-and-writes-it-the-correct-bu