### PR TITLE
BAU: Make instance_type configurable

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -8,6 +8,7 @@ module "egress_proxy_ecs_asg" {
   instance_subnets    = aws_subnet.internal.*.id
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id
@@ -55,11 +56,11 @@ locals {
 
 locals {
   egress_proxy_whitelist_list = [
-    "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com",                   # Apt
-    "security\\.ubuntu\\.com",                                    # Apt
-    "artifacts\\.elastic\\.co",                                   # Journalbeat
+    "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com",              # Apt
+    "security\\.ubuntu\\.com",                               # Apt
+    "artifacts\\.elastic\\.co",                              # Journalbeat
     replace(var.logit_elasticsearch_url, ".", "\\."),        # Logit
-    "sentry\\.tools\\.signin\\.service\\.gov\\.uk",               # Tools Sentry
+    "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
   ]

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -9,6 +9,7 @@ module "config_ecs_asg" {
 
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -9,6 +9,7 @@ module "policy_ecs_asg" {
 
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -10,6 +10,7 @@ module "saml_engine_ecs_asg" {
   use_egress_proxy    = true
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -11,6 +11,7 @@ module "saml_proxy_ecs_asg" {
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id
+  instance_type              = var.instance_type
 
   additional_instance_security_group_ids = [
     aws_security_group.scraped_by_prometheus.id,

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -8,6 +8,7 @@ module "saml_soap_proxy_ecs_asg" {
   instance_subnets    = aws_subnet.internal.*.id
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -297,6 +297,7 @@ module "ingress_ecs_asg" {
   instance_subnets    = aws_subnet.internal.*.id
   number_of_instances = var.number_of_apps * 2
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -24,9 +24,7 @@ variable "additional_instance_role_policy_arns" {
   default = []
 }
 
-variable "instance_type" {
-  default = "t3.medium"
-}
+variable "instance_type" {}
 
 variable "use_egress_proxy" {
   default = false

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -8,6 +8,7 @@ module "static_ingress_ecs_asg" {
   instance_subnets    = aws_subnet.internal.*.id
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
+  instance_type       = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -74,6 +74,10 @@ variable "analytics_endpoint" {
   description = "Analytics endpoint"
 }
 
+variable "instance_type" {
+  default = "t3.medium"
+}
+
 variable "splunk_url" {
   description = "Splunk http event collector endpoint, used by saml-engine"
 }


### PR DESCRIPTION
This change allows us to choose specific instance_type for each environment.

Co-authored-by: Phillip Miller <phillip.miller@digital.cabinet-office.gov.uk>
Co-authored-by: Chris Wynne <christopher.wynne@digital.cabinet-office.gov.uk>