### PR TITLE
Adjust config metadata access policy

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -13,7 +13,3 @@ output "can_connect_to_container_vpc_endpoint" {
 output "public_subnet_ids" {
   value = "${aws_subnet.ingress.*.id}"
 }
-
-output "route_table_ids" {
-  value = "${aws_route_table.private.*.id}"
-}

--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -37,7 +37,9 @@ resource "aws_vpc_endpoint" "s3" {
                 "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store",
                 "arn:aws:s3:::gds-${var.deployment}-ssm-session-logs-store/*",
                 "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata",
-                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata/*"
+                "arn:aws:s3:::govukverify-self-service-${var.deployment}-config-metadata/*",
+                "arn:aws:s3:::govukverify-self-service-integration-config-metadata",
+                "arn:aws:s3:::govukverify-self-service-integration-config-metadata/*"
             ]
         }
     ]

--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -189,16 +189,13 @@ data "aws_iam_policy_document" "access_config_metadata" {
   statement {
     sid       = "AllowGetAndPutObject"
     effect    = "Allow"
-    resources = [
-      "${aws_s3_bucket.config_metadata.arn}/*",
-      "${data.aws_ssm_parameter.integration_metadata_bucket.value}/*"
-    ]
+    resources = ["${concat(local.config_metadata_buckets_arns, var.additional_buckets)}"]
 
     actions = [
-      "s3:GetO*",
-      "s3:PutO*",
-      "s3:DeleteO*",
-      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket"
     ]
   }
 }
@@ -211,8 +208,4 @@ resource "aws_iam_policy" "access_config_metadata" {
 resource "aws_iam_role_policy_attachment" "task_access_metadata_bucket_attachment" {
   role       = "${aws_iam_role.self_service_task.name}"
   policy_arn = "${aws_iam_policy.access_config_metadata.arn}"
-}
-
-data "aws_ssm_parameter" "integration_metadata_bucket" {
-  name = "/staging/${local.service}/integration-bucket-arn"
 }

--- a/terraform/modules/self-service/site.tf
+++ b/terraform/modules/self-service/site.tf
@@ -1,5 +1,9 @@
 locals {
-  service = "self-service"
+  service                      = "self-service"
+  config_metadata_buckets_arns = [
+    "${aws_s3_bucket.config_metadata.arn}",
+    "${aws_s3_bucket.config_metadata.arn}/*"
+  ]
 }
 
 data "aws_region" "region" {}

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -52,3 +52,9 @@ variable "image_digest" {}
 variable "hub_environments" {
   description = "JSON string of hub environments and the config metadata buckets"
 }
+
+variable "additional_buckets" {
+  description = "Additional bucket ARNs which the app will publish to"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
- Be more explicit about permissions
- Stop using the parameter store. The bucket ARN is probably not a secret.
- Add integration bucket to the S3 endpoint policy
- Remove the route table ids output as we no longer need to create a self service specific s3 endpoint

https://trello.com/c/PMZorhCM/634-add-permission-for-app-in-staging-to-publish-to-integration-bucket