### PR TITLE
BAU: Update docker volume mount

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -195,7 +195,7 @@ docker run \
   --volume=/lib64:/lib64 \
   --volume=/lib:/lib \
   --volume=/proc:/host/proc \
-  --volume=/sbin:/sbin \
+  --volume=/sbin:/host/sbin \
   --volume=/sys/fs/cgroup:/sys/fs/cgroup \
   --volume=/usr/lib:/usr/lib \
   --volume=/var/lib/ecs/data:/data \


### PR DESCRIPTION
This change updates docker volume mount to use /host/sbin instead of /sbin. This change is needed to avoid conflict with newer Docker. Please see further details on the following link (https://github.com/aws/amazon-ecs-agent/pull/2345).

I have tested this change in staging environment. Cloud-init has stopped throwing the following error.

```
[  217.816995] cloud-init[1463]: docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/sbin/docker-init\": stat /sbin/docker-init: no such file or directory": unknown.
```

Author: @adityapahuja