### PR TITLE
AUT-606: Change ECS scheduler's placement strategy for ingress cluster

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -84,4 +84,9 @@ resource "aws_ecs_service" "analytics" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -126,6 +126,11 @@ resource "aws_ecs_service" "frontend_v2" {
     registry_arn = aws_service_discovery_service.frontend.arn
     port         = 8443
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }
 
 module "frontend_can_connect_to_config" {

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -56,4 +56,9 @@ resource "aws_ecs_service" "metadata" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }


### PR DESCRIPTION
At this moment, ECS scheduler is using random for ECS task placement strategy. This issue with the strategy is that it places all same containers (e.g. metadata) on one EC2 instance. This is not a good strategy and it increases the risk of losing a service if all same containers are on one EC2 instance. This change updates ECS scheduler to use spread for ECS task placement strategy. This strategy will ensure that tasks are distributed evenly across all instances. This change applies to metadata, analytics and frontend containers. beat-exporter's service type is daemon and it can be safely ignored.

Source: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html

Author: @adityapahuja