### PR TITLE
Adding temporary hub-environment-legacy variable

### DIFF
--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -17,6 +17,7 @@ locals  {
     asset_prefix                       = "${element(split(":", var.image_digest),1)}/assets/"
     sentry_dsn                         = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
     hub_environments                   = var.hub_environments
+    hub_environments_legacy            = var.hub_environments_legacy
     hub_config_host                    = "https://config.${local.hub_deployment}${var.hub_host}:443"
     notify_key                         = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/notify-key"
     self_service_authentication_header = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/authentication-header"

--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -76,6 +76,10 @@
         {
           "name": "APP_URL",
           "value": "${domain}"
+        },
+        {
+          "name": "HUB_ENVIRONMENTS_LEGACY",
+          "value": "${hub_environments_legacy}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -63,6 +63,10 @@
         {
           "name": "APP_URL",
           "value": "${domain}"
+        },
+        {
+          "name": "HUB_ENVIRONMENTS_LEGACY",
+          "value": "${hub_environments_legacy}"
         }
       ],
       "secrets": [

--- a/terraform/modules/self-service/variables.tf
+++ b/terraform/modules/self-service/variables.tf
@@ -69,6 +69,10 @@ variable "hub_host" {
   default     = "signin.service.gov.uk"
 }
 
+variable "hub_environments_legacy" {
+  description = "JSON string of hub environments and the config metadata buckets"
+}
+
 variable "additional_buckets" {
   description = "Additional bucket ARNs which the app will publish to"
   type        = "list"


### PR DESCRIPTION
Adding hub-environment-legacy variable so that we can extend the
scheme of the hub-environment variable to accomodate more values
in a future PR.

Co-authored-by: Rosa Fox <Rosa.fox@digital.cabinet-office-gov.uk>