### PR TITLE
BAU: Use default ssl_session_timeout

### DIFF
--- a/dockerfiles/nginx-tls/nginx.conf.tpl
+++ b/dockerfiles/nginx-tls/nginx.conf.tpl
@@ -25,7 +25,6 @@ http {
     ssl_certificate     /tmp/tls/cert.pem;
     ssl_certificate_key /tmp/tls/key.pem;
     ssl_session_cache   shared:SSL:1m;
-    ssl_session_timeout 1m;
 
     $location_blocks
   }


### PR DESCRIPTION
Setting ssl_session_timeout to 1 minute seems too low. This change removes `ssl_session_timeout 1m` from nginx config file to get nginx to use 5 minutes (default value) for ssl_session_timeout. This may help to reduce 502 errors seen in staging and integration environments.

Author: @adityapahuja