### PR TITLE
BUGFIX: Notify key is a secret

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -74,10 +74,6 @@
           "value": "${hub_config_host}"
         },
         {
-          "name": "NOTIFY_KEY",
-          "value": "${notify_key}"
-        },
-        {
           "name": "APP_URL",
           "value": "${domain}"
         }
@@ -90,6 +86,10 @@
         {
           "name": "DATABASE_PASSWORD",
           "valueFrom": "${database_password_arn}"
+        },
+        {
+          "name": "NOTIFY_KEY",
+          "value": "${notify_key}"
         }
       ],
       "logConfiguration": {

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -61,10 +61,6 @@
           "value": "${hub_config_host}"
         },
         {
-          "name": "NOTIFY_KEY",
-          "value": "${notify_key}"
-        },
-        {
           "name": "APP_URL",
           "value": "${domain}"
         }
@@ -85,6 +81,10 @@
         {
           "name": "SELF_SERVICE_AUTHENTICATION_HEADER",
           "valueFrom": "${self_service_authentication_header}"
+        },
+        {
+          "name": "NOTIFY_KEY",
+          "value": "${notify_key}"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
It wasn't evaluating the SSM secret but just using the path. It needs to be in the secret section
to evaluate the actual value.