### PR TITLE
BAU: Specify CPU and Memory requirements

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -49,6 +49,8 @@ resource "aws_ecs_task_definition" "analytics" {
   container_definitions = data.template_file.analytics_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
+  cpu                   = 924
+  memory                = 250
 }
 
 resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https" {

--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -20,6 +20,8 @@ resource "aws_ecs_task_definition" "beat_exporter" {
   container_definitions = data.template_file.beat_exporter_task_def.rendered
   execution_role_arn    = module.beat_exporter_ecs_roles.execution_role_arn
   network_mode          = "host"
+  cpu                   = 100
+  memory                = 64
 }
 
 locals {

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -20,6 +20,8 @@ resource "aws_ecs_task_definition" "cloudwatch_exporter" {
   family                = "${var.deployment}-cloudwatch-exporter"
   container_definitions = data.template_file.cloudwatch_exporter_task_def.rendered
   execution_role_arn    = module.cloudwatch_exporter_ecs_roles.execution_role_arn
+  cpu                   = 462
+  memory                = 1024
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -160,6 +160,8 @@ resource "aws_ecs_task_definition" "egress_proxy" {
   family                = "${var.deployment}-egress-proxy"
   container_definitions = data.template_file.egress_proxy_task_def.rendered
   execution_role_arn    = module.egress_proxy_ecs_roles.execution_role_arn
+  cpu                   = 1024
+  memory                = 3500
 }
 
 resource "aws_ecs_service" "egress_proxy" {

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/beat-exporter.json
+++ b/terraform/modules/hub/files/tasks/beat-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "beat-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 100,
     "memory": 64,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "cloudwatch-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 462,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -27,7 +27,7 @@
   {
     "name": "frontend",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3000,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "config",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "policy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-engine",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-proxy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 924,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "metadata-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 462,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -2,7 +2,7 @@
   {
     "name": "prometheus",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -2,7 +2,7 @@
   {
     "name": "squid",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -2,7 +2,7 @@
   {
     "name": "static-ingress",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": ${allocated_cpu},
     "memory": ${allocated_memory},
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -114,6 +114,8 @@ module "config" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.config_task_def.rendered
+  cpu                        = 1948
+  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -86,6 +86,8 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = data.template_file.frontend_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.frontend_ecs_roles.execution_role_arn
+  cpu                   = 1948
+  memory                = 3250
 }
 
 # This is called frontend_v2 because there was an old frontend service

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -32,6 +32,8 @@ resource "aws_ecs_task_definition" "metadata" {
   container_definitions = data.template_file.metadata_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
+  cpu                   = 1024
+  memory                = 250
 }
 
 resource "aws_ecs_service" "metadata" {

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -85,6 +85,8 @@ module "policy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.policy_task_def.rendered
+  cpu                        = 1948
+  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -65,6 +65,8 @@ module "saml_engine" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_engine_task_def.rendered
+  cpu                        = 1948
+  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -81,6 +81,8 @@ module "saml_proxy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_proxy_task_def.rendered
+  cpu                        = 1948
+  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -81,6 +81,8 @@ module "saml_soap_proxy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_soap_proxy_task_def.rendered
+  cpu                        = 1948
+  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -21,6 +21,8 @@ resource "aws_ecs_task_definition" "metadata_exporter" {
   family                = "${var.deployment}-metadata-exporter"
   container_definitions = data.template_file.metadata_exporter_task_def.rendered
   execution_role_arn    = module.metadata_exporter_ecs_roles.execution_role_arn
+  cpu                   = 462
+  memory                = 1024
 }
 
 resource "aws_ecs_service" "metadata_exporter" {

--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -21,6 +21,8 @@ resource "aws_ecs_task_definition" "cluster" {
   execution_role_arn    = module.cluster_ecs_roles.execution_role_arn
   task_role_arn         = module.cluster_ecs_roles.task_role_arn
   network_mode          = "bridge"
+  cpu                   = var.cpu
+  memory                = var.memory
 }
 
 output "task_role_name" {

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -4,6 +4,8 @@ variable "container_port" {}
 variable "deployment" {}
 variable "domain" {}
 variable "task_definition" {}
+variable "cpu" {}
+variable "memory" {}
 variable "vpc_id" {}
 variable "tools_account_id" {}
 variable "instance_security_group_id" {}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -453,6 +453,8 @@ resource "aws_ecs_task_definition" "prometheus" {
   container_definitions = element(data.template_file.prometheus_task_def.*.rendered, count.index)
   execution_role_arn    = module.prometheus_ecs_roles.execution_role_arn
   network_mode          = "host"
+  cpu                   = 1024
+  memory                = 3500
 
   volume {
     name      = "tsdb"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -95,6 +95,13 @@ module "static_ingress_can_connect_to_ingress_https" {
   port = 443
 }
 
+locals {
+  allocated_cpu_for_http     = 924
+  allocated_cpu_for_https    = 1024
+  allocated_memory_for_http  = 250
+  allocated_memory_for_https = 3000
+}
+
 data "template_file" "static_ingress_http_task_def" {
   template = file("${path.module}/files/tasks/static-ingress.json")
 
@@ -103,7 +110,8 @@ data "template_file" "static_ingress_http_task_def" {
     backend          = var.signin_domain
     bind_port        = 80
     backend_port     = 80
-    allocated_memory = 250
+    allocated_cpu    = local.allocated_cpu_for_http
+    allocated_memory = local.allocated_memory_for_http
   }
 }
 
@@ -115,7 +123,8 @@ data "template_file" "static_ingress_https_task_def" {
     backend          = var.signin_domain
     bind_port        = 443
     backend_port     = 443
-    allocated_memory = 3000
+    allocated_cpu    = local.allocated_cpu_for_https
+    allocated_memory = local.allocated_memory_for_https
   }
 }
 
@@ -133,12 +142,16 @@ resource "aws_ecs_task_definition" "static_ingress_http" {
   family                = "${var.deployment}-static-ingress-http"
   container_definitions = data.template_file.static_ingress_http_task_def.rendered
   execution_role_arn    = module.static_ingress_ecs_roles.execution_role_arn
+  cpu                   = local.allocated_cpu_for_http
+  memory                = local.allocated_memory_for_http
 }
 
 resource "aws_ecs_task_definition" "static_ingress_https" {
   family                = "${var.deployment}-static-ingress-https"
   container_definitions = data.template_file.static_ingress_https_task_def.rendered
   execution_role_arn    = module.static_ingress_ecs_roles.execution_role_arn
+  cpu                   = local.allocated_cpu_for_https
+  memory                = local.allocated_memory_for_https
 }
 
 resource "aws_ecs_cluster" "static-ingress" {


### PR DESCRIPTION
According to Amazon Elastic Container Service documentation, 1 virtual CPU is equal to 1024 CPU shares. Setting CPU to 0 in a container definition means that it needs 2 CPU shares. This CPU requirement is quite low. This commit updates all container definitions and task definitions to specify both CPU and memory requirements. This will ensure that each application gets a fair share of CPU and memory.

Author: @adityapahuja