### PR TITLE
Move Self Service Cognito into a module

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -1,3 +1,7 @@
+locals {
+  service = "self-service"
+}
+
 resource "aws_cognito_user_pool" "user_pool" {
   name = "${local.service}-user-pool"
 

--- a/terraform/modules/self-service/site.tf
+++ b/terraform/modules/self-service/site.tf
@@ -18,3 +18,6 @@ data "terraform_remote_state" "hub" {
   }
 }
 
+module "cognito" {
+  source = "modules/cognito"
+}


### PR DESCRIPTION
We would like to be able to target just the cognito module for some environments.