### PR TITLE
BAU: Update the scheduler deployment

### DIFF
--- a/terraform/modules/self-service/cloudwatch.tf
+++ b/terraform/modules/self-service/cloudwatch.tf
@@ -18,5 +18,15 @@ resource "aws_cloudwatch_event_target" "scheduler_target" {
   ecs_target {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.scheduler_task_def.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      security_groups = [
+        aws_security_group.egress_over_https.id,
+        data.terraform_remote_state.hub.outputs.can_connect_to_container_vpc_endpoint,
+        aws_security_group.egress_to_db.id
+      ]
+
+      subnets = data.terraform_remote_state.hub.outputs.internal_subnet_ids
+    }
   }
 }

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -129,6 +129,24 @@ resource "aws_ecs_service" "migrations_service" {
   }
 }
 
+resource "aws_ecs_service" "scheduler_service" {
+  name            = "${local.service}-scheduler"
+  task_definition = aws_ecs_task_definition.scheduler_task_def.arn
+  cluster         = aws_ecs_cluster.cluster.id
+  desired_count   = 0
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups = [
+      aws_security_group.egress_over_https.id,
+      data.terraform_remote_state.hub.outputs.can_connect_to_container_vpc_endpoint,
+      aws_security_group.egress_to_db.id
+    ]
+
+    subnets = data.terraform_remote_state.hub.outputs.internal_subnet_ids
+  }
+}
+
 resource "random_string" "rails_secret_key_base" {
   length  = 128
   special = false


### PR DESCRIPTION
It defaults automatically to EC2 instead of Fargate, so had to add the `launch_type` option.

Also, we forgot to define a service, this fixes is too...