### PR TITLE
Fix intermittent failures of mounting the prometheus data volume during initialisation.

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -130,30 +130,31 @@ systemctl enable prometheus-node-exporter
 systemctl restart prometheus-node-exporter
 
 echo 'Configuring prometheus EBS'
-vol="nvme1n1"
-mkdir -p /srv/prometheus
-while true; do
-  lsblk | grep -q "$vol" && break
-  echo "still waiting for volume /dev/$vol ; sleeping 5"
+vol=""
+while [ -z "$vol" ]; do
+  # adapted from
+  # https://medium.com/@moonape1226/mount-aws-ebs-on-ec2-automatically-with-cloud-init-e5e837e5438a
+  # [Last accessed on 2020-04-02]
+  vol=$(lsblk | grep -e disk | awk '{sub("G","",$4)} {if ($4+0 == ${data_volume_size}) print $1}')
+  echo "still waiting for data volume ; sleeping 5"
   sleep 5
 done
+mkdir -p /srv/prometheus
 echo "found volume /dev/$vol"
 if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
-  if file -s "/dev/$vol" | grep -q ": data" ; then
+  if [ -z "$(blkid /dev/$vol | grep ext4)" ] ; then
     echo "volume /dev/$vol is not formatted ; formatting"
-    mkfs -F -t ext4   "/dev/$vol"
-  fi
-  echo "volume /dev/$vol is formatted"
-
-  if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
-    echo "volume /dev/$vol is not mounted ; mounting"
-    mount "/dev/$vol" /srv/prometheus
+    mkfs -F -t ext4 "/dev/$vol"
+  else
+    echo "volume /dev/$vol is already formatted"
   fi
 
-  echo "volume /dev/$vol is mounted ; writing fstab entry"
+  echo "volume /dev/$vol is not mounted ; mounting"
+  mount "/dev/$vol" /srv/prometheus
+  UUID=$(blkid /dev/$vol -s UUID -o value)
+  if [ -z "$(grep $UUID /etc/fstab)" ] ; then
+    echo "writing fstab entry"
 
-  if grep -qv "/dev/$vol" /etc/fstab ; then
-    UUID=$(blkid /dev/$vol -s UUID -o value)
     echo "UUID=$UUID /srv/prometheus ext4 defaults,nofail 0 2" >> /etc/fstab
   fi
 fi

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -332,6 +332,7 @@ data "template_file" "prometheus_cloud_init" {
     cluster                    = aws_ecs_cluster.prometheus.name
     ecs_agent_image_identifier = local.ecs_agent_image_identifier
     tools_account_id           = var.tools_account_id
+    data_volume_size           = var.prometheus_volume_size
   }
 }
 
@@ -364,7 +365,7 @@ resource "aws_instance" "prometheus" {
 resource "aws_ebs_volume" "prometheus" {
   count = var.number_of_prometheus_apps
 
-  size      = 100
+  size      = var.prometheus_volume_size
   encrypted = true
 
   availability_zone = element(

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -18,6 +18,10 @@ variable "number_of_prometheus_apps" {
   default = 3
 }
 
+variable "prometheus_volume_size" {
+  default = 100
+}
+
 variable "publically_accessible_from_cidrs" {
   type = "list"
 }


### PR DESCRIPTION
EBS volumes are mapped to device identifiers in the kernel in a way that
is unpredictable (it gives numbers and letters based on the order in which
it becomes aware of them and so it cannot be relied upon). We are seeing
an issue whereby the ordering of the devices sometimes reverses and so an
attempt is made to mount the wrong device.

Also, the check for whether the disk was formatted was failing sometimes.
The `file -s` command wasn't returning the expected string and so a disk
that needed formatting wasn't being formatted. The mount command that
follows then fails because there's no filesystem to mount.

This change attempts to discover the identifier by looking it up by disk
size. It's a hack, but, for the moment, prometheus is only using a single
disk of that size. The failing `file -s` check has been replaced by a
check interrogating `blkid` which seems to be more reliable in testing.