### PR TITLE
remove redundent iam_role for services

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -68,7 +68,6 @@ resource "aws_ecs_service" "analytics" {
   name            = "${var.deployment}-analytics"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.analytics.arn
-  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_analytics_apps
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -102,7 +102,6 @@ resource "aws_ecs_service" "frontend_v2" {
   name            = "${var.deployment}-frontend-v2"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.frontend.arn
-  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_frontend_apps
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -38,7 +38,6 @@ resource "aws_ecs_service" "metadata" {
   name            = "${var.deployment}-metadata"
   cluster         = aws_ecs_cluster.ingress.id
   task_definition = aws_ecs_task_definition.metadata.arn
-  iam_role        = aws_iam_role.ecs_service_role.arn
 
   desired_count                      = var.number_of_metadata_apps
   deployment_minimum_healthy_percent = 50


### PR DESCRIPTION
it seems the task definition service role overrides the need for the
iam_role, and causes ECS to error