### PR TITLE
BAU: Make log level configurable for frontend task

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -89,7 +89,7 @@
       "Value": "false"
     }, {
       "Name": "LOG_LEVEL",
-      "Value": "warn"
+      "Value": "${log_level}"
     }, {
       "Name": "RULES_DIRECTORY",
       "Value": "/verify-frontend/federation/configuration/idp-rules"

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -69,6 +69,7 @@ data "template_file" "frontend_task_def" {
     analytics_endpoint        = var.analytics_endpoint
     cross_gov_ga_tracker_id   = var.cross_gov_ga_tracker_id
     cross_gov_ga_domain_names = var.cross_gov_ga_domain_names
+    log_level                 = var.log_level
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -99,6 +99,11 @@ variable "cross_gov_ga_domain_names" {
   default     = "www.gov.uk"
 }
 
+variable "log_level" {
+  description = "Log level for Puma and Frontend applications"
+  default     = "warn"
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
This commit makes log level configurable for frontend task. This will allow us to set log level for a specific environment. This will enable us to investigate errors and fix them.

Author: @adityapahuja