### PR TITLE
BAU: Ignore the unused_account_validity_days attribute

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -172,7 +172,7 @@ resource "aws_cognito_user_pool" "user_pool" {
       admin_create_user_config["unused_account_validity_days"]
     ]
 
-    prevent_destroy = false
+    prevent_destroy = true
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
As of now, the aws provider doesn't support setting this value. As a workaround
we'll be setting the value manually. Therefore we need to tell terraform to
ignore this manual change and stop trying to revert it back