### PR TITLE
BAU: Specify CPU and Memory requirements

### DIFF
--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/beat-exporter.json
+++ b/terraform/modules/hub/files/tasks/beat-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "beat-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 128,
     "memory": 64,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "cloudwatch-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 448,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,8 +2,8 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
-    "memory": 250,
+    "cpu": 1024,
+    "memory": 512,
     "essential": true,
     "portMappings": [
       {
@@ -27,8 +27,8 @@
   {
     "name": "frontend",
     "image": "${image_identifier}",
-    "cpu": 0,
-    "memory": 3000,
+    "cpu": 1024,
+    "memory": 3072,
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "config",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "policy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-engine",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-proxy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 0,
+    "cpu": 896,
     "memory": 250,
     "essential": true,
     "portMappings": [
@@ -28,7 +28,7 @@
   {
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -2,7 +2,7 @@
   {
     "name": "metadata-exporter",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 448,
     "memory": 1024,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -2,7 +2,7 @@
   {
     "name": "prometheus",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -2,7 +2,7 @@
   {
     "name": "squid",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": 1024,
     "memory": 3500,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -2,7 +2,7 @@
   {
     "name": "static-ingress",
     "image": "${image_identifier}",
-    "cpu": 0,
+    "cpu": ${allocated_cpu},
     "memory": ${allocated_memory},
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -95,6 +95,13 @@ module "static_ingress_can_connect_to_ingress_https" {
   port = 443
 }
 
+locals {
+  allocated_cpu_for_http     = 896
+  allocated_cpu_for_https    = 1024
+  allocated_memory_for_http  = 250
+  allocated_memory_for_https = 3000
+}
+
 data "template_file" "static_ingress_http_task_def" {
   template = file("${path.module}/files/tasks/static-ingress.json")
 
@@ -103,7 +110,8 @@ data "template_file" "static_ingress_http_task_def" {
     backend          = var.signin_domain
     bind_port        = 80
     backend_port     = 80
-    allocated_memory = 250
+    allocated_cpu    = local.allocated_cpu_for_http
+    allocated_memory = local.allocated_memory_for_http
   }
 }
 
@@ -115,7 +123,8 @@ data "template_file" "static_ingress_https_task_def" {
     backend          = var.signin_domain
     bind_port        = 443
     backend_port     = 443
-    allocated_memory = 3000
+    allocated_cpu    = local.allocated_cpu_for_https
+    allocated_memory = local.allocated_memory_for_https
   }
 }
 


### PR DESCRIPTION
According to Amazon Elastic Container Service documentation, 1 virtual CPU is equal to 1024 CPU shares. Setting CPU to 0 in a container definition means that it needs 2 CPU shares. This CPU requirement is quite low. This commit updates all container definitions to specify both CPU and memory requirements. This will ensure that each application gets a fair share of CPU and memory.

The following link contains a spreadsheet which provides how much CPU and memory are allocated to each task.

Source: https://docs.google.com/spreadsheets/d/1pr-eSNAYLQ7KJqR8uDx0ZWZs5qRiRL2430wGrm3PY3I/edit?folder=0B0oLRgbrP-tUZHNuNnB6Q3lsV0E#gid=0


We do not need to specify cpu and memory requirements in task definitions as they are for Fargate only. We will specify them if we want applications to be migrated from EC2 to Fargate.

Author: @adityapahuja