### PR TITLE
Output cognito module ID's for Self Service

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -90,3 +90,12 @@ resource "aws_cognito_user_pool_client" "client" {
   supported_identity_providers = ["COGNITO"]
   refresh_token_validity       = 1
 }
+
+
+output "user_pool_client_id" {
+  value = "${aws_cognito_user_pool_client.client.id}"
+}
+
+output "user_pool_id" {
+  value = "${aws_cognito_user_pool.user_pool.id}"
+}


### PR DESCRIPTION
Now Cognito is a module we need to output these IDs in order for the ECS tasks to make use of them.