### PR TITLE
HJ6aAR9F: Add a fargate scheduled task

### DIFF
--- a/terraform/modules/self-service/cloudwatch.tf
+++ b/terraform/modules/self-service/cloudwatch.tf
@@ -1,3 +1,21 @@
 resource "aws_cloudwatch_log_group" "self_service" {
   name = local.service
 }
+
+resource "aws_cloudwatch_event_rule" "scheduler_rule" {
+  name                = "${var.deployment}-${local.service}-cert-expiry-scheduler-rule"
+  description         = "Run send_cert_expiry_reminder_emails task at a scheduled time"
+  # scheduled to run every day at 2am
+  schedule_expression = "cron(0 2 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "scheduler_target" {
+  target_id = "${var.deployment}-${local.service}-cert-expiry-scheduler-target"
+  rule      = aws_cloudwatch_event_rule.scheduler_rule.name
+  arn       = aws_ecs_cluster.cluster.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.scheduler_task_def.arn
+  }
+}

--- a/terraform/modules/self-service/cloudwatch.tf
+++ b/terraform/modules/self-service/cloudwatch.tf
@@ -13,6 +13,7 @@ resource "aws_cloudwatch_event_target" "scheduler_target" {
   target_id = "${var.deployment}-${local.service}-cert-expiry-scheduler-target"
   rule      = aws_cloudwatch_event_rule.scheduler_rule.name
   arn       = aws_ecs_cluster.cluster.arn
+  role_arn  = "${aws_iam_role.scheduled_task_cloudwatch.arn}"
 
   ecs_target {
     task_count          = 1

--- a/terraform/modules/self-service/cloudwatch.tf
+++ b/terraform/modules/self-service/cloudwatch.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_event_target" "scheduler_target" {
   target_id = "${var.deployment}-${local.service}-cert-expiry-scheduler-target"
   rule      = aws_cloudwatch_event_rule.scheduler_rule.name
   arn       = aws_ecs_cluster.cluster.arn
-  role_arn  = "${aws_iam_role.scheduled_task_cloudwatch.arn}"
+  role_arn  = aws_iam_role.self_service_scheduled_task_cloudwatch.arn
 
   ecs_target {
     task_count          = 1

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -24,6 +24,13 @@ locals  {
   }
 }
 
+resource "aws_iam_role_policy" "scheduled_task_cloudwatch_policy" {
+  name   = "${local.service}-${var.deployment}-st-cloudwatch-policy"
+  role   = "${aws_iam_role."self_service_scheduled_task_cloudwatch.id}"
+  policy = "${data.template_file.scheduled_task_cloudwatch_policy.rendered}"
+}
+
+
 resource "aws_ecs_cluster" "cluster" {
   name = local.service
 }

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -24,13 +24,6 @@ locals  {
   }
 }
 
-resource "aws_iam_role_policy" "scheduled_task_cloudwatch_policy" {
-  name   = "${local.service}-${var.deployment}-st-cloudwatch-policy"
-  role   = "${aws_iam_role."self_service_scheduled_task_cloudwatch.id}"
-  policy = "${data.template_file.scheduled_task_cloudwatch_policy.rendered}"
-}
-
-
 resource "aws_ecs_cluster" "cluster" {
   name = local.service
 }

--- a/terraform/modules/self-service/files/scheduler-task-def.json
+++ b/terraform/modules/self-service/files/scheduler-task-def.json
@@ -1,0 +1,104 @@
+[
+    {
+      "essential": true,
+      "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service@${image_digest}",
+      "memory": 1024,
+      "name": "self-service",
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080
+        }
+      ],
+      "entryPoint": [
+        "bundle",
+        "exec",
+        "rake",
+        "send_cert_expiry_reminder_emails"
+      ],
+      "environment": [
+        {
+          "name": "RAILS_ENV",
+          "value": "production"
+        },
+        {
+          "name": "DISABLE_COGNITO_SEEDING",
+          "value": "true"
+        },
+        {
+          "name": "DISABLE_INTEGRITY_CHECKER",
+          "value": "true"
+        },
+        {
+          "name": "AWS_COGNITO_CLIENT_ID",
+          "value": "${cognito_client_id}"
+        },
+        {
+          "name": "AWS_COGNITO_USER_POOL_ID",
+          "value": "${cognito_user_pool_id}"
+        },
+        {
+          "name": "AWS_REGION",
+          "value": "${region}"
+        },
+        {
+          "name": "AWS_COGNITO_CLIENT_ID",
+          "value": "${cognito_client_id}"
+        },
+        {
+          "name": "DATABASE_HOST",
+          "value": "${database_host}"
+        },
+        {
+          "name": "DATABASE_NAME",
+          "value": "${database_name}"
+        },
+        {
+          "name": "DATABASE_USERNAME",
+          "value": "${database_username}"
+        },
+        {
+          "name": "ASSET_HOST",
+          "value": "${asset_host}"
+        },
+        {
+          "name": "ASSET_PREFIX",
+          "value": "${asset_prefix}"
+        },
+        {
+          "name": "HUB_ENVIRONMENTS",
+          "value": "${hub_environments}"
+        },
+        {
+          "name": "HUB_CONFIG_HOST",
+          "value": "${hub_config_host}"
+        },
+        {
+          "name": "NOTIFY_KEY",
+          "value": "${notify_key}"
+        },
+        {
+          "name": "APP_URL",
+          "value": "${domain}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "SECRET_KEY_BASE",
+          "valueFrom": "${rails_secret_key_base}"
+        },
+        {
+          "name": "DATABASE_PASSWORD",
+          "valueFrom": "${database_password_arn}"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "self-service",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "self-service-scheduler"
+        }
+      }
+    }
+  ]

