### PR TITLE
BAU: Add dependency between nginx and Hub applications

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -149,7 +149,7 @@
       "Command": [ "CMD-SHELL", "curl -sfm10 http://localhost:8080/cookies || exit 1" ],
       "Interval": 10,
       "Retries": 3,
-      "StartPeriod": 30,
+      "StartPeriod": 10,
       "Timeout": 5
     }
   }

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -17,6 +17,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "config",
+        "condition": "HEALTHY"
+      }
     ]
   },
   {
@@ -75,6 +81,13 @@
         "Name": "METADATA_OBJECT_KEY",
         "Value": "${metadata_object_key}"
       }
-    ]
+    ],
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -f http://localhost:8080/service-status || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 10,
+      "Timeout": 5
+    }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -17,6 +17,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "policy",
+        "condition": "HEALTHY"
+      }
     ]
   },
   {
@@ -75,6 +81,13 @@
         "Name": "JAVA_OPTS",
         "Value": "-Dservice.name=policy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       }
-    ]
+    ],
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -f http://localhost:8080/service-status || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 10,
+      "Timeout": 5
+    }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -17,6 +17,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "saml-engine",
+        "condition": "HEALTHY"
+      }
     ]
   },
   {
@@ -87,6 +93,13 @@
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
       }
-    ]
+    ],
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -f http://localhost:8080/service-status || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 10,
+      "Timeout": 5
+    }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -17,6 +17,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "saml-proxy",
+        "condition": "HEALTHY"
+      }
     ]
   },
   {
@@ -75,6 +81,13 @@
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
       }
-    ]
+    ],
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -f http://localhost:8080/service-status || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 10,
+      "Timeout": 5
+    }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -17,6 +17,12 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "saml-soap-proxy",
+        "condition": "HEALTHY"
+      }
     ]
   },
   {
@@ -75,6 +81,13 @@
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
       }
-    ]
+    ],
+    "healthCheck" : {
+      "Command": [ "CMD-SHELL", "curl -f http://localhost:8080/service-status || exit 1" ],
+      "Interval": 10,
+      "Retries": 3,
+      "StartPeriod": 10,
+      "Timeout": 5
+    }
   }
 ]


### PR DESCRIPTION
AWS ECS introduced Enhanced Container Dependency Management on 7th March 2019. There is already a dependency between nginx and frontend and it helps to reduce 502 errors further. This commit adds dependency between nginx and remaining hub applications. This will ensure that nginx does not send requests to applications not running (i.e. nginx should start sending requests to applications after they are up and running).

Author: @adityapahuja