### PR TITLE
5CR1WpE4: RP truststore enabled flag for saml-soap-proxy

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -70,6 +70,10 @@
       {
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+      },
+      {
+        "Name": "RP_TRUSTSTORE_ENABLED",
+        "Value": "${rp_truststore_enabled}"
       }
     ]
   }

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -68,6 +68,7 @@ data "template_file" "saml_soap_proxy_task_def" {
     region                        = "${data.aws_region.region.id}"
     account_id                    = "${data.aws_caller_identity.account.account_id}"
     event_emitter_api_gateway_url = "${var.event_emitter_api_gateway_url}"
+    rp_truststore_enabled         = "${var.rp_truststore_enabled}"
   }
 }
 


### PR DESCRIPTION
We need to stop validating against the RP truststore in saml-soap-proxy, so that RPs can use self-signed certificates.