### PR TITLE
Revert "BAU: Specify CPU and Memory requirements"

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -49,8 +49,6 @@ resource "aws_ecs_task_definition" "analytics" {
   container_definitions = data.template_file.analytics_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
-  cpu                   = 924
-  memory                = 250
 }
 
 resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https" {

--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -20,8 +20,6 @@ resource "aws_ecs_task_definition" "beat_exporter" {
   container_definitions = data.template_file.beat_exporter_task_def.rendered
   execution_role_arn    = module.beat_exporter_ecs_roles.execution_role_arn
   network_mode          = "host"
-  cpu                   = 100
-  memory                = 64
 }
 
 locals {

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -20,8 +20,6 @@ resource "aws_ecs_task_definition" "cloudwatch_exporter" {
   family                = "${var.deployment}-cloudwatch-exporter"
   container_definitions = data.template_file.cloudwatch_exporter_task_def.rendered
   execution_role_arn    = module.cloudwatch_exporter_ecs_roles.execution_role_arn
-  cpu                   = 462
-  memory                = 1024
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -160,8 +160,6 @@ resource "aws_ecs_task_definition" "egress_proxy" {
   family                = "${var.deployment}-egress-proxy"
   container_definitions = data.template_file.egress_proxy_task_def.rendered
   execution_role_arn    = module.egress_proxy_ecs_roles.execution_role_arn
-  cpu                   = 1024
-  memory                = 3500
 }
 
 resource "aws_ecs_service" "egress_proxy" {

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/beat-exporter.json
+++ b/terraform/modules/hub/files/tasks/beat-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "beat-exporter",
     "image": "${image_identifier}",
-    "cpu": 100,
+    "cpu": 0,
     "memory": 64,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "cloudwatch-exporter",
     "image": "${image_identifier}",
-    "cpu": 462,
+    "cpu": 0,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -27,7 +27,7 @@
   {
     "name": "frontend",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3000,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "config",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "policy",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-engine",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-proxy",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 924,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "metadata-exporter",
     "image": "${image_identifier}",
-    "cpu": 462,
+    "cpu": 0,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -2,7 +2,7 @@
   {
     "name": "prometheus",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -2,7 +2,7 @@
   {
     "name": "squid",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 0,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -2,7 +2,7 @@
   {
     "name": "static-ingress",
     "image": "${image_identifier}",
-    "cpu": ${allocated_cpu},
+    "cpu": 0,
     "memory": ${allocated_memory},
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -114,8 +114,6 @@ module "config" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.config_task_def.rendered
-  cpu                        = 1948
-  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -92,8 +92,6 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = data.template_file.frontend_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.frontend_ecs_roles.execution_role_arn
-  cpu                   = 1948
-  memory                = 3250
 }
 
 # This is called frontend_v2 because there was an old frontend service

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -32,8 +32,6 @@ resource "aws_ecs_task_definition" "metadata" {
   container_definitions = data.template_file.metadata_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
-  cpu                   = 1024
-  memory                = 250
 }
 
 resource "aws_ecs_service" "metadata" {

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -85,8 +85,6 @@ module "policy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.policy_task_def.rendered
-  cpu                        = 1948
-  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -66,8 +66,6 @@ module "saml_engine" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_engine_task_def.rendered
-  cpu                        = 1948
-  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -82,8 +82,6 @@ module "saml_proxy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_proxy_task_def.rendered
-  cpu                        = 1948
-  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -82,8 +82,6 @@ module "saml_soap_proxy" {
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id
   task_definition            = data.template_file.saml_soap_proxy_task_def.rendered
-  cpu                        = 1948
-  memory                     = 3750
   container_name             = "nginx"
   container_port             = "8443"
   number_of_tasks            = var.number_of_apps

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -22,8 +22,6 @@ resource "aws_ecs_task_definition" "metadata_exporter" {
   family                = "${var.deployment}-metadata-exporter"
   container_definitions = data.template_file.metadata_exporter_task_def.rendered
   execution_role_arn    = module.metadata_exporter_ecs_roles.execution_role_arn
-  cpu                   = 462
-  memory                = 1024
 }
 
 resource "aws_ecs_service" "metadata_exporter" {

--- a/terraform/modules/hub/modules/ecs_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_app/ecs.tf
@@ -21,8 +21,6 @@ resource "aws_ecs_task_definition" "cluster" {
   execution_role_arn    = module.cluster_ecs_roles.execution_role_arn
   task_role_arn         = module.cluster_ecs_roles.task_role_arn
   network_mode          = "bridge"
-  cpu                   = var.cpu
-  memory                = var.memory
 }
 
 output "task_role_name" {

--- a/terraform/modules/hub/modules/ecs_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_app/variables.tf
@@ -4,8 +4,6 @@ variable "container_port" {}
 variable "deployment" {}
 variable "domain" {}
 variable "task_definition" {}
-variable "cpu" {}
-variable "memory" {}
 variable "vpc_id" {}
 variable "tools_account_id" {}
 variable "instance_security_group_id" {}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -453,8 +453,6 @@ resource "aws_ecs_task_definition" "prometheus" {
   container_definitions = element(data.template_file.prometheus_task_def.*.rendered, count.index)
   execution_role_arn    = module.prometheus_ecs_roles.execution_role_arn
   network_mode          = "host"
-  cpu                   = 1024
-  memory                = 3500
 
   volume {
     name      = "tsdb"

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -95,13 +95,6 @@ module "static_ingress_can_connect_to_ingress_https" {
   port = 443
 }
 
-locals {
-  allocated_cpu_for_http     = 924
-  allocated_cpu_for_https    = 1024
-  allocated_memory_for_http  = 250
-  allocated_memory_for_https = 3000
-}
-
 data "template_file" "static_ingress_http_task_def" {
   template = file("${path.module}/files/tasks/static-ingress.json")
 
@@ -110,8 +103,7 @@ data "template_file" "static_ingress_http_task_def" {
     backend          = var.signin_domain
     bind_port        = 80
     backend_port     = 80
-    allocated_cpu    = local.allocated_cpu_for_http
-    allocated_memory = local.allocated_memory_for_http
+    allocated_memory = 250
   }
 }
 
@@ -123,8 +115,7 @@ data "template_file" "static_ingress_https_task_def" {
     backend          = var.signin_domain
     bind_port        = 443
     backend_port     = 443
-    allocated_cpu    = local.allocated_cpu_for_https
-    allocated_memory = local.allocated_memory_for_https
+    allocated_memory = 3000
   }
 }
 
@@ -142,16 +133,12 @@ resource "aws_ecs_task_definition" "static_ingress_http" {
   family                = "${var.deployment}-static-ingress-http"
   container_definitions = data.template_file.static_ingress_http_task_def.rendered
   execution_role_arn    = module.static_ingress_ecs_roles.execution_role_arn
-  cpu                   = local.allocated_cpu_for_http
-  memory                = local.allocated_memory_for_http
 }
 
 resource "aws_ecs_task_definition" "static_ingress_https" {
   family                = "${var.deployment}-static-ingress-https"
   container_definitions = data.template_file.static_ingress_https_task_def.rendered
   execution_role_arn    = module.static_ingress_ecs_roles.execution_role_arn
-  cpu                   = local.allocated_cpu_for_https
-  memory                = local.allocated_memory_for_https
 }
 
 resource "aws_ecs_cluster" "static-ingress" {


### PR DESCRIPTION
Reverts alphagov/verify-infrastructure#320. AWS wants us to set CPU and memory to one of values taken from the table (Source: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html). I will need to recalculate the CPU and memory using the values from the table. I want to revert this change until I find right CPU and memory size for each task.

Author: @adityapahuja