### PR TITLE
use new alertmanagers

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -7,11 +7,12 @@ global:
 alerting:
   alertmanagers:
   - scheme: https
-    static_configs:
-    - targets:
-      - 'alerts-1.monitoring.gds-reliability.engineering'
-      - 'alerts-2.monitoring.gds-reliability.engineering'
-      - 'alerts-3.monitoring.gds-reliability.engineering'
+    tls_config:
+      server_name: alerts.monitoring.gds-reliability.engineering
+    dns_sd_configs:
+    - names: [ alerts.monitoring.gds-reliability.engineering ]
+      type: A
+      port: 443
 rule_files:
   - "alerts.yml"
 scrape_configs:


### PR DESCRIPTION
We have changed how we deploy alertmanager - it's now multiple A
records on the same domain, not three different domains.

The tls_config: section is necessary because otherwise it tries to use
the IP address as the TLS ServerName and fails to validate the
certificate.