### PR TITLE
BAU: Make Metadata Exporter's environment configurable

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -16,6 +16,9 @@
       "-c",
       "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment}"
     ],
-    "environment": []
+    "environment": [{
+      "Name": "APP_ENV",
+      "Value": "${environment}"
+    }]
   }
 ]

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -14,6 +14,7 @@ data "template_file" "metadata_exporter_task_def" {
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter@${var.metadate_exporter_image_digest}"
     signin_domain    = var.signin_domain
     deployment       = var.deployment
+    environment      = var.metadata_exporter_environment
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -104,6 +104,11 @@ variable "log_level" {
   default     = "warn"
 }
 
+variable "metadata_exporter_environment" {
+  description = "Metadata Exporter environment"
+  default     = "development"
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
According to Sinatra documentation (http://sinatrarb.com/configuration.html), not specifying either APP_ENV or :environment in Metadata Exporter causes it to use environment=development by default. This change makes Metadata Exporter's environment configurable so that we can specify it in different environments (e.g. staging, production, etc.).

Author: @adityapahuja