### PR TITLE
TfEzFC4W implement cross domain google analytics tracking config variables

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -132,6 +132,12 @@
     }, {
       "Name": "RAILS_LOG_TO_STDOUT",
       "Value": "true"
+    }, {
+      "Name": "CROSS_GOV_GOOGLE_ANALYTICS_TRACKER_ID",
+      "Value": "${cross_gov_ga_tracker_id}"
+    }, {
+      "Name": "CROSS_GOV_GOOGLE_ANALYTICS_DOMAIN_LIST",
+      "Value": "${cross_gov_ga_domain_names}"
     }]
   }
 ]

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -55,18 +55,20 @@ data "template_file" "frontend_task_def" {
   template = "${file("${path.module}/files/tasks/frontend.json")}"
 
   vars {
-    account_id             = "${data.aws_caller_identity.account.account_id}"
-    deployment             = "${var.deployment}"
-    image_identifier       = "${local.tools_account_ecr_url_prefix}-verify-frontend@${var.hub_frontend_image_digest}"
-    nginx_image_identifier = "${local.nginx_image_identifier}"
-    domain                 = "${local.root_domain}"
-    region                 = "${data.aws_region.region.id}"
-    location_blocks_base64 = "${local.location_blocks_base64}"
-    zendesk_username       = "${var.zendesk_username}"
-    zendesk_url            = "${var.zendesk_url}"
-    matomo_site_id         = "${var.matomo_site_id}"
-    ab_test_file           = "${var.ab_test_file}"
-    analytics_endpoint     = "${var.analytics_endpoint}"
+    account_id                = "${data.aws_caller_identity.account.account_id}"
+    deployment                = "${var.deployment}"
+    image_identifier          = "${local.tools_account_ecr_url_prefix}-verify-frontend@${var.hub_frontend_image_digest}"
+    nginx_image_identifier    = "${local.nginx_image_identifier}"
+    domain                    = "${local.root_domain}"
+    region                    = "${data.aws_region.region.id}"
+    location_blocks_base64    = "${local.location_blocks_base64}"
+    zendesk_username          = "${var.zendesk_username}"
+    zendesk_url               = "${var.zendesk_url}"
+    matomo_site_id            = "${var.matomo_site_id}"
+    ab_test_file              = "${var.ab_test_file}"
+    analytics_endpoint        = "${var.analytics_endpoint}"
+    cross_gov_ga_account_id   = "${var.cross_gov_ga_tracker_id}"
+    cross_gov_ga_domain_names = "${var.cross_gov_ga_domain_names}"
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -89,6 +89,16 @@ variable "self_service_enabled" {
   default     = "false"
 }
 
+variable "cross_gov_ga_account_id" {
+  description = "The Google Analytics account ID for GOV.UK cross domain analysis"
+  default     = ""
+}
+
+variable "cross_gov_ga_domain_names" {
+  description = "List of (space delimited) domains to automatically enable links for cross-domain analytics"
+  default     = ""
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -95,7 +95,7 @@ variable "cross_gov_ga_tracker_id" {
 }
 
 variable "cross_gov_ga_domain_names" {
-  description = "List of (space delimited) domains to automatically enable links for cross-domain analytics"
+  description = "List of (space delimited) domains to automatically enable links and forms for cross-domain analytics"
   default     = "www.gov.uk"
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -89,14 +89,14 @@ variable "self_service_enabled" {
   default     = "false"
 }
 
-variable "cross_gov_ga_account_id" {
-  description = "The Google Analytics account ID for GOV.UK cross domain analysis"
+variable "cross_gov_ga_tracker_id" {
+  description = "The Google Analytics tracker ID for GOV.UK cross domain analysis"
   default     = ""
 }
 
 variable "cross_gov_ga_domain_names" {
   description = "List of (space delimited) domains to automatically enable links for cross-domain analytics"
-  default     = ""
+  default     = "www.gov.uk"
 }
 
 variable "hub_config_image_digest" {}


### PR DESCRIPTION
## What

We need to implement some Google Analytics (GA) tracking code on the Hub.

This isn't because we're going to use GA for Verify analytics.

It's because GOV.UK is now implementing GA tracking across various x.gov.uk subdomains.

GDS needs to be able to track user journeys across campaign pages, GOV.UK content and transactions on the service domain.

Verify is part of these journeys, hence the need to get the GA code up and running on the Hub. 

## How
Add new variables to hub module that will contain GA config values.
Add cross domain config values to frontend task environment variables

Co-authored-by: Alex Gee <alexander.gee@digital.cabinet-office.gov.uk>