### PR TITLE
G4akRQMR: Make certificate cache expiry configurable

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -92,6 +92,10 @@
       {
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
+      },
+      {
+        "Name": "CERTIFICATES_CONFIG_CACHE_EXPIRY",
+        "Value": "${certificates_config_cache_expiry}"
       }
     ],
     "healthCheck" : {

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -80,6 +80,10 @@
       {
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
+      },
+      {
+        "Name": "CERTIFICATES_CONFIG_CACHE_EXPIRY",
+        "Value": "${certificates_config_cache_expiry}"
       }
     ],
     "healthCheck" : {

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -80,6 +80,10 @@
       {
         "Name": "RP_TRUSTSTORE_ENABLED",
         "Value": "${rp_truststore_enabled}"
+      },
+      {
+        "Name": "CERTIFICATES_CONFIG_CACHE_EXPIRY",
+        "Value": "${certificates_config_cache_expiry}"
       }
     ],
     "healthCheck" : {

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -43,16 +43,17 @@ data "template_file" "saml_engine_task_def" {
   template = file("${path.module}/files/tasks/hub-saml-engine.json")
 
   vars = {
-    account_id             = data.aws_caller_identity.account.account_id
-    deployment             = var.deployment
-    domain                 = local.root_domain
-    image_identifier       = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
-    nginx_image_identifier = local.nginx_image_identifier
-    region                 = data.aws_region.region.id
-    location_blocks_base64 = local.nginx_saml_engine_location_blocks_base64
-    redis_host             = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
-    splunk_url             = var.splunk_url
-    rp_truststore_enabled  = var.rp_truststore_enabled
+    account_id                       = data.aws_caller_identity.account.account_id
+    deployment                       = var.deployment
+    domain                           = local.root_domain
+    image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
+    nginx_image_identifier           = local.nginx_image_identifier
+    region                           = data.aws_region.region.id
+    location_blocks_base64           = local.nginx_saml_engine_location_blocks_base64
+    redis_host                       = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
+    splunk_url                       = var.splunk_url
+    rp_truststore_enabled            = var.rp_truststore_enabled
+    certificates_config_cache_expiry = var.certificates_config_cache_expiry
   }
 }
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -60,15 +60,16 @@ data "template_file" "saml_proxy_task_def" {
   template = file("${path.module}/files/tasks/hub-saml-proxy.json")
 
   vars = {
-    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
-    nginx_image_identifier        = local.nginx_image_identifier
-    domain                        = local.root_domain
-    deployment                    = var.deployment
-    location_blocks_base64        = local.nginx_saml_proxy_location_blocks_base64
-    region                        = data.aws_region.region.id
-    account_id                    = data.aws_caller_identity.account.account_id
-    event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
-    rp_truststore_enabled         = var.rp_truststore_enabled
+    image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
+    nginx_image_identifier           = local.nginx_image_identifier
+    domain                           = local.root_domain
+    deployment                       = var.deployment
+    location_blocks_base64           = local.nginx_saml_proxy_location_blocks_base64
+    region                           = data.aws_region.region.id
+    account_id                       = data.aws_caller_identity.account.account_id
+    event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
+    rp_truststore_enabled            = var.rp_truststore_enabled
+    certificates_config_cache_expiry = var.certificates_config_cache_expiry
   }
 }
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -60,15 +60,16 @@ data "template_file" "saml_soap_proxy_task_def" {
   template = file("${path.module}/files/tasks/hub-saml-soap-proxy.json")
 
   vars = {
-    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
-    nginx_image_identifier        = local.nginx_image_identifier
-    domain                        = local.root_domain
-    deployment                    = var.deployment
-    location_blocks_base64        = local.nginx_saml_soap_proxy_location_blocks_base64
-    region                        = data.aws_region.region.id
-    account_id                    = data.aws_caller_identity.account.account_id
-    event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
-    rp_truststore_enabled         = var.rp_truststore_enabled
+    image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
+    nginx_image_identifier           = local.nginx_image_identifier
+    domain                           = local.root_domain
+    deployment                       = var.deployment
+    location_blocks_base64           = local.nginx_saml_soap_proxy_location_blocks_base64
+    region                           = data.aws_region.region.id
+    account_id                       = data.aws_caller_identity.account.account_id
+    event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
+    rp_truststore_enabled            = var.rp_truststore_enabled
+    certificates_config_cache_expiry = var.certificates_config_cache_expiry
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -104,6 +104,11 @@ variable "publish_hub_config_enabled" {
   default     = "false"
 }
 
+variable "certificates_config_cache_expiry" {
+  description = "Sets the expiry time of cache for certificates in saml-proxy, saml-engine and saml-soap-proxy"
+  default     = "5m"
+}
+
 variable "log_level" {
   description = "Log level for Puma and Frontend applications"
   default     = "warn"


### PR DESCRIPTION
We want to be able to control cache expiry on saml-engine, saml-proxy and saml-soap-proxy.
This makes sure we can pass different values.
For now we default to 5mins - the same value which is the hub.
The corresponding changes in the hub have been already made: https://github.com/alphagov/verify-hub/pull/413