### PR TITLE
Resource AWS naming fixes

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -2,7 +2,7 @@ module "ecs_roles" {
   source = "../ecs_iam_role_pair"
 
   deployment       = var.deployment
-  service_name     = var.app
+  service_name     = "${var.app}-fargate"
   tools_account_id = var.tools_account_id
   image_name       = var.image_name
 }

--- a/terraform/modules/hub/modules/ecs_fargate_app/security_groups.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/security_groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "lb" {
-  name        = "${local.identifier}-lb"
-  description = "${local.identifier}-lb"
+  name        = "${local.identifier}-fargate-lb"
+  description = "${local.identifier}-fargate-lb"
 
   vpc_id = var.vpc_id
 }


### PR DESCRIPTION
Need to ensure that resources for our Fargate modules have different names to
those for our EC2 modules.