### PR TITLE
upgrade haproxy to v2.0.x

### DIFF
--- a/dockerfiles/haproxy-static-ingress-tls/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.9.4-alpine
+FROM haproxy:2.0.14-alpine
 
 EXPOSE 4500
 

--- a/dockerfiles/haproxy-static-ingress/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.9.4-alpine
+FROM haproxy:2.0.14-alpine
 
 EXPOSE 4500
 


### PR DESCRIPTION
## What

Upgrade to haproxy v2.x.x ...sticking with v2.0.x for now to minimise impact.

Config appears to be compatible as is.

## Why

so we are still cool and hip and cutting edge ... and because v1.x.x is [EOL 2020Q2](http://www.haproxy.org/)