### PR TITLE
Disable Cognito seeder and Integrity checker for migrations

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -22,6 +22,14 @@
           "value": "production"
         },
         {
+          "name": "DISABLE_COGNITO_SEEDING",
+          "value": "true"
+        },
+        {
+          "name": "DISABLE_INTEGRITY_CHECKER",
+          "value": "true"
+        },
+        {
           "name": "AWS_COGNITO_CLIENT_ID",
           "value": "${cognito_client_id}"
         },


### PR DESCRIPTION
We don't want to run these during migrations as they're not essential and
also they might actually be dependent on the migration, so should happen afterwards
with the normal app start.