### PR TITLE
5CR1WpE4: RP truststore enabled flag for saml-engine

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -82,6 +82,10 @@
       {
         "Name": "SPLUNK_SOURCE",
         "Value": "verify-hub_saml-engine_${deployment}"
+      },
+      {
+        "Name": "RP_TRUSTSTORE_ENABLED",
+        "Value": "${rp_truststore_enabled}"
       }
     ]
   }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -52,6 +52,7 @@ data "template_file" "saml_engine_task_def" {
     location_blocks_base64 = "${local.nginx_saml_engine_location_blocks_base64}"
     redis_host             = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
     splunk_url             = "${var.splunk_url}"
+    rp_truststore_enabled  = "${var.rp_truststore_enabled}"
   }
 }
 


### PR DESCRIPTION
We need to stop validating against the RP truststore in saml-engine, so that RPs can use self-signed certificates.