### PR TITLE
BAU: Fix JSON format error

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -145,14 +145,12 @@
       "Name": "CROSS_GOV_GOOGLE_ANALYTICS_DOMAIN_LIST",
       "Value": "${cross_gov_ga_domain_names}"
     }],
-    "healthCheck" : [
-      {
-        "Command": [ "CMD-SHELL", "curl -sfm10 http://localhost:8080/cookies || exit 1" ],
-        "Interval": 10,
-        "Retries": 3,
-        "StartPeriod": 30,
-        "Timeout": 5
-      }
-    ]
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -sfm10 http://localhost:8080/cookies || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 30,
+      "Timeout": 5
+    }
   }
 ]


### PR DESCRIPTION
There was an error message.
`ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal array into Go struct field ContainerDefinition.HealthCheck of type ecs.HealthCheck`

It means that the healthcheck should be an object and not an array of objects. This commit fixes this.

Author: @adityapahuja