### PR TITLE
BAU: Remove now redundant provisioner from cognito in self-service

### DIFF
--- a/terraform/modules/self-service/modules/cognito/cognito.tf
+++ b/terraform/modules/self-service/modules/cognito/cognito.tf
@@ -197,10 +197,6 @@ resource "aws_cognito_user_pool" "user_pool" {
     prevent_destroy = true
   }
 
-  provisioner "local-exec" {
-    command = "aws cognito-idp set-user-pool-mfa-config --user-pool-id ${aws_cognito_user_pool.user_pool.id} --software-token-mfa-configuration Enabled=true --mfa-configuration ON"
-  }
-
 }
 
 resource "aws_cognito_user_pool_client" "client" {


### PR DESCRIPTION
The provisioner was needed to set the TOTP MFA since terraform did no support
setting it. The latest version of the AWS provider now supports it so it
can be set and doesn't need the provisioner.