### PR TITLE
AUT-198: Upgrade Journalbeat from v6.7.0 to v6.8.3

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -75,16 +75,16 @@ elastic_beats="artifacts.elastic.co/downloads/beats"
 mkdir -p /tmp/journalbeat
 cd /tmp/journalbeat
 
-cat <<EOF > journalbeat-oss-6.7.0-amd64.deb.sha512
-532c910eb3e2d37d04990a166d4930e1b9c7ea9139cadf1870022a6877066844480240a13b6a57433020b6e9c13a084e757e510d6d5d7a9a35783e94b51bddea  journalbeat-oss-6.7.0-amd64.deb
+cat <<EOF > journalbeat-oss-6.8.3-amd64.deb.sha512
+685e571638a3422e8b1c6f6aa7c15db8bf8fa9b91ecfedb4ce7c26dedc418e90b558a37711af2a547cb5025de17361d2fed1042be2d0871d22ec78037f7225a6  journalbeat-oss-6.8.3-amd64.deb
 EOF
 
 curl --silent --fail \
      -L -O \
-     "https://$elastic_beats/journalbeat/journalbeat-oss-6.7.0-amd64.deb"
+     "https://$elastic_beats/journalbeat/journalbeat-oss-6.8.3-amd64.deb"
 
-sha512sum -c journalbeat-oss-6.7.0-amd64.deb.sha512
-dpkg -i journalbeat-oss-6.7.0-amd64.deb
+sha512sum -c journalbeat-oss-6.8.3-amd64.deb.sha512
+dpkg -i journalbeat-oss-6.8.3-amd64.deb
 )
 
 cat <<EOF > /etc/journalbeat/journalbeat.yml

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -88,16 +88,16 @@ elastic_beats="artifacts.elastic.co/downloads/beats"
 mkdir -p /tmp/journalbeat
 cd /tmp/journalbeat
 
-cat <<EOF > journalbeat-oss-6.7.0-amd64.deb.sha512
-532c910eb3e2d37d04990a166d4930e1b9c7ea9139cadf1870022a6877066844480240a13b6a57433020b6e9c13a084e757e510d6d5d7a9a35783e94b51bddea  journalbeat-oss-6.7.0-amd64.deb
+cat <<EOF > journalbeat-oss-6.8.3-amd64.deb.sha512
+685e571638a3422e8b1c6f6aa7c15db8bf8fa9b91ecfedb4ce7c26dedc418e90b558a37711af2a547cb5025de17361d2fed1042be2d0871d22ec78037f7225a6  journalbeat-oss-6.8.3-amd64.deb
 EOF
 
 $CURL --silent --fail \
       -L -O \
-      "https://$elastic_beats/journalbeat/journalbeat-oss-6.7.0-amd64.deb"
+      "https://$elastic_beats/journalbeat/journalbeat-oss-6.8.3-amd64.deb"
 
-sha512sum -c journalbeat-oss-6.7.0-amd64.deb.sha512
-dpkg -i journalbeat-oss-6.7.0-amd64.deb
+sha512sum -c journalbeat-oss-6.8.3-amd64.deb.sha512
+dpkg -i journalbeat-oss-6.8.3-amd64.deb
 )
 
 cat <<EOF > /etc/journalbeat/journalbeat.yml


### PR DESCRIPTION
Journalbeat v6.7.0 is sending duplicate entries to Logit which makes more difficult for Support team to investigate issues. This change upgrades Journalbeat from v6.7.0 to v6.8.3 to stop sending duplicate entries. The other changes are as follows:

Beats v6.8.3
- [Bugfixes] Iterate over journal correctly, so no duplicate entries are sent.

Beats v6.8.1
- [Bugfixes] Fixed a memory leak when using the add_process_metadata processor under Windows.

Beats v6.8.0
- Updates to support changes to licensing of security features.

Beats v6.7.2
- [Bugfixes] Relax validation of the X-Pack license UID value.
- [Bugfixes] Fix a parsing error with the X-Pack license check on 32-bit system.
- [Bugfixes] Fix OS family classification in add_host_metadata for Amazon Linux, Raspbian, and RedHat Linux.
- [Bugfixes] Fix false positives reported in the host.containerized field added by add_host_metadata.
- [Bugfixes] Fix the add_host_metadata’s host.id field on older Linux versions.

Beats v6.7.1
- [Breaking changes] Initialize the Paths before the keystore and save the keystore into data/{beatname}.keystore.
- [Bugfixes] Remove IP fields from default_field in Elasticsearch template.

Source: https://www.elastic.co/guide/en/beats/libbeat/6.8/release-notes-6.8.3.html

Author: @adityapahuja