### PR TITLE
HUH-234 add variables for 2019 short hub ABC test configuration

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -100,6 +100,12 @@
       "Name": "RULES_DIRECTORY_VARIANT",
       "Value": "/verify-frontend/federation/configuration/idp-rules-variant"
     }, {
+      "Name": "RULES_B_DIRECTORY",
+      "Value": "/verify-frontend/federation/configuration/idp-rules-variant-b"
+    }, {
+      "Name": "RULES_C_DIRECTORY",
+      "Value": "/verify-frontend/federation/configuration/idp-rules-variant-c"
+    }, {
       "Name": "RP_CONFIG",
       "Value": "/verify-frontend/federation/configuration/relying_parties.yml"
     }, {
@@ -112,8 +118,17 @@
       "Name": "AB_TEST_FILE",
       "Value": "/verify-frontend/federation/configuration/ab_test/${ab_test_file}"
     }, {
+      "Name": "ABC_VARIANTS_CONFIG",
+      "Value": "/verify-frontend/federation/configuration/special-cases/abc-variants.yml"
+    }, {
       "Name": "SEGMENT_DEFINITIONS",
       "Value": "/verify-frontend/federation/configuration/segment_definitions.yml"
+    }, {
+      "Name": "SEGMENT_DEFINITIONS_VARIANT_B",
+      "Value": "/verify-frontend/federation/configuration/segment_definitions_variant_b.yml"
+    }, {
+      "Name": "SEGMENT_DEFINITIONS_VARIANT_C",
+      "Value": "/verify-frontend/federation/configuration/segment_definitions_variant_c.yml"
     }, {
       "Name": "PUBLIC_PIWIK_HOST",
       "Value": "https://www.${domain}:443/analytics"


### PR DESCRIPTION
Adds:

* `RULES_B_DIRECTORY`
* `RULES_C_DIRECTORY`
* `ABC_VARIANTS_CONFIG`
* `SEGMENT_DEFINITIONS_VARIANT_B`
* `SEGMENT_DEFINITIONS_VARIANT_C`