### PR TITLE
Ensure the right process gets the signals.

### DIFF
--- a/dockerfiles/haproxy-static-ingress-tls/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress-tls/docker-entrypoint.sh
@@ -22,4 +22,4 @@ cat /tmp/tls/key.pem /tmp/tls/cert.pem > /tmp/tls/chain.pem
 
 echo /tmp/tls/chain.pem
 
-haproxy -f /tmp/haproxy.cfg
+exec haproxy -f /tmp/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress/docker-entrypoint.sh
@@ -8,4 +8,4 @@ set -ueo pipefail
 
 envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl
 
-haproxy -f /tmp/haproxy.cfg
+exec haproxy -f /tmp/haproxy.cfg

--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -77,4 +77,4 @@ openssl req -x509 \
 envsubst > /tmp/nginx.conf < /tmp/nginx.conf.tpl
 
 
-nginx -g 'daemon off;' -c /tmp/nginx.conf
+exec nginx -g 'daemon off;' -c /tmp/nginx.conf

--- a/dockerfiles/squid/docker-entrypoint.sh
+++ b/dockerfiles/squid/docker-entrypoint.sh
@@ -38,4 +38,4 @@ cache deny all
 EOF
 
 # squid -N => no daemon mode
-squid -N
+exec squid -N


### PR DESCRIPTION
A shell won't necessarily propagate an incoming signal to its child
processes. In the cases of these Verify components there's no need for the
shell itself to continue to exist so the relevant application can become
"pid 1" and take over. This brings these containers inline with current
best practices in docker deployments.