### PR TITLE
Ignore cognito user config lifecycle changes in Self Service

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -169,7 +169,10 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   lifecycle {
     ignore_changes = [
-      admin_create_user_config["unused_account_validity_days"]
+      # we need to ignore the entire admin_create_user_config block as it
+      # does not seem to be possible to ignore a specific attribute
+      # despite what the docs say
+      admin_create_user_config
     ]
 
     prevent_destroy = true


### PR DESCRIPTION
The `temporary_password_validity_days` attribute remains unsupported in Terraform. As described [in the docs](https://www.terraform.io/docs/configuration/resources.html#lifecycle-lifecycle-customizations) it should be possible to ignore a specific attribute for a given block but this does not seem to be the case in practice.