### PR TITLE
Configure a copy of the config service to run on Fargate

### DIFF
--- a/terraform/modules/hub/fargate-ecs.tf
+++ b/terraform/modules/hub/fargate-ecs.tf
@@ -1,0 +1,3 @@
+resource "aws_ecs_cluster" "fargate-ecs-cluster" {
+  name = var.deployment
+}

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -136,7 +136,7 @@ module "config-fargate" {
   source = "./modules/ecs_fargate_app"
 
   deployment                 = var.deployment
-  cluster                    = "config"
+  app                        = "config"
   domain                     = local.root_domain
   vpc_id                     = aws_vpc.hub.id
   lb_subnets                 = aws_subnet.internal.*.id

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -135,6 +135,13 @@ module "frontend_can_connect_to_config" {
   destination_sg_id = module.config.lb_sg_id
 }
 
+module "frontend_can_connect_to_config_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.frontend_task.id
+  destination_sg_id = module.config-fargate.lb_sg_id
+}
+
 module "frontend_can_connect_to_policy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -129,6 +129,13 @@ module "policy_can_connect_to_config" {
   destination_sg_id = module.config.lb_sg_id
 }
 
+module "policy_can_connect_to_config_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_ecs_asg.instance_sg_id
+  destination_sg_id = module.config-fargate.lb_sg_id
+}
+
 module "policy_can_connect_to_saml_engine" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -86,6 +86,13 @@ module "saml_engine_can_connect_to_config" {
   destination_sg_id = module.config.lb_sg_id
 }
 
+module "saml_engine_can_connect_to_config_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
+  destination_sg_id = module.config-fargate.lb_sg_id
+}
+
 module "saml_engine_can_connect_to_policy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -126,6 +126,13 @@ module "saml_proxy_can_connect_to_config" {
   destination_sg_id = module.config.lb_sg_id
 }
 
+module "saml_proxy_can_connect_to_config_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.config-fargate.lb_sg_id
+}
+
 module "saml_proxy_can_connect_to_policy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -126,6 +126,13 @@ module "saml_soap_proxy_can_connect_to_config" {
   destination_sg_id = module.config.lb_sg_id
 }
 
+module "saml_soap_proxy_can_connect_to_config_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.config-fargate.lb_sg_id
+}
+
 module "saml_soap_proxy_can_connect_to_policy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/modules/ecs_fargate_app/data.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "account" {}
