### PR TITLE
Detect device identifier of prometheus EBS volume for mounting.

### DIFF
--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -332,6 +332,7 @@ data "template_file" "prometheus_cloud_init" {
     cluster                    = aws_ecs_cluster.prometheus.name
     ecs_agent_image_identifier = local.ecs_agent_image_identifier
     tools_account_id           = var.tools_account_id
+    data_volume_size           = var.prometheus_volume_size
   }
 }
 
@@ -364,7 +365,7 @@ resource "aws_instance" "prometheus" {
 resource "aws_ebs_volume" "prometheus" {
   count = var.number_of_prometheus_apps
 
-  size      = 100
+  size      = var.prometheus_volume_size
   encrypted = true
 
   availability_zone = element(

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -18,6 +18,10 @@ variable "number_of_prometheus_apps" {
   default = 3
 }
 
+variable "prometheus_volume_size" {
+  default = 100
+}
+
 variable "publically_accessible_from_cidrs" {
   type = "list"
 }


### PR DESCRIPTION
EBS volumes are mapped to device identifiers in the kernel in a way that
is unpredictable (it gives numbers and letters based on the order in which
it becomes aware of them and so it cannot be relied upon). We are seeing
an issue whereby the ordering of the devices sometimes reverses and so an
attempt is made to mount the wrong device.

This change attempts to discover the identifier by looking it up by disk
size. It's a hack, but, for the moment, prometheus is only using a single
disk of that size.