### PR TITLE
OFCDsnoA: Output the security group ID for config load balancer

### DIFF
--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -13,3 +13,7 @@ output "can_connect_to_container_vpc_endpoint" {
 output "public_subnet_ids" {
   value = aws_subnet.ingress.*.id
 }
+
+output "config_lb_sg_id" {
+  value = module.config.lb_sg_id
+}


### PR DESCRIPTION
We want the self-service app to communicate with the config service.
This requires a new rule in the config service load balancer security group.
This will output that ID so we can later use it to attach the new rule to it.

To be merged before https://github.com/alphagov/verify-infrastructure-config/pull/224