### PR TITLE
AUT-606: Increase the number of EC2 instances for ingress in prod

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -295,7 +295,7 @@ module "ingress_ecs_asg" {
   cluster             = "ingress"
   vpc_id              = aws_vpc.hub.id
   instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.ingress_instance_type == "t3.xlarge" ? var.number_of_apps : var.number_of_apps * 2
+  number_of_instances = var.number_of_apps * 2
   domain              = local.root_domain
   instance_type       = var.ingress_instance_type
 


### PR DESCRIPTION
At this moment not all containers in ingress cluster fit on EC2 instances in production due to insufficient CPU and memory units because ECS scheduler is still using random strategy (poor strategy). Changing ECS scheduler's strategy from random to spread will solve this problem. Unfortunately, it is not ZDD.

To resolve the problem, this change uses number_of_apps * 2 to double the number of EC2 in production for ingress cluster in production. ECS scheduler will be able to place all containers on different EC2 instances in ingress cluster.

Author: @adityapahuja