### PR TITLE
Temporary Password Validity Days

### DIFF
--- a/terraform/modules/self-service/cognito.tf
+++ b/terraform/modules/self-service/cognito.tf
@@ -73,6 +73,10 @@ resource "aws_cognito_user_pool" "user_pool" {
   provisioner "local-exec" {
     command = "aws cognito-idp set-user-pool-mfa-config --user-pool-id ${aws_cognito_user_pool.user_pool.id} --software-token-mfa-configuration Enabled=true --mfa-configuration OPTIONAL"
   }
+
+  provisioner "local-exec" {
+    command = "aws cognito-idp update-user-pool --user-pool-id  ${aws_cognito_user_pool.user_pool.id} --admin-create-user-config {'TemporaryPasswordValidityDays': 1}"
+  }
 }
 
 resource "aws_cognito_user_pool_client" "client" {


### PR DESCRIPTION
Alternate implementation to the the trello card
[Set Cognito temporary password expiry to 1 day](https://trello.com/c/A0wglRIe/625-set-cognito-temporary-password-expiry-to-1-day)

The default is 7 days. For security reasons this should be set to the
minimum possible value, which is 1 day.