### PR TITLE
BAU: Add configurable items for Java applications

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -130,6 +130,46 @@ variable "java_app_memory" {
   default = 3500
 }
 
+variable "config_memory_hard_limit" {
+  default = 3500
+}
+
+variable "saml_proxy_memory_hard_limit" {
+  default = 3500
+}
+
+variable "policy_memory_hard_limit" {
+  default = 3500
+}
+
+variable "saml_engine_memory_hard_limit" {
+  default = 3500
+}
+
+variable "saml_soap_proxy_memory_hard_limit" {
+  default = 3500
+}
+
+variable "config_instance_type" {
+  default = "t3.medium"
+}
+
+variable "saml_proxy_instance_type" {
+  default = "t3.medium"
+}
+
+variable "policy_instance_type" {
+  default = "t3.medium"
+}
+
+variable "saml_engine_instance_type" {
+  default = "t3.medium"
+}
+
+variable "saml_soap_proxy_instance_type" {
+  default = "t3.medium"
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}


### PR DESCRIPTION
This change adds configurable hard memory limit and instance type for each Java application. This allows us to choose hard memory limit and instance type for each Java application in different environments. These variables are not used yet. They will replace existing java_app_memory and instance_type variables used for Java applications only after they are defined for production environment. This is to stop AWS ECS from changing instance types for Java applications unnecessarily in production environment.

Author: @adityapahuja