### PR TITLE
BAU: Create a separate variable for prometheus

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -14,6 +14,10 @@ variable "number_of_apps" {
   default = 2
 }
 
+variable "number_of_prometheus_apps" {
+  default = 3
+}
+
 variable "publically_accessible_from_cidrs" {
   type = "list"
 }


### PR DESCRIPTION
Prometheus needs to run in each Availability Zone (AZ). There are three Availability Zones in London region. There is no need to scale to more than 3 instances of Prometheus. This change creates a separate variable called number_of_prometheus_apps which defaults to 3. This replaces number_of_apps with number_of_prometheus_apps for Prometheus cluster only.

Author: @adityapahuja