### PR TITLE
BAU: Add a healthcheck to frontend container

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -144,6 +144,15 @@
     }, {
       "Name": "CROSS_GOV_GOOGLE_ANALYTICS_DOMAIN_LIST",
       "Value": "${cross_gov_ga_domain_names}"
-    }]
+    }],
+    "healthCheck" : [
+      {
+        "Command": "curl -sfm10 localhost:8080/cookies",
+        "Interval": 10,
+        "Retries": 3,
+        "StartPeriod": 30,
+        "Timeout": 5
+      }
+    ]
   }
 ]


### PR DESCRIPTION
AWS threw the following error message.
`A dependency container with HEALTHY condition must have health check configured`

There is no healthcheck in frontend container. This commit adds a healthcheck to the container to resolve this error.

Author: @adityapahuja