### PR TITLE
DO NOT MERGE: temporary_password_validity_days

### DIFF
--- a/terraform/modules/self-service/cognito.tf
+++ b/terraform/modules/self-service/cognito.tf
@@ -7,7 +7,8 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
-    unused_account_validity_days = 1
+    unused_account_validity_days = 0
+    temporary_password_validity_days = 1
   }
 
   password_policy {
@@ -67,7 +68,7 @@ resource "aws_cognito_user_pool" "user_pool" {
     ignore_changes = [
       "mfa_configuration"
     ]
-    
+
     prevent_destroy = true
   }
 


### PR DESCRIPTION
based on open PR: https://github.com/terraform-providers/terraform-provider-aws/pull/8845

temporary_password_validity_days can now be specified in a password policy in an aws_cognito_user_pool.
One gotcha is that to use the new field in combination with admin_create_user_config fields
you will need to specify the deprecated admin_create_user_config.unused_account_validity_days to 0. Or else you will get an AWS API error that advises you to use the new password_policy.temporary_password_validity_days field.