### PR TITLE
BAU: Make java app container's memory limit configurable

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -29,7 +29,7 @@
     "name": "config",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": ${java_app_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -29,7 +29,7 @@
     "name": "policy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": ${java_app_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -29,7 +29,7 @@
     "name": "saml-engine",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": ${java_app_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -29,7 +29,7 @@
     "name": "saml-proxy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": ${java_app_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -29,7 +29,7 @@
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": ${java_app_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -74,6 +74,7 @@ data "template_file" "config_task_def" {
     self_service_enabled     = var.self_service_enabled
     services_metadata_bucket = local.services_metadata_bucket
     metadata_object_key      = local.metadata_object_key
+    java_app_memory          = var.java_app_memory
   }
 }
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -69,6 +69,7 @@ data "template_file" "policy_task_def" {
     region                        = data.aws_region.region.id
     account_id                    = data.aws_caller_identity.account.account_id
     event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
+    java_app_memory               = var.java_app_memory
 
     redis_host = "rediss://${
       aws_elasticache_replication_group.policy_session_store.primary_endpoint_address

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -54,6 +54,7 @@ data "template_file" "saml_engine_task_def" {
     splunk_url                       = var.splunk_url
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
+    java_app_memory                  = var.java_app_memory
   }
 }
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -71,6 +71,7 @@ data "template_file" "saml_proxy_task_def" {
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
     jvm_options                      = var.jvm_options
+    java_app_memory                  = var.java_app_memory
   }
 }
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -70,6 +70,7 @@ data "template_file" "saml_soap_proxy_task_def" {
     event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
+    java_app_memory                  = var.java_app_memory
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -122,6 +122,10 @@ variable "metadata_exporter_environment" {
   default     = "development"
 }
 
+variable "java_app_memory" {
+  default = 3500
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
Since the instance type is made configurable (https://github.com/alphagov/verify-infrastructure/pull/361), this change makes java app container's memory limit configurable in each environment. This will allow us to update the memory limit when the instance type changes (e.g. from t3.medium (4GB) to t3.large (8GB)). The default memory limit for java app container is 3500 MB because the instance type is set to the default value `t3.medium`.

Author: @adityapahuja