### PR TITLE
5CR1WpE4: RP truststore enabled flag for saml-proxy

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -70,6 +70,10 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+      },
+      {
+        "Name": "RP_TRUSTSTORE_ENABLED",
+        "Value": "${rp_truststore_enabled}"
       }
     ]
   }

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -68,6 +68,7 @@ data "template_file" "saml_proxy_task_def" {
     region                        = "${data.aws_region.region.id}"
     account_id                    = "${data.aws_caller_identity.account.account_id}"
     event_emitter_api_gateway_url = "${var.event_emitter_api_gateway_url}"
+    rp_truststore_enabled         = "${var.rp_truststore_enabled}"
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -28,6 +28,11 @@ variable "redis_cache_size" {
 
 variable "truststore_password" {}
 
+variable "rp_truststore_enabled" {
+  description = "The RP truststore should be disabled if any self-service certs will be used by RPs, since we cannot validate the trust chain for self-signed certs"
+  default = "true"
+}
+
 locals {
   root_domain                  = "${replace(var.signin_domain, "/www[.]/", "")}"
   number_of_availability_zones = 3


### PR DESCRIPTION
We need to stop validating against the RP truststore in saml-proxy, so that RPs can use self-signed certificates.

https://trello.com/c/5CR1WpE4/627-verify-the-e2e-journey-with-self-signed-certs