### PR TITLE
BAU gain more memory by changing from medium to large

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -25,7 +25,7 @@ variable "additional_instance_role_policy_arns" {
 }
 
 variable "instance_type" {
-  default = "t3.medium"
+  default = "t3.large"
 }
 
 variable "use_egress_proxy" {


### PR DESCRIPTION
During self-assessment period, we are seeing a significant memory increase on `saml-engine`.
We can double our memory available by upgrading to t3.large (4GB to 8GB).