### PR TITLE
BAU: Fix JSON format error

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -147,7 +147,7 @@
     }],
     "healthCheck" : [
       {
-        "Command": ["curl -sfm10 localhost:8080/cookies"],
+        "Command": [ "CMD-SHELL", "curl -sfm10 http://localhost:8080/cookies || exit 1" ],
         "Interval": 10,
         "Retries": 3,
         "StartPeriod": 30,

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -147,7 +147,7 @@
     }],
     "healthCheck" : [
       {
-        "Command": "curl -sfm10 localhost:8080/cookies",
+        "Command": ["curl -sfm10 localhost:8080/cookies"],
         "Interval": 10,
         "Retries": 3,
         "StartPeriod": 30,


### PR DESCRIPTION
AWS threw the following error.
`ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal array into Go struct field ContainerDefinition.HealthCheck of type ecs.HealthCheck`

According to AWS documentation (https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html), Command should have a string array. This commit updates to change Command's type from string to string array.

Author: @adityapahuja