### PR TITLE
Fix the leading space in JSON

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "self_service_execution" {
 resource "aws_iam_role" "self_service_scheduled_task_cloudwatch" {
   name               = "${local.service}-${var.deployment}-st-cloudwatch-role"
   assume_role_policy = <<-EOF
-    {
+  {
     "Version": "2012-10-17",
     "Statement": [
       {


### PR DESCRIPTION
AWS doesn't like spaces...

```
Error: Error creating IAM Role self-service-staging-st-cloudwatch-role: MalformedPolicyDocument: JSON strings must not have leading spaces

	status code: 400


  on ../../../../../verify-infrastructure/terraform/modules/self-service/iam.tf line 25, in resource "aws_iam_role" "self_service_scheduled_task_cloudwatch":

  25: resource "aws_iam_role" "self_service_scheduled_task_cloudwatch" {
```