### PR TITLE
BAU: Update to use healthy instead of success

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -20,7 +20,7 @@
     "dependsOn": [
       {
         "containerName": "frontend",
-        "condition": "SUCCESS"
+        "condition": "HEALTHY"
       }
     ]
   },


### PR DESCRIPTION
AWS threw the following error.
`A dependency container with SUCCESS or COMPLETE condition cannot be an essential container`

Frontend container is an essential container and SUCCESS or COMPLETE cannot be used to apply to the container.

This commit updates to use HEALTHY instead of SUCCESS which can be applied to the essential container. There is an example in AWS documentation which shows the use of healthy applied to an essential container.

Source:  https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_task_definitions.html#example_task_definition-containerdependency.

Author: @adityapahuja