### PR TITLE
BAU: Add a dependency between nginx and frontend

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -16,6 +16,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "frontend",
+        "condition": "SUCCESS"
+      }
     ]
   },
   {


### PR DESCRIPTION
AWS ECS introduced Enhanced Container Dependency Management on 7th March 2019. This commit update frontend task definition to include a dependency between nginx and frontend. This will ensure that nginx comes up after the frontend is up and running.

Author: @adityapahuja