### PR TITLE
Upgrade squid to 4.11-r0

### DIFF
--- a/dockerfiles/squid/Dockerfile
+++ b/dockerfiles/squid/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.8
+FROM alpine:3.11
 
-RUN apk add --no-cache squid=3.5.27-r4
+RUN apk add --no-cache squid=4.10-r0
 
 RUN    touch /etc/squid/squid.conf \
     && chown squid /etc/squid/squid.conf


### PR DESCRIPTION
I reviewed the changelog and nothing jumps out as affecting us so we should be safe. It'll be obvious if something does catastrophically break and is easily reverted.