### PR TITLE
fix terraform stealing var interpolation in tmpl

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -5,8 +5,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 function wait-for-lock() {
 	lock_file=$1
-	while fuser "${lock_file}" >/dev/null 2>&1 ; do
-		echo "Waiting for ${lock_file} to be released..."
+	while fuser "$lock_file" >/dev/null 2>&1 ; do
+		echo "Waiting for $lock_file to be released..."
 		sleep 3
 	done
 }


### PR DESCRIPTION
cloud-init is interpolated by terraform templating.

"$this_var_is_not_processed_by_tf"

"${this_var_is_processed_by_tf}"