### PR TITLE
BAU: Resolve ECS task placement issue on ingress cluster

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -49,11 +49,6 @@ resource "aws_ecs_task_definition" "analytics" {
   container_definitions = data.template_file.analytics_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
-
-  placement_constraints {
-    type       = "memberOf"
-    expression = "not(task:group == service:${var.deployment}-frontend-v2)"
-  }
 }
 
 resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https" {

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
+    "cpu": 298,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,8 +2,8 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 512,
+    "cpu": 300,
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -28,7 +28,7 @@
     "name": "frontend",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3072,
+    "memory": 3071,
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 1024,
+    "cpu": 298,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -92,11 +92,6 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = data.template_file.frontend_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.frontend_ecs_roles.execution_role_arn
-
-  placement_constraints {
-    type       = "memberOf"
-    expression = "not(task:group == service:${aws_ecs_service.analytics.name}) and not(task:group == service:${aws_ecs_service.metadata.name})"
-  }
 }
 
 # This is called frontend_v2 because there was an old frontend service

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -32,11 +32,6 @@ resource "aws_ecs_task_definition" "metadata" {
   container_definitions = data.template_file.metadata_task_def.rendered
   network_mode          = "awsvpc"
   execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
-
-  placement_constraints {
-    type       = "memberOf"
-    expression = "not(task:group == service:${var.deployment}-frontend-v2)"
-  }
 }
 
 resource "aws_ecs_service" "metadata" {


### PR DESCRIPTION
This pull request has two commits.

1. The first commit updates CPU and memory limits in all tasks for ingress cluster so that they can run on one EC2 instance. This will stop ECS from taking a long time to figure out which EC2 instance has enough CPU or memory for four tasks having different CPU and memory requirements.

2. The second commit removes placement constraints from frontend, analytics and metadata tasks for ingress cluster. ECS does not do task placement very well. It is better for all tasks to run on one EC2 instance so that ECS doesn't spend time figuring out which one of EC2 instances has enough CPU and memory space for each task (frontend, analytics, metadata and beat-exporter).

I ran terraform apply. There were no errors.

Author: @adityapahuja