### PR TITLE
BAU: Add configurable jvm_options to all Java applications

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -67,7 +67,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=config ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "SELF_SERVICE_ENABLED",

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -79,7 +79,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=policy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=policy ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       }
     ],
     "healthCheck" : {

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -75,7 +75,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=config -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=config ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "REDIS_HOST",

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -75,7 +75,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=saml-soap-proxy -Xms3000m -Xmx3200m -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=saml-soap-proxy ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "RP_TRUSTSTORE_ENABLED",

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -76,6 +76,7 @@ data "template_file" "config_task_def" {
     services_metadata_bucket = local.services_metadata_bucket
     metadata_object_key      = local.metadata_object_key
     java_app_memory          = var.java_app_memory
+    jvm_options              = var.jvm_options
   }
 }
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -71,6 +71,7 @@ data "template_file" "policy_task_def" {
     account_id                    = data.aws_caller_identity.account.account_id
     event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
     java_app_memory               = var.java_app_memory
+    jvm_options                   = var.jvm_options
 
     redis_host = "rediss://${
       aws_elasticache_replication_group.policy_session_store.primary_endpoint_address

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -56,6 +56,7 @@ data "template_file" "saml_engine_task_def" {
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
     java_app_memory                  = var.java_app_memory
+    jvm_options                      = var.jvm_options
   }
 }
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -72,6 +72,7 @@ data "template_file" "saml_soap_proxy_task_def" {
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
     java_app_memory                  = var.java_app_memory
+    jvm_options                      = var.jvm_options
   }
 }
 


### PR DESCRIPTION
This changes replaces the hardcoded Java options "-Xms3000m -Xmx3200m" with the configurable jvm_options. This will allow us to add other java options such as -XX:MaxRAMPercentage to limit JVM heap size in different environments. The jvm_options uses the default options (-Xms3000m -Xmx3200m).

Author: @adityapahuja