### PR TITLE
BAU: Remove comma to fix an error

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -51,7 +51,7 @@ resource "aws_ecs_task_definition" "analytics" {
   execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
 
   placement_constraints {
-    type = "memberOf",
+    type       = "memberOf"
     expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
   }
 }

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -94,7 +94,7 @@ resource "aws_ecs_task_definition" "frontend" {
   execution_role_arn    = module.frontend_ecs_roles.execution_role_arn
 
   placement_constraints {
-    type = "memberOf",
+    type       = "memberOf"
     expression = "not(task:group == service:${aws_ecs_service.analytics.name}) and not(task:group == service:${aws_ecs_service.metadata.name})"
   }
 }

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "metadata" {
   execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
 
   placement_constraints {
-    type = "memberOf",
+    type       = "memberOf"
     expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
   }
 }


### PR DESCRIPTION
Terraform threw the following error.

`Argument definitions must be separated by newlines, not commas. An argument definition must end with a newline.`

This change removes the comma to resolve the error. I was using the example taken from AWS documentation (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html). This example has comma and it is not written in terraform code.

Author: @adityapahuja