### PR TITLE
AUT-515: Resolve roll-staging failure

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -17,6 +17,9 @@ function apt-get-wait() {
   do
     if (( retry>0 ))
     then
+      echo "Identifying who owns the lock and/or lock-frontend."
+      lsof /var/lib/dpkg/lock
+      lsof /var/lib/dpkg/lock-frontend
       echo "Reattempting to execute apt-get $* $retry times."
     fi;
     wait-for-lock /var/lib/dpkg/lock


### PR DESCRIPTION
`roll-staging` job failed due to the following error messages.

E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?

This change updates the `cloud-init.sh` script to retry up to 5 times whenever it fails to acquire a lock. When the script fails to acquire the lock 5 times, it will exit with an error code.

Author: @adityapahuja