### PR TITLE
BAU: Adjust permissions for self-service S3 bucket

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -194,6 +194,7 @@ data "aws_iam_policy_document" "access_config_metadata" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
+      "s3:PutObjectAcl",
       "s3:DeleteObject",
       "s3:ListBucket"
     ]


### PR DESCRIPTION
We're now setting ACL for objects being put in S3 buckets for self-service.
This change was made in [#268](https://github.com/alphagov/verify-self-service/pull/268).
This now requires one more permission.