### PR TITLE
BAU: Fix for missing env for migration task

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -72,6 +72,14 @@
         {
           "name": "HUB_CONFIG_HOST",
           "value": "${hub_config_host}"
+        },
+        {
+          "name": "NOTIFY_KEY",
+          "value": "${notify_key}"
+        },
+        {
+          "name": "APP_URL",
+          "value": "${domain}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
We've added two new environment variables to the app, but forget to update the migration
task with them.