### PR TITLE
Self Service variables default values

### DIFF
--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -4,15 +4,18 @@ variable "deployment" {
 
 variable "domain" {
   description = "Domain on which the app is hosted"
+  default     = ""
 }
 
 variable "ssl_certificate_arn" {
   description = "ARN for the SSL certificate"
+  default     = ""
 }
 
 variable "accessible_from_cidrs" {
   description = "Accessible from CIDRs"
-  type = "list"
+  type        = "list"
+  default     = []
 }
 
 data "aws_caller_identity" "account" {}
@@ -47,10 +50,13 @@ variable "asset_host" {
   default     = "gds-verify-self-service-assets.s3.amazonaws.com"
 }
 
-variable "image_digest" {}
+variable "image_digest" {
+  default = ""
+}
 
 variable "hub_environments" {
   description = "JSON string of hub environments and the config metadata buckets"
+  default     = ""
 }
 
 variable "additional_buckets" {


### PR DESCRIPTION
Certain environments only have specific components of the self service infrastructure deployed to them. Setting default values allows the terraform to initialize without values being passed in.

https://trello.com/c/GbR4zJgK/568-terraform-cognito-for-self-service-development-environment-in-hub