### PR TITLE
AUT-732: Upgrade Sentry to v9.1.2

### DIFF
--- a/dockerfiles/verify-sentry/Dockerfile
+++ b/dockerfiles/verify-sentry/Dockerfile
@@ -1,1 +1,1 @@
-FROM sentry:9.0-onbuild
+FROM sentry:9.1.2-onbuild


### PR DESCRIPTION
This change updates Dockerfile from v9 to v9.1.2 so that we can run sentry-upgrade task to perform database migration.

Co-authored-by: David Pye <david.pye@digital.cabinet-office.gov.uk>
Co-authored-by: Jamie Maynard <james.maynard@digital.cabinet-office.gov.uk>