### PR TITLE
OFCDsnoA: Add hub hostname as environment variable

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -1,4 +1,6 @@
 locals  {
+  hub_deployment = "${var.deployment == "prod" ? "" : "${var.deployment}." }"
+
   task_vars = {
     image_digest          = var.image_digest
     aws_bucket            = aws_s3_bucket.config_metadata.bucket
@@ -15,6 +17,7 @@ locals  {
     asset_prefix          = "${element(split(":", var.image_digest),1)}/assets/"
     sentry_dsn            = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
     hub_environments      = var.hub_environments
+    hub_config_host       = "https://config.${local.hub_deployment}${var.hub_host}:443"
   }
 }
 

--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -68,6 +68,10 @@
         {
           "name": "HUB_ENVIRONMENTS",
           "value": "${hub_environments}"
+        },
+        {
+          "name": "HUB_CONFIG_HOST",
+          "value": "${hub_config_host}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -55,6 +55,10 @@
         {
           "name": "HUB_ENVIRONMENTS",
           "value": "${hub_environments}"
+        },
+        {
+          "name": "HUB_CONFIG_HOST",
+          "value": "${hub_config_host}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -64,6 +64,11 @@ variable "hub_environments" {
   default     = ""
 }
 
+variable "hub_host" {
+  description = "The host for the Verify hub"
+  default     = "signin.service.gov.uk"
+}
+
 variable "additional_buckets" {
   description = "Additional bucket ARNs which the app will publish to"
   type        = "list"


### PR DESCRIPTION
So self-service knows where to call.

Required for https://github.com/alphagov/verify-self-service/pull/309