### PR TITLE
Actually show unhealthy MSAs in the Hub ECS grafana dashboard

### DIFF
--- a/dashboards/Hub-ECS.json
+++ b/dashboards/Hub-ECS.json
@@ -892,7 +892,7 @@
       ],
       "targets": [
         {
-          "expr": "avg without (instance)(verify_saml_soap_proxy_msa_info\nand on (instance, job)\nverify_saml_soap_proxy_msa_health_status == 1)\n",
+          "expr": "avg without (instance)(verify_saml_soap_proxy_msa_health_status\nand on (instance, job)\nverify_saml_soap_proxy_msa_info)\n",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
This query was a bit weird because the table had a "healthy" column
but we only requested health checks for which
`verify_saml_soap_proxy_msa_health_status == 1` - ie only the healthy
ones.

This fixes the query to remove the `== 1` filter and to return all MSA
health checks, whether healthy or not.  To do this I had to flip the
operands of the `and` operator since the value of the first operand is
returned and the value we care about is the health check result.