### PR TITLE
BAU: Add both execution and task roles to the resources for cloudwatch event

### DIFF
--- a/terraform/modules/self-service/iam.tf
+++ b/terraform/modules/self-service/iam.tf
@@ -61,6 +61,7 @@ resource "aws_iam_role_policy" "self_service_scheduled_task_cloudwatch_policy" {
         "Effect": "Allow",
         "Action": "iam:PassRole",
         "Resource": [
+          "${aws_iam_role.self_service_execution.arn}",
           "${aws_iam_role.self_service_task.arn}"
         ]
       }


### PR DESCRIPTION
Turned out it passes through the both roles, so both are required in the resource access.