### PR TITLE
BAU: Increase timeout on analytics nginx

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -16,6 +16,9 @@ locals {
   location /analytics {
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_pass $analytics/matomo.php?$args;
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
   }
 
   location /healthcheck {


### PR DESCRIPTION
There are 504 errors coming from analytics nginx. This change increases the timeout from 60s to 300s to reduce the number of 504 errors.

Author: @adityapahuja