### PR TITLE
Independently scale-out frontend, analytics, and metadata 

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -88,4 +88,9 @@ resource "aws_ecs_service" "analytics" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }

--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -68,6 +68,7 @@ resource "aws_ecs_service" "analytics" {
   name            = "${var.deployment}-analytics"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.analytics.arn
+  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_apps
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_service" "analytics" {
   task_definition = aws_ecs_task_definition.analytics.arn
   iam_role        = aws_iam_role.ecs_service_role.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_analytics_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/ecs_service_role.tf
+++ b/terraform/modules/hub/ecs_service_role.tf
@@ -1,0 +1,21 @@
+// let ecs manage AutoScaling/LoadBalancers
+data "aws_iam_policy_document" "ecs_service_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_service_role" {
+  assume_role_policy = data.aws_iam_policy_document.ecs_service_role_policy.json
+  name               = "${var.deployment}-ecs-service-role"
+}
+
+resource "aws_iam_role_policy_attachment" "service_role" {
+  role       = aws_iam_role.ecs_service_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -1,14 +1,15 @@
 module "egress_proxy_ecs_asg" {
   source = "./modules/ecs_asg"
 
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "egress-proxy"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.instance_type
+  ami_id           = data.aws_ami.ubuntu_bionic.id
+  deployment       = var.deployment
+  cluster          = "egress-proxy"
+  vpc_id           = aws_vpc.hub.id
+  instance_subnets = aws_subnet.internal.*.id
+  min_size         = var.number_of_apps
+  max_size         = var.number_of_apps
+  domain           = local.root_domain
+  instance_type    = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -7,9 +7,10 @@ module "config_ecs_asg" {
   vpc_id           = aws_vpc.hub.id
   instance_subnets = aws_subnet.internal.*.id
 
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.config_instance_type
+  min_size      = var.number_of_apps
+  max_size      = var.number_of_apps
+  domain        = local.root_domain
+  instance_type = var.config_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -104,7 +104,7 @@ resource "aws_ecs_service" "frontend_v2" {
   task_definition = aws_ecs_task_definition.frontend.arn
   iam_role        = aws_iam_role.ecs_service_role.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_frontend_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -102,6 +102,7 @@ resource "aws_ecs_service" "frontend_v2" {
   name            = "${var.deployment}-frontend-v2"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.frontend.arn
+  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_apps
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -127,6 +127,11 @@ resource "aws_ecs_service" "frontend_v2" {
     registry_arn = aws_service_discovery_service.frontend.arn
     port         = 8443
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }
 
 module "frontend_can_connect_to_config" {

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -38,6 +38,7 @@ resource "aws_ecs_service" "metadata" {
   name            = "${var.deployment}-metadata"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.metadata.arn
+  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_apps
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -57,4 +57,9 @@ resource "aws_ecs_service" "metadata" {
       aws_security_group.can_connect_to_container_vpc_endpoint.id,
     ]
   }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_service" "metadata" {
   task_definition = aws_ecs_task_definition.metadata.arn
   iam_role        = aws_iam_role.ecs_service_role.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_metadata_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -7,9 +7,10 @@ module "policy_ecs_asg" {
   vpc_id           = aws_vpc.hub.id
   instance_subnets = aws_subnet.internal.*.id
 
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.policy_instance_type
+  min_size      = var.number_of_apps
+  max_size      = var.number_of_apps
+  domain        = local.root_domain
+  instance_type = var.policy_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -7,10 +7,11 @@ module "saml_engine_ecs_asg" {
   vpc_id           = aws_vpc.hub.id
   instance_subnets = aws_subnet.internal.*.id
 
-  use_egress_proxy    = true
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.saml_engine_instance_type
+  use_egress_proxy = true
+  min_size         = var.number_of_apps
+  max_size         = var.number_of_apps
+  domain           = local.root_domain
+  instance_type    = var.saml_engine_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -1,13 +1,14 @@
 module "saml_proxy_ecs_asg" {
   source = "./modules/ecs_asg"
 
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "saml-proxy"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
+  ami_id           = data.aws_ami.ubuntu_bionic.id
+  deployment       = var.deployment
+  cluster          = "saml-proxy"
+  vpc_id           = aws_vpc.hub.id
+  instance_subnets = aws_subnet.internal.*.id
+  min_size         = var.number_of_apps
+  max_size         = var.number_of_apps
+  domain           = local.root_domain
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -1,14 +1,15 @@
 module "saml_soap_proxy_ecs_asg" {
   source = "./modules/ecs_asg"
 
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "saml-soap-proxy"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.saml_soap_proxy_instance_type
+  ami_id           = data.aws_ami.ubuntu_bionic.id
+  deployment       = var.deployment
+  cluster          = "saml-soap-proxy"
+  vpc_id           = aws_vpc.hub.id
+  instance_subnets = aws_subnet.internal.*.id
+  min_size         = var.number_of_apps
+  max_size         = var.number_of_apps
+  domain           = local.root_domain
+  instance_type    = var.saml_soap_proxy_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -290,14 +290,15 @@ resource "aws_route53_record" "ingress_www" {
 module "ingress_ecs_asg" {
   source = "./modules/ecs_asg"
 
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "ingress"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps * 2
-  domain              = local.root_domain
-  instance_type       = var.ingress_instance_type
+  ami_id           = data.aws_ami.ubuntu_bionic.id
+  deployment       = var.deployment
+  cluster          = "ingress"
+  vpc_id           = aws_vpc.hub.id
+  instance_subnets = aws_subnet.internal.*.id
+  min_size         = var.number_of_apps * 2
+  max_size         = var.number_of_apps * 2
+  domain           = local.root_domain
+  instance_type    = var.ingress_instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -295,8 +295,8 @@ module "ingress_ecs_asg" {
   cluster          = "ingress"
   vpc_id           = aws_vpc.hub.id
   instance_subnets = aws_subnet.internal.*.id
-  min_size         = var.number_of_apps * 2
-  max_size         = var.number_of_apps * 10
+  min_size         = 2
+  max_size         = 20
   domain           = local.root_domain
   instance_type    = var.ingress_instance_type
 

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -52,9 +52,8 @@ resource "aws_launch_configuration" "cluster" {
 resource "aws_autoscaling_group" "cluster" {
   name                 = local.identifier
   launch_configuration = aws_launch_configuration.cluster.name
-  min_size             = var.number_of_instances
-  max_size             = var.number_of_instances
-  desired_capacity     = var.number_of_instances
+  min_size             = var.min_size
+  max_size             = var.max_size
   vpc_zone_identifier  = var.instance_subnets
 
   tag {

--- a/terraform/modules/hub/modules/ecs_asg/iam.tf
+++ b/terraform/modules/hub/modules/ecs_asg/iam.tf
@@ -149,3 +149,8 @@ resource "aws_iam_role_policy_attachment" "instance_additional" {
   role       = aws_iam_role.instance.name
   policy_arn = element(var.additional_instance_role_policy_arns, count.index)
 }
+
+resource "aws_iam_role_policy_attachment" "instance_ecs_service_role" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}

--- a/terraform/modules/hub/modules/ecs_asg/outputs.tf
+++ b/terraform/modules/hub/modules/ecs_asg/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = aws_autoscaling_group.cluster.name
+}
+
+output "arn" {
+  value = aws_autoscaling_group.cluster.arn
+}

--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -12,7 +12,11 @@ locals {
   identifier = "${var.deployment}-${var.cluster}"
 }
 
-variable "number_of_instances" {
+variable "min_size" {
+  default = 2
+}
+
+variable "max_size" {
   default = 2
 }
 

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -1,14 +1,15 @@
 module "static_ingress_ecs_asg" {
   source = "./modules/ecs_asg"
 
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "static-ingress"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.instance_type
+  ami_id           = data.aws_ami.ubuntu_bionic.id
+  deployment       = var.deployment
+  cluster          = "static-ingress"
+  vpc_id           = aws_vpc.hub.id
+  instance_subnets = aws_subnet.internal.*.id
+  min_size         = var.number_of_apps
+  max_size         = var.number_of_apps
+  domain           = local.root_domain
+  instance_type    = var.instance_type
 
   ecs_agent_image_identifier = local.ecs_agent_image_identifier
   tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -14,6 +14,18 @@ variable "number_of_apps" {
   default = 2
 }
 
+variable "number_of_frontend_apps" {
+  default = 2
+}
+
+variable "number_of_metadata_apps" {
+  default = 2
+}
+
+variable "number_of_analytics_apps" {
+  default = 2
+}
+
 variable "number_of_prometheus_apps" {
   default = 3
 }


### PR DESCRIPTION
## What

Allow us to set the scale of the `number_of_frontend_apps`, `number_of_analytics_apps` and `number_of_metadata_apps` independently from the global `number_of_apps`

## Why

So that we can scale out only the application that requires scaling out and avoid needing to overprovision the ECS cluster size.

## Context

frontend, analytics and metadata apps all live on the same "ingress" ECS cluster with a fixed cluster size, making it tricky to scale out the apps while keeping track of how big the cluster should be.

This changes uses [asg capacity provider](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html#asg-capacity-providers) to automatically scale the "ingress" cluster size based on the desired number of frontend, analytics and metadata app instances configured.

to ensure that two of the same task don't run on the same instance, we use the "spread" placement strategy.

## :warning: Before Merging

* [x] Ensure https://github.com/alphagov/verify-infrastructure-config/pull/285 has been merged FIRST to avoid accidentally scaling down frontend instances in prod!