### PR TITLE
BAU: Fix the resource for the IAM role to trigger scheduled task

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -61,7 +61,7 @@ resource "aws_iam_role_policy" "self_service_scheduled_task_cloudwatch_policy" {
         "Effect": "Allow",
         "Action": "iam:PassRole",
         "Resource": [
-          "${aws_iam_role.self_service_execution.arn}"
+          "${aws_iam_role.self_service_task.arn}"
         ]
       }
     ]


### PR DESCRIPTION
It needs access to the task role, not task-execution.

Error:
`"User: arn:aws:sts::account:assumed-role/self-service-staging-st-cloudwatch-role/4247b13a3eb73d8db8c8eecc79db60fc is not authorized to perform: iam:PassRole on resource: arn:aws:iam::account:role/self-service-task"`