--- a/terraform/modules/self-service/files/scheduler-task-def.json
+++ b/terraform/modules/self-service/files/scheduler-task-def.json
@@ -74,10 +74,6 @@
           "value": "${hub_config_host}"
         },
         {
-          "name": "NOTIFY_KEY",
-          "value": "${notify_key}"
-        },
-        {
           "name": "APP_URL",
           "value": "${domain}"
         }
@@ -90,6 +86,14 @@
         {
           "name": "DATABASE_PASSWORD",
           "valueFrom": "${database_password_arn}"
+        },
+        {
+          "name": "SELF_SERVICE_AUTHENTICATION_HEADER",
+          "valueFrom": "${self_service_authentication_header}"
+        },
+        {
+          "name": "NOTIFY_KEY",
+          "valueFrom": "${notify_key}"
         }
       ],
       "logConfiguration": {

--- a/terraform/modules/self-service/files/scheduler-task-def.json
+++ b/terraform/modules/self-service/files/scheduler-task-def.json
@@ -3,7 +3,7 @@
       "essential": true,
       "image": "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service@${image_digest}",
       "memory": 1024,
-      "name": "self-service",
+      "name": "self-service-scheduler",
       "portMappings": [
         {
           "containerPort": 8080,

--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -22,6 +22,33 @@ resource "aws_iam_role" "self_service_execution" {
   EOF
 }
 
+resource "aws_iam_policy" "self_service_scheduled_task_cloudwatch" {
+  name               = "${local.service}-${var.deployment}-cloudwatch-role"
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecs:RunTask"
+        ],
+        "Resource": [
+          "*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": "iam:PassRole",
+        "Resource": [
+          "${task_execution_role_arn}"
+        ]
+      }
+    ]
+  }
+  EOF
+}
+
 resource "aws_iam_policy" "can_write_to_logs" {
   name = "${local.service}-can-write-to-logs"
 

--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -22,9 +22,29 @@ resource "aws_iam_role" "self_service_execution" {
   EOF
 }
 
-resource "aws_iam_policy" "self_service_scheduled_task_cloudwatch" {
-  name               = "${local.service}-${var.deployment}-cloudwatch-role"
+resource "aws_iam_role" "self_service_scheduled_task_cloudwatch" {
+  name               = "${local.service}-${var.deployment}-st-cloudwatch-role"
   assume_role_policy = <<-EOF
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+          "Service": "events.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "self_service_scheduled_task_cloudwatch_policy" {
+  name   = "${local.service}-${var.deployment}-st-cloudwatch-policy"
+  role   = aws_iam_role.self_service_scheduled_task_cloudwatch.id
+  policy = <<-EOF
   {
     "Version": "2012-10-17",
     "Statement": [
@@ -41,13 +61,14 @@ resource "aws_iam_policy" "self_service_scheduled_task_cloudwatch" {
         "Effect": "Allow",
         "Action": "iam:PassRole",
         "Resource": [
-          "${task_execution_role_arn}"
+          "${aws_iam_role.self_service_execution.arn}"
         ]
       }
     ]
   }
   EOF
 }
+
 
 resource "aws_iam_policy" "can_write_to_logs" {
   name = "${local.service}-can-write-to-logs"


### PR DESCRIPTION
This adds a new fargate task definition to run on a schedule in order to trigger the rake task
to send emails when certs expire.

The PR consists of:
- new ECS service and task definition for the scheduled rake
- a CloudWatch rules and target to trigger the task every day at 02:00 AM
- roles and policies for CloudWatch to trigger the task


`terraform plan`

```
Terraform will perform the following actions:

  # module.self-service.aws_cloudwatch_event_rule.scheduler_rule will be created
  + resource "aws_cloudwatch_event_rule" "scheduler_rule" {
      + arn                 = (known after apply)
      + description         = "Run send_cert_expiry_reminder_emails task at a scheduled time"
      + id                  = (known after apply)
      + is_enabled          = true
      + name                = "staging-self-service-cert-expiry-scheduler-rule"
      + schedule_expression = "cron(0 2 * * ? *)"
    }

  # module.self-service.aws_cloudwatch_event_target.scheduler_target will be created
  + resource "aws_cloudwatch_event_target" "scheduler_target" {
      + arn       = "arn:aws:ecs:eu-west-2:423528588951:cluster/self-service"
      + id        = (known after apply)
      + role_arn  = (known after apply)
      + rule      = "staging-self-service-cert-expiry-scheduler-rule"
      + target_id = "staging-self-service-cert-expiry-scheduler-target"

      + ecs_target {
          + launch_type         = "EC2"
          + task_count          = 1
          + task_definition_arn = (known after apply)
        }
    }

  # module.self-service.aws_ecs_task_definition.scheduler_task_def will be created
  + resource "aws_ecs_task_definition" "scheduler_task_def" {
      + arn                      = (known after apply)
      + container_definitions    = jsonencode(
            [
              + {
                  + entryPoint       = [
                      + "bundle",
                      + "exec",
                      + "rake",
                      + "send_cert_expiry_reminder_emails",
                    ]
                  + environment      = [
                      + {
                          + name  = "RAILS_ENV"
                          + value = "production"
                        },
                      + {
                          + name  = "DISABLE_COGNITO_SEEDING"
                          + value = "true"
                        },
                      + {
                          + name  = "DISABLE_INTEGRITY_CHECKER"
                          + value = "true"
                        },
                      + {
                          + name  = "AWS_COGNITO_CLIENT_ID"
                          + value = "4ighclse4944jcjgkl8jrermo3"
                        },
                      + {
                          + name  = "AWS_COGNITO_USER_POOL_ID"
                          + value = "eu-west-2_N9y3xDJYX"
                        },
                      + {
                          + name  = "AWS_REGION"
                          + value = "eu-west-2"
                        },
                      + {
                          + name  = "AWS_COGNITO_CLIENT_ID"
                          + value = "4ighclse4944jcjgkl8jrermo3"
                        },
                      + {
                          + name  = "DATABASE_HOST"
                          + value = "staging-self-service-db.cr5qoonjgkdq.eu-west-2.rds.amazonaws.com"
                        },
                      + {
                          + name  = "DATABASE_NAME"
                          + value = "selfservice"
                        },
                      + {
                          + name  = "DATABASE_USERNAME"
                          + value = "postgres"
                        },
                      + {
                          + name  = "ASSET_HOST"
                          + value = "gds-verify-self-service-assets.s3.amazonaws.com"
                        },
                      + {
                          + name  = "ASSET_PREFIX"
                          + value = "a/assets/"
                        },
                      + {
                          + name  = "HUB_ENVIRONMENTS"
                          + value = jsonencode(
                                {
                                  + staging = "govukverify-self-service-staging-config-metadata"
                                }
                            )
                        },
                      + {
                          + name  = "HUB_CONFIG_HOST"
                          + value = "https://config.staging.signin.service.gov.uk:443"
                        },
                      + {
                          + name  = "NOTIFY_KEY"
                          + value = "arn:aws:ssm:eu-west-2:423528588951:parameter/staging/self-service/notify-key"
                        },
                      + {
                          + name  = "APP_URL"
                          + value = "staging.admin.verify.service.gov.uk"
                        },
                    ]
                  + essential        = true
                  + image            = "753415395406.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-self-service@a"
                  + logConfiguration = {
                      + logDriver = "awslogs"
                      + options   = {
                          + awslogs-group         = "self-service"
                          + awslogs-region        = "eu-west-2"
                          + awslogs-stream-prefix = "self-service-scheduler"
                        }
                    }
                  + memory           = 1024
                  + name             = "self-service"
                  + portMappings     = [
                      + {
                          + containerPort = 8080
                          + hostPort      = 8080
                        },
                    ]
                  + secrets          = [
                      + {
                          + name      = "SECRET_KEY_BASE"
                          + valueFrom = "arn:aws:ssm:eu-west-2:423528588951:parameter/staging/self-service/rails-secret-key-base"
                        },
                      + {
                          + name      = "DATABASE_PASSWORD"
                          + valueFrom = "arn:aws:ssm:eu-west-2:423528588951:parameter/staging/self-service/db-master-password"
                        },
                    ]
                },
            ]
        )
      + cpu                      = "1024"
      + execution_role_arn       = "arn:aws:iam::423528588951:role/self-service-execution"
      + family                   = "self-service-scheduler"
      + id                       = (known after apply)
      + memory                   = "2048"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + task_role_arn            = "arn:aws:iam::423528588951:role/self-service-task"
    }

  # module.self-service.aws_iam_role.self_service_scheduled_task_cloudwatch will be created
  + resource "aws_iam_role" "self_service_scheduled_task_cloudwatch" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "events.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "self-service-staging-st-cloudwatch-role"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # module.self-service.aws_iam_role_policy.self_service_scheduled_task_cloudwatch_policy will be created
  + resource "aws_iam_role_policy" "self_service_scheduled_task_cloudwatch_policy" {
      + id     = (known after apply)
      + name   = "self-service-staging-st-cloudwatch-policy"
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ecs:RunTask",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "*",
                        ]
                    },
                  + {
                      + Action   = "iam:PassRole"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:iam::423528588951:role/self-service-execution",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role   = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```