### PR TITLE
set cognito temporary password expiry to 1 day

### DIFF
--- a/terraform/modules/self-service/cognito.tf
+++ b/terraform/modules/self-service/cognito.tf
@@ -7,6 +7,7 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
+    unused_account_validity_days = 1
   }
 
   password_policy {
@@ -66,6 +67,8 @@ resource "aws_cognito_user_pool" "user_pool" {
     ignore_changes = [
       "mfa_configuration"
     ]
+    
+    prevent_destroy = true
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.self-service.aws_cognito_user_pool.user_pool
      admin_create_user_config.0.unused_account_validity_days: "7" => "1"

Plan: 0 to add, 1 to change, 0 to destroy.