### PR TITLE
Use target_type ip for Fargate apps

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -15,7 +15,7 @@ resource "aws_lb_target_group" "task" {
   name                 = "${local.identifier}-fargate-task"
   port                 = "8443"
   protocol             = "HTTPS"
-  target_type          = "instance"
+  target_type          = "ip"
   vpc_id               = var.vpc_id
   deregistration_delay = 15
   slow_start           = 30


### PR DESCRIPTION
Error: InvalidParameterException: The provided target group [...] has target type instance, which is incompatible with the awsvpc network mode specified in the task definition. "staging-config"