### PR TITLE
O80814Xg: Add content to the Cognito invitation email

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -1,3 +1,8 @@
+variable "domain" {
+  description = "Domain on which the app is hosted"
+  default     = "localhost:3000"
+}
+
 locals {
   service = "self-service"
 }
@@ -96,6 +101,30 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
+    invite_message_template {
+      email_subject = "You have been invited to collaborate on the GOV.UK Verify Manage certificates service"
+      email_message = <<-EOT
+        Dear {username}
+
+        You have been invited to collaborate on the GOV.UK Verify Manage certificates service.
+
+        Sign in at ${var.domain} using the following temporary password:
+
+        {####}
+
+        You will be asked to create a new password and set up multi-factor authentication using your preferred authentication app.
+
+        Please sign in within 24 hours, otherwise the temporary password will expire.
+
+        If you miss this deadline, contact your admin to ask for another temporary password.
+
+        Thanks
+
+        The GOV.UK Verify team
+        https://www.verify.service.gov.uk/
+      EOT
+      sms_message = "Sign in at ${var.domain} using the following temporary password {####} and your email {username}."
+    }
   }
 
   password_policy {

--- a/terraform/modules/self-service/site.tf
+++ b/terraform/modules/self-service/site.tf
@@ -20,4 +20,5 @@ data "terraform_remote_state" "hub" {
 
 module "cognito" {
   source = "./modules/cognito"
+  domain = var.domain
 }


### PR DESCRIPTION
As per the content design adding the email content. The SMS is not used but it's required by AWS.
I have added the default domain variable, since the cognito module is called directly
in the development environment. For all the other ones the domain variable is already present.