### PR TITLE
Serve static files in Self Service app

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -14,6 +14,7 @@ locals  {
     asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
     sentry_dsn            = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
     hub_environments      = "${var.hub_environments}"
+    serve_static_files    = "${var.serve_static_files}"
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -59,6 +59,10 @@
         {
           "name": "HUB_ENVIRONMENTS",
           "value": "${hub_environments}"
+        },
+        {
+          "name": "RAILS_SERVE_STATIC_FILES",
+          "value": "${serve_static_files}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -64,3 +64,7 @@ variable "additional_buckets" {
   type        = "list"
   default     = []
 }
+
+variable "serve_static_files" {
+  default = true
+}


### PR DESCRIPTION
We want to serve the robots.txt file added in [this PR](https://github.com/alphagov/verify-self-service/pull/157)

https://trello.com/c/y02L98Wo/643-add-robotstxt