### PR TITLE
8Dakh37S: Use entrypoint.sh for starting up

### DIFF
--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -11,18 +11,9 @@
         }
       ],
       "entryPoint": [
-        "bundle",
-        "exec",
-        "rake",
-        "assets:precompile",
-        "&&",
-        "bundle",
-        "exec",
-        "puma",
-        "-p",
-        "8080",
-        "-b",
-        "tcp://0.0.0.0"
+        "/bin/sh",
+        "-c",
+        "./entrypoint.sh"
       ],
       "environment": [
         {


### PR DESCRIPTION
We want to run more than one command, so
it's better and more readable to just use a shell script.

For: https://github.com/alphagov/verify-self-service/pull/302