### PR TITLE
Remove password complexity for Self Service app

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -104,10 +104,6 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   password_policy {
     minimum_length    = 8
-    require_uppercase = true
-    require_lowercase = true
-    require_numbers   = true
-    require_symbols   = false
   }
 
   schema {


### PR DESCRIPTION
[NCSC guidelines](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach#PasswordGuidance:UpdatingYourApproach-Donotusecomplexityrequirements) recommend that we do not enforce complex passwords for users, only a minimum number of characters.

<img width="302" alt="Screen Shot 2019-09-20 at 11 47 29" src="https://user-images.githubusercontent.com/3466862/65321661-b33cd400-db9c-11e9-8074-013c7e37f797.png">

https://trello.com/c/vfOQoNM3/676-remove-password-complexity