### PR TITLE
BAU: Add configurable jvm_options to SAML Proxy

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -75,7 +75,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=saml-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=saml-proxy ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "RP_TRUSTSTORE_ENABLED",

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -70,6 +70,7 @@ data "template_file" "saml_proxy_task_def" {
     event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
+    jvm_options                      = var.jvm_options
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -10,6 +10,9 @@ variable "tools_account_id" {
   description = "AWS account id of the tools account, where docker images will be pulled from"
 }
 
+variable "jvm_options" {
+  default = "-Xms3000m -Xmx3200m"
+}
 variable "number_of_apps" {
   default = 2
 }


### PR DESCRIPTION
This change allows us to add other java options like -XX:MaxRAMPercentage to limit JVM heap size.

Co-authored-by: Phillip Miller <phillip.miller@digital.cabinet-office.gov.uk>