### PR TITLE
BAU: Fix terraform cycle error

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -52,7 +52,7 @@ resource "aws_ecs_task_definition" "analytics" {
 
   placement_constraints {
     type       = "memberOf"
-    expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
+    expression = "not(task:group == service:${var.deployment}-frontend-v2)"
   }
 }
 

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_task_definition" "metadata" {
 
   placement_constraints {
     type       = "memberOf"
-    expression = "not(task:group == service:${aws_ecs_service.frontend_v2.name})"
+    expression = "not(task:group == service:${var.deployment}-frontend-v2)"
   }
 }
 


### PR DESCRIPTION
Terraform threw the following error message.

`Error: Cycle: module.hub.aws_ecs_service.metadata, module.hub.aws_ecs_task_definition.analytics, module.hub.aws_ecs_service.analytics, module.hub.aws_ecs_task_definition.frontend, module.hub.aws_ecs_service.frontend_v2, module.hub.aws_ecs_task_definition.metadata`

This change updates to use hardcoded frontend name to break the cycle.

I have ran terraform plan manually. It shows no error messages.

Author: @adityapahuja