+
+locals {
+  account_id = data.aws_caller_identity.account.account_id
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -1,0 +1,41 @@
+module "cluster_ecs_roles" {
+  source = "../ecs_iam_role_pair"
+
+  deployment       = var.deployment
+  service_name     = var.cluster
+  tools_account_id = var.tools_account_id
+  image_name       = var.image_name
+}
+
+resource "aws_ecs_task_definition" "cluster" {
+  family                   = local.identifier
+  container_definitions    = var.task_definition
+  execution_role_arn       = module.cluster_ecs_roles.execution_role_arn
+  task_role_arn            = module.cluster_ecs_roles.task_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+}
+
+output "task_role_name" {
+  value = module.cluster_ecs_roles.task_role_name
+}
+
+resource "aws_ecs_service" "cluster" {
+  name            = local.identifier
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.cluster.arn
+
+  desired_count                      = var.number_of_tasks
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.task.arn
+    container_name   = var.container_name
+    container_port   = var.container_port
+  }
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -1,4 +1,4 @@
-module "cluster_ecs_roles" {
+module "ecs_roles" {
   source = "../ecs_iam_role_pair"
 
   deployment       = var.deployment
@@ -10,8 +10,8 @@ module "cluster_ecs_roles" {
 resource "aws_ecs_task_definition" "app" {
   family                   = local.identifier
   container_definitions    = var.task_definition
-  execution_role_arn       = module.cluster_ecs_roles.execution_role_arn
-  task_role_arn            = module.cluster_ecs_roles.task_role_arn
+  execution_role_arn       = module.ecs_roles.execution_role_arn
+  task_role_arn            = module.ecs_roles.task_role_arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.cpu
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "app" {
 }
 
 output "task_role_name" {
-  value = module.cluster_ecs_roles.task_role_name
+  value = module.ecs_roles.task_role_name
 }
 
 resource "aws_ecs_service" "app" {

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -2,12 +2,12 @@ module "cluster_ecs_roles" {
   source = "../ecs_iam_role_pair"
 
   deployment       = var.deployment
-  service_name     = var.cluster
+  service_name     = var.app
   tools_account_id = var.tools_account_id
   image_name       = var.image_name
 }
 
-resource "aws_ecs_task_definition" "cluster" {
+resource "aws_ecs_task_definition" "app" {
   family                   = local.identifier
   container_definitions    = var.task_definition
   execution_role_arn       = module.cluster_ecs_roles.execution_role_arn
@@ -22,10 +22,10 @@ output "task_role_name" {
   value = module.cluster_ecs_roles.task_role_name
 }
 
-resource "aws_ecs_service" "cluster" {
+resource "aws_ecs_service" "app" {
   name            = local.identifier
   cluster         = var.ecs_cluster_id
-  task_definition = aws_ecs_task_definition.cluster.arn
+  task_definition = aws_ecs_task_definition.app.arn
 
   desired_count                      = var.number_of_tasks
   deployment_minimum_healthy_percent = var.deployment_min_healthy_percent

--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -1,4 +1,4 @@
-resource "aws_lb" "cluster" {
+resource "aws_lb" "app" {
   load_balancer_type = "application"
 
   name            = local.identifier
@@ -29,12 +29,12 @@ resource "aws_lb_target_group" "task" {
   }
 
   depends_on = [
-    "aws_lb.cluster",
+    "aws_lb.app",
   ]
 }
 
 resource "aws_lb_listener" "cluster_http" {
-  load_balancer_arn = aws_lb.cluster.arn
+  load_balancer_arn = aws_lb.app.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -50,7 +50,7 @@ resource "aws_lb_listener" "cluster_http" {
 }
 
 resource "aws_lb_listener" "cluster_https" {
-  load_balancer_arn = aws_lb.cluster.arn
+  load_balancer_arn = aws_lb.app.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-1-2017-01"

--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -1,0 +1,63 @@
+resource "aws_lb" "cluster" {
+  load_balancer_type = "application"
+
+  name            = local.identifier
+  internal        = true
+  security_groups = [aws_security_group.lb.id]
+  subnets         = var.lb_subnets
+
+  tags = {
+    Deployment = var.deployment
+  }
+}
+
+resource "aws_lb_target_group" "task" {
+  name                 = "${local.identifier}-task"
+  port                 = "8443"
+  protocol             = "HTTPS"
+  target_type          = "instance"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 15
+  slow_start           = 30
+
+  health_check {
+    path     = var.health_check_path
+    protocol = var.health_check_protocol
+    interval = var.health_check_interval
+    timeout  = var.health_check_timeout
+    matcher  = var.health_check_http_codes
+  }
+
+  depends_on = [
+    "aws_lb.cluster",
+  ]
+}
+
+resource "aws_lb_listener" "cluster_http" {
+  load_balancer_arn = aws_lb.cluster.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "cluster_https" {
+  load_balancer_arn = aws_lb.cluster.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-1-2017-01"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.task.arn
+  }
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -33,7 +33,7 @@ resource "aws_lb_target_group" "task" {
   ]
 }
 
-resource "aws_lb_listener" "cluster_http" {
+resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.app.arn
   port              = "80"
   protocol          = "HTTP"
@@ -49,7 +49,7 @@ resource "aws_lb_listener" "cluster_http" {
   }
 }
 
-resource "aws_lb_listener" "cluster_https" {
+resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.app.arn
   port              = "443"
   protocol          = "HTTPS"

--- a/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "app" {
-  name = "${var.app}.${var.domain}."
+  name = "${var.app}-fargate.${var.domain}."
 
   vpc {
     vpc_id = var.vpc_id
@@ -12,7 +12,7 @@ resource "aws_route53_zone" "app" {
 
 resource "aws_route53_record" "lb" {
   zone_id = aws_route53_zone.app.zone_id
-  name    = "${var.app}.${var.domain}."
+  name    = "${var.app}-fargate.${var.domain}."
   type    = "A"
 
   alias {

--- a/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "cluster" {
+  name = "${var.cluster}.${var.domain}."
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  tags = {
+    Deployment = var.deployment
+  }
+}
+
+resource "aws_route53_record" "lb" {
+  zone_id = aws_route53_zone.cluster.zone_id
+  name    = "${var.cluster}.${var.domain}."
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.cluster.dns_name
+    zone_id                = aws_lb.cluster.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/route53.tf
@@ -1,5 +1,5 @@
-resource "aws_route53_zone" "cluster" {
-  name = "${var.cluster}.${var.domain}."
+resource "aws_route53_zone" "app" {
+  name = "${var.app}.${var.domain}."
 
   vpc {
     vpc_id = var.vpc_id
@@ -11,13 +11,13 @@ resource "aws_route53_zone" "cluster" {
 }
 
 resource "aws_route53_record" "lb" {
-  zone_id = aws_route53_zone.cluster.zone_id
-  name    = "${var.cluster}.${var.domain}."
+  zone_id = aws_route53_zone.app.zone_id
+  name    = "${var.app}.${var.domain}."
   type    = "A"
 
   alias {
-    name                   = aws_lb.cluster.dns_name
-    zone_id                = aws_lb.cluster.zone_id
+    name                   = aws_lb.app.dns_name
+    zone_id                = aws_lb.app.zone_id
     evaluate_target_health = false
   }
 }

--- a/terraform/modules/hub/modules/ecs_fargate_app/security_groups.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/security_groups.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "lb" {
+  name        = "${local.identifier}-lb"
+  description = "${local.identifier}-lb"
+
+  vpc_id = var.vpc_id
+}
+
+output "lb_sg_id" {
+  value = aws_security_group.lb.id
+}
+
+resource "aws_security_group_rule" "task_ingress_from_lb" {
+  type     = "ingress"
+  protocol = "tcp"
+
+  from_port = 1025
+  to_port   = 65535
+
+  security_group_id        = var.instance_security_group_id
+  source_security_group_id = aws_security_group.lb.id
+}
+
+resource "aws_security_group_rule" "lb_egress_to_task" {
+  type     = "egress"
+  protocol = "tcp"
+
+  from_port = 1025
+  to_port   = 65535
+
+  # source is destination for egress
+  source_security_group_id = var.instance_security_group_id
+  security_group_id        = aws_security_group.lb.id
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
@@ -1,0 +1,66 @@
+variable "cluster" {}
+variable "container_name" {}
+variable "container_port" {}
+variable "deployment" {}
+variable "domain" {}
+variable "task_definition" {}
+variable "vpc_id" {}
+variable "tools_account_id" {}
+variable "instance_security_group_id" {}
+variable "certificate_arn" {}
+
+variable "image_name" {
+  default = ""
+}
+
+variable "lb_subnets" {
+  type = "list"
+}
+
+locals {
+  identifier = "${var.deployment}-${var.cluster}"
+}
+
+variable "number_of_tasks" {
+  default = 2
+}
+
+variable "deployment_min_healthy_percent" {
+  default = 50
+}
+
+variable "deployment_max_percent" {
+  default = 100
+}
+
+variable "health_check_path" {
+  default = "/"
+}
+
+variable "health_check_protocol" {
+  default = "HTTPS"
+}
+
+variable "health_check_interval" {
+  default = 10
+}
+
+variable "health_check_timeout" {
+  default = 5
+}
+
+variable "health_check_http_codes" {
+  default = "200"
+}
+
+variable "ecs_cluster_id" {
+  type = "string"
+}
+
+variable "cpu" {
+  type = number
+}
+
+variable "memory" {
+  type = number
+}

--- a/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster" {}
+variable "app" {}
 variable "container_name" {}
 variable "container_port" {}
 variable "deployment" {}
@@ -18,7 +18,7 @@ variable "lb_subnets" {
 }
 
 locals {
-  identifier = "${var.deployment}-${var.cluster}"
+  identifier = "${var.deployment}-${var.app}"
 }
 
 variable "number_of_tasks" {

--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -17,3 +17,7 @@ output "public_subnet_ids" {
 output "config_lb_sg_id" {
   value = module.config.lb_sg_id
 }
+
+output "config_fargate_lb_sg_id" {
+  value = module.config-fargate.lb_sg_id
+}

--- a/terraform/modules/self-service/security_groups.tf
+++ b/terraform/modules/self-service/security_groups.tf
@@ -72,6 +72,19 @@ resource "aws_security_group_rule" "self_service_ingress_to_config_lb" {
   description = "Allows traffic from self-service app to config"
 }
 
+resource "aws_security_group_rule" "self_service_ingress_to_config_fargate_lb" {
+  type     = "ingress"
+  protocol = "tcp"
+
+  from_port = 443
+  to_port   = 443
+
+  security_group_id        = data.terraform_remote_state.hub.outputs.config_fargate_lb_sg_id
+  source_security_group_id = aws_security_group.egress_over_https.id
+
+  description = "Allows traffic from self-service app to config-fargate"
+}
+
 resource "aws_security_group" "egress_to_db" {
   name        = "${local.service}-egress-to-db"
   description = "${local.service} security group connecting to self service db"


### PR DESCRIPTION
You may want to use `diff -rb terraform/modules/hub/modules/ecs_app terraform/modules/hub/modules/ecs_fargate_app` to review part of this PR. By and large it's the existing thing with some tweaks to send it to Fargate instead of EC2.