### PR TITLE
BAU: Make ECS more intelligent on task placement

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -49,6 +49,11 @@ resource "aws_ecs_task_definition" "analytics" {
   container_definitions = data.template_file.analytics_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
+
+  placement_constraints {
+    type = "memberOf",
+    expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
+  }
 }
 
 resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https" {

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -92,6 +92,11 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = data.template_file.frontend_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.frontend_ecs_roles.execution_role_arn
+
+  placement_constraints {
+    type = "memberOf",
+    expression = "not(task:group == service:${aws_ecs_service.analytics.name}) and not(task:group == service:${aws_ecs_service.metadata.name})"
+  }
 }
 
 # This is called frontend_v2 because there was an old frontend service

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -32,6 +32,11 @@ resource "aws_ecs_task_definition" "metadata" {
   container_definitions = data.template_file.metadata_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
+
+  placement_constraints {
+    type = "memberOf",
+    expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
+  }
 }
 
 resource "aws_ecs_service" "metadata" {


### PR DESCRIPTION
ECS is trying to place analytics and metadata tasks on container instances which hold frontend task. These instances do not have free CPU space for the two tasks. ECS is not smart enough to know that there are other container instances which have free CPU space and ECS does not attempt to place these tasks on the other container instances which have free CPU space.

This change adds placement_constraints to analytics and metadata tasks to stop ECS from placing these tasks on container instances which hold frontend task. It also adds placement constraints to frontend task to stop ECS from placing this task on container instances which hold analytics task, metadata task or both tasks. This should make ECS more sensible to place tasks in right container instances.

Author: @adityapahuja