### PR TITLE
7BEyqDxp: Add the domain as environment variable

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -20,6 +20,7 @@ locals  {
     hub_config_host                    = "https://config.${local.hub_deployment}${var.hub_host}:443"
     notify_key                         = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/notify-key"
     self_service_authentication_header = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/authentication-header"
+    domain                             = var.domain
   }
 }
 

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -63,6 +63,10 @@
         {
           "name": "NOTIFY_KEY",
           "value": "${notify_key}"
+        },
+        {
+          "name": "APP_URL",
+          "value": "${domain}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
So self-service can send emails with the right domain.

Co-Authored-By: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>