### PR TITLE
Fix dodgy bash pipeline

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -153,7 +153,7 @@ if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
   echo "volume /dev/$vol is mounted ; writing fstab entry"
 
   if grep -qv "/dev/$vol" /etc/fstab ; then
-    UUID=$(ls -l /dev/disk/by-uuid | grep $vol | cut -d' ' -f9)
+    UUID=$(blkid /dev/$vol -s UUID -o value)
     echo "UUID=$UUID /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
   fi
 fi


### PR DESCRIPTION
We want to find the UUID of a disk.  We have `ls -l` and `grep` and
`cut`.  However, this broke this month because the output of ls looks
like

```
total 0
lrwxrwxrwx 1 root root 13 Oct  3 12:40 5c536736-16cc-45be-a7bf-925182515ad3 -> ../../nvme0n1
lrwxrwxrwx 1 root root 15 Oct  3 12:40 651cda91-e465-4685-b697-67aa07181279 -> ../../nvme1n1p1
```

The problem is that `Oct  3` has two spaces, so that `cut -f9` now
thinks there is an extra field in the output, and thinks that `12:40`
is the UUID.

The fix is to use a less flaky tool, `blkid`, which allows us to
directly query for the UUID of the disk.

Co-authored-by: Alex Monk <alex.monk@digital.cabinet-office.gov.uk>