### PR TITLE
Additional self service envars for task definition

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -22,10 +22,6 @@
           "value": "production"
         },
         {
-          "name": "AWS_BUCKET",
-          "value": "${aws_bucket}"
-        },
-        {
           "name": "AWS_COGNITO_CLIENT_ID",
           "value": "${cognito_client_id}"
         },

--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -26,6 +26,14 @@
           "value": "${aws_bucket}"
         },
         {
+          "name": "AWS_COGNITO_CLIENT_ID",
+          "value": "${cognito_client_id}"
+        },
+        {
+          "name": "AWS_COGNITO_USER_POOL_ID",
+          "value": "${cognito_user_pool_id}"
+        },
+        {
           "name": "AWS_REGION",
           "value": "${region}"
         },

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -29,10 +29,6 @@
           "value": "${region}"
         },
         {
-          "name": "AWS_BUCKET",
-          "value": "${aws_bucket}"
-        },
-        {
           "name": "AWS_COGNITO_CLIENT_ID",
           "value": "${cognito_client_id}"
         },


### PR DESCRIPTION
## Additional envars for Self Service migrations task definition

As a result of [this PR](alphagov/verify-self-service#128) we now make sure the app raises an exception if certain environment variables are not. This adds the extra ones it needs.

## Remove AWS_BUCKET from Self Service task definitions

As a result of [this PR](alphagov/verify-self-service#125) we now get the environment s3 buckets from the `hub_environments` envar so AWS_BUCKET can come out.