### PR TITLE
add aws cli and some friends to the awsc image

### DIFF
--- a/dockerfiles/awsc/Dockerfile
+++ b/dockerfiles/awsc/Dockerfile
@@ -5,4 +5,7 @@ ENV GO111MODULE  on
 
 RUN go get github.com/alphagov/awsc@$AWSC_VERSION
 
+RUN apt-get update  --yes && \
+    apt-get install --yes awscli jq
+
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
we need the aws cli in the awsc concourse-task image so that we can implement some
logic waiting for ECS-tasks to become ready, jq is included to make
scripting of aws cli calls easier