### PR TITLE
Use temporary validity password attribute in Self Service app

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -96,14 +96,11 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
-    # This is currently unsupported in terraform
-    # and is manually adjusted in the AWS console.
-    # Having it here makes sure we can ignore it.
-    unused_account_validity_days = 1
   }
 
   password_policy {
-    minimum_length    = 8
+    minimum_length                   = 8
+    temporary_password_validity_days = 1
   }
 
   schema {
@@ -164,13 +161,6 @@ resource "aws_cognito_user_pool" "user_pool" {
   }
 
   lifecycle {
-    ignore_changes = [
-      # we need to ignore the entire admin_create_user_config block as it
-      # does not seem to be possible to ignore a specific attribute
-      # despite what the docs say
-      admin_create_user_config
-    ]
-
     prevent_destroy = true
   }
 


### PR DESCRIPTION
AWS changed their cognito API and the old field `UnusedAccountValidityDays` is now TemporaryPasswordValidityDays. These translate to snake case alternatives in Terraform. The attribute now also exists in the password policy block instead of the admin user block.

Unfortunately the official provider may not be updated for a while.

In the mean time we have forked and updated our own AWS provider. This means we have created our own binary version and will be using that with the Self Service app until the official update happens.

We will be adding the use of the custom provider to the Self Service deployment pipeline.

[This corresponding infrastructure config PR](https://github.com/alphagov/verify-infrastructure-config/pull/202) will enforce the use of the custom provider.

Co-authored-by: Jakub Miarka jakub.miarka@digital.cabinet-office.gov.uk