### PR TITLE
BAU: Replace generic variables with specific variables

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -29,7 +29,7 @@
     "name": "config",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": ${java_app_memory},
+    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -29,7 +29,7 @@
     "name": "policy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": ${java_app_memory},
+    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -29,7 +29,7 @@
     "name": "saml-engine",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": ${java_app_memory},
+    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -29,7 +29,7 @@
     "name": "saml-proxy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": ${java_app_memory},
+    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -29,7 +29,7 @@
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": ${java_app_memory},
+    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -9,7 +9,7 @@ module "config_ecs_asg" {
 
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
-  instance_type       = var.instance_type
+  instance_type       = var.config_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -75,7 +75,7 @@ data "template_file" "config_task_def" {
     self_service_enabled     = var.self_service_enabled
     services_metadata_bucket = local.services_metadata_bucket
     metadata_object_key      = local.metadata_object_key
-    java_app_memory          = var.java_app_memory
+    memory_hard_limit        = var.config_memory_hard_limit
     jvm_options              = var.jvm_options
   }
 }

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -70,7 +70,7 @@ data "template_file" "policy_task_def" {
     region                        = data.aws_region.region.id
     account_id                    = data.aws_caller_identity.account.account_id
     event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
-    java_app_memory               = var.java_app_memory
+    memory_hard_limit             = var.policy_memory_hard_limit
     jvm_options                   = var.jvm_options
 
     redis_host = "rediss://${

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -9,7 +9,7 @@ module "policy_ecs_asg" {
 
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
-  instance_type       = var.instance_type
+  instance_type       = var.policy_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -55,7 +55,7 @@ data "template_file" "saml_engine_task_def" {
     splunk_url                       = var.splunk_url
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
-    java_app_memory                  = var.java_app_memory
+    memory_hard_limit                = var.saml_engine_memory_hard_limit
     jvm_options                      = var.jvm_options
   }
 }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -10,7 +10,7 @@ module "saml_engine_ecs_asg" {
   use_egress_proxy    = true
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
-  instance_type       = var.instance_type
+  instance_type       = var.saml_engine_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -72,7 +72,7 @@ data "template_file" "saml_proxy_task_def" {
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
     jvm_options                      = var.jvm_options
-    java_app_memory                  = var.java_app_memory
+    memory_hard_limit                = var.saml_proxy_memory_hard_limit
   }
 }
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -11,7 +11,7 @@ module "saml_proxy_ecs_asg" {
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id
-  instance_type              = var.instance_type
+  instance_type              = var.saml_proxy_instance_type
 
   additional_instance_security_group_ids = [
     aws_security_group.scraped_by_prometheus.id,

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -8,7 +8,7 @@ module "saml_soap_proxy_ecs_asg" {
   instance_subnets    = aws_subnet.internal.*.id
   number_of_instances = var.number_of_apps
   domain              = local.root_domain
-  instance_type       = var.instance_type
+  instance_type       = var.saml_soap_proxy_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -71,7 +71,7 @@ data "template_file" "saml_soap_proxy_task_def" {
     event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
     rp_truststore_enabled            = var.rp_truststore_enabled
     certificates_config_cache_expiry = var.certificates_config_cache_expiry
-    java_app_memory                  = var.java_app_memory
+    memory_hard_limit                = var.saml_soap_proxy_memory_hard_limit
     jvm_options                      = var.jvm_options
   }
 }


### PR DESCRIPTION
This pull request contains 2 commits.

1. The first commit replaces the generic variable `java_app_memory` with specific variables. This allows us to control maximum memory hard limit for each Java application. It also renames java_app_memory to memory_hard_limit to make it clear.

2. The second commit replaces the generic variable `instance_type` with specific variables. This change allows us to choose instance type for each Java application.

I have ran terraform plan on Staging, Integration and Production. There are no changes. Infrastructures are up-to-date.

Author: @adityapahuja
