### PR TITLE
OFCDsnoA: Add a new security group rule to allow traffic from self-service to config service

### DIFF
--- a/terraform/modules/self-service/security_groups.tf
+++ b/terraform/modules/self-service/security_groups.tf
@@ -58,6 +58,20 @@ resource "aws_security_group" "egress_over_https" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group_rule" "self_service_ingress_to_config_lb" {
+  type     = "ingress"
+  protocol = "tcp"
+
+  from_port = 443
+  to_port   = 443
+
+  security_group_id        = data.terraform_remote_state.hub.outputs.config_lb_sg_id
+  source_security_group_id = aws_security_group.egress_over_https.id
+
+  description = "Allows traffic from self-service app to config"
+}
+
 resource "aws_security_group" "egress_to_db" {
   name        = "${local.service}-egress-to-db"
   description = "${local.service} security group connecting to self service db"


### PR DESCRIPTION
In order for the self-service app to communicate with the config service,
an additional rule needs to be added on the existing security group of the load
balancer on the config service.

Only merge after these two have been merged and applied across all environments:
https://github.com/alphagov/verify-infrastructure/pull/330
https://github.com/alphagov/verify-infrastructure-config/pull/224