### PR TITLE
BAU: Enable TOTP MFA config for self-service cognito

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -95,6 +95,10 @@ resource "aws_cognito_user_pool" "user_pool" {
     sns_caller_arn = aws_iam_role.cognito_sns_role.arn
   }
 
+  software_token_mfa_configuration {
+    enabled = true
+  }
+
   username_attributes = [
     "email",
   ]


### PR DESCRIPTION
The recent Terraform AWS provider version now supports the flag to set
the MFA config on. Previously this was done manually in the UI and now the new
version of the provider resets it. This should resolve it.