### PR TITLE
BAU: Reduce CPU limit for frontend nginx

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 1024,
+    "cpu": 896,
     "memory": 512,
     "essential": true,
     "portMappings": [


### PR DESCRIPTION
beat-exporter is a daemon service and it needs to run on every EC2 instance. This change reduces Frontend nginx's CPU max limit from 1024 to 896 by beat-exporter's CPU max limit (128). This will ensure that both frontend and beat-exporter tasks can run together on one EC2 instance.

The spreadsheet (https://docs.google.com/spreadsheets/d/1pr-eSNAYLQ7KJqR8uDx0ZWZs5qRiRL2430wGrm3PY3I/edit?folder=0B0oLRgbrP-tUZHNuNnB6Q3lsV0E#gid=0) includes this change (highlighted in blue colour).

Author: @adityapahuja