### PR TITLE
BAU: Fix nginx permission error

### DIFF
--- a/dockerfiles/nginx-tls/nginx.conf.tpl
+++ b/dockerfiles/nginx-tls/nginx.conf.tpl
@@ -10,6 +10,12 @@ http {
   tcp_nopush   on;
   server_names_hash_bucket_size 128;
 
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path       /tmp/proxy_temp_path;
+  fastcgi_temp_path     /tmp/fastcgi_temp;
+  uwsgi_temp_path       /tmp/uwsgi_temp;
+  scgi_temp_path        /tmp/scgi_temp;
+
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
 


### PR DESCRIPTION
Nginx is throwing the following error message.

`nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`

This commit reconfigures nginx to use writable directories to resolve the permission error. Please see an example under Running nginx as a non-root user in https://hub.docker.com/_/nginx.

Author: @adityapahuja