### PR TITLE
Revert "AUT-606: Change ECS scheduler's placement strategy for ingress cluster"

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -84,9 +84,4 @@ resource "aws_ecs_service" "analytics" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
-
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
-  }
 }

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -126,11 +126,6 @@ resource "aws_ecs_service" "frontend_v2" {
     registry_arn = aws_service_discovery_service.frontend.arn
     port         = 8443
   }
-
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
-  }
 }
 
 module "frontend_can_connect_to_config" {

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -56,9 +56,4 @@ resource "aws_ecs_service" "metadata" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
-
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
-  }
 }


### PR DESCRIPTION
This change reverts alphagov/verify-infrastructure#383. The pull request changes are not Zero Downtime Deployment (ZDD) compliant. According to terraform upgrade note (Source: https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#resource-aws_ecs_service), `placement_strategy` has been replaced with `ordered_placement_strategy`. Please see terraform plan below. It requires replacement rather than update. 

```
      + ordered_placement_strategy { # forces replacement
          + field = "instanceId" # forces replacement
          + type  = "spread" # forces replacement
        }

      + placement_strategy {
          + field = (known after apply)
          + type  = (known after apply)
        }
```

Author: @adityapahuja 