### PR TITLE
Revert "set cognito temporary password expiry to 1 day"

### DIFF
--- a/terraform/modules/self-service/cognito.tf
+++ b/terraform/modules/self-service/cognito.tf
@@ -7,7 +7,6 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
-    unused_account_validity_days = 1
   }
 
   password_policy {
@@ -67,7 +66,7 @@ resource "aws_cognito_user_pool" "user_pool" {
     ignore_changes = [
       "mfa_configuration"
     ]
-    
+
     prevent_destroy = true
   }
 


### PR DESCRIPTION
Reverts alphagov/verify-infrastructure#281

This has been reverted because **unused_account_validity_days** is being deprecated
temporary_password_validity_days is now recommended however there is an

open PR https://github.com/terraform-providers/terraform-provider-aws/pull/8845

and a [DO NOT MERGE](https://github.com/alphagov/verify-infrastructure/pull/282) PR to address this