### PR TITLE
bump squid version to r3 release

### DIFF
--- a/dockerfiles/squid/Dockerfile
+++ b/dockerfiles/squid/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-RUN apk add --no-cache squid=3.5.27-r2
+RUN apk add --no-cache squid=3.5.27-r3
 
 RUN    touch /etc/squid/squid.conf \
     && chown squid /etc/squid/squid.conf


### PR DESCRIPTION
squid 3.5.27-r2 no longer exists in alpine package repo, r3 does