### PR TITLE
BAU: Update docker volume mount

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -210,7 +210,7 @@ docker run \
   --volume=/lib64:/lib64 \
   --volume=/lib:/lib \
   --volume=/proc:/host/proc \
-  --volume=/sbin:/sbin \
+  --volume=/sbin:/host/sbin \
   --volume=/sys/fs/cgroup:/sys/fs/cgroup \
   --volume=/usr/lib:/usr/lib \
   --volume=/var/lib/ecs/data:/data \


### PR DESCRIPTION
This change updates docker volume mount to use /host/sbin instead of /sbin. This change is needed to avoid conflict with newer Docker. Please see further details on the following link (https://github.com/aws/amazon-ecs-agent/pull/2345).

Author: @adityapahuja