### PR TITLE
zfVNkzhm: Allow suppling the db command

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -8,6 +8,7 @@ locals  {
     database_password_arn = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/db-master-password"
     database_host         = "${aws_db_instance.self_service.address}"
     database_name         = "${aws_db_instance.self_service.name}"
+    db_command            = "${var.db_command}"
     cognito_client_id     = "${module.cognito.user_pool_client_id}"
     cognito_user_pool_id  = "${module.cognito.user_pool_id}"
     asset_host            = "${var.asset_host}"

--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -14,7 +14,7 @@
         "bundle",
         "exec",
         "rails",
-        "db:migrate"
+        "db:${db_command}"
       ],
       "environment": [
         {

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -45,6 +45,11 @@ variable "db_username" {
   default     = "postgres"
 }
 
+variable "db_command" {
+  description = "Command to run during the DB migration step, e.g. `bundle exec rails db:<value>`"
+  default     = "migrate"
+}
+
 variable "asset_host" {
   description = "Host where the static assets are hosted"
   default     = "gds-verify-self-service-assets.s3.amazonaws.com"


### PR DESCRIPTION
The way terraform is currently set up means that the DB migration task shares the command across all the environments. Meaning that if we wanted to for example drop a database in production, it will drop it in all the environments as it goes through the pipeline.

We should be able to specify the command per-environment basis. It's essential especially when spinning up a new environment where we want to run the `db:setup` command.

This adds a new variable with a default of `migrate`. It will now allow us to
supply a different command per deployment.