### PR TITLE
BAU: Increase proxy buffer in Frontend Nginx

### DIFF
--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -45,6 +45,10 @@ locals {
     proxy_pass http://localhost:8080;
     proxy_set_header Host ${var.signin_domain};
     proxy_set_header X-Forwarded-Proto https;
+
+    proxy_buffer_size          128k;
+    proxy_buffers              4 256k;
+    proxy_busy_buffers_size    256k;
   }
   LOCATIONS
 


### PR DESCRIPTION
Before Nginx sends a response back to a visitor, it will cache the request it had to make from its upstream. However, there are limited buffers available to buffer such a response. If the HTTP headers contain more information than anticipated, those proxy buffers can get saturated and Nginx will drop the request with the following error message in its logs and send 502 error.

"[error] 21#21: *30889 upstream sent too big header while reading response header from upstream..."

This change increases Nginx’s proxy buffer from the default 4KB to 128KB enough to cache any backend response without posing a risk to a server. After all, that server now has to assign more memory to buffer each backend response.

Source: https://ma.ttias.be/nginx-proxy-upstream-sent-big-header-reading-response-header-upstream/

Author: @adityapahuja