### PR TITLE
BAU: Decrease caching of certificates across environments

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -106,7 +106,7 @@ variable "publish_hub_config_enabled" {
 
 variable "certificates_config_cache_expiry" {
   description = "Sets the expiry time of cache for certificates in saml-proxy, saml-engine and saml-soap-proxy"
-  default     = "5m"
+  default     = "1m"
 }
 
 variable "log_level" {


### PR DESCRIPTION
Decreasing the value of cache expiry for saml-proxy, saml-engine and saml-soap-proxy
from 5 minutes to 1 minute. This has been tested in the staging environment with
no observable effect on the performance. Therefore now decreasing it across environments.
This is to make RP rotations quicker.