### PR TITLE
Add awslogs configuration to config in Fargate

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -87,6 +87,15 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
+    },
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${deployment}-hub",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "config",
+        "awslogs-create-group": true
+      }
     }
   }
 ]

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -22,6 +22,30 @@ output "task_role_name" {
   value = module.ecs_roles.task_role_name
 }
 
+resource "aws_iam_policy" "execution" {
+  name = "${local.identifier}-execution"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:CreateLogGroup"
+      ],
+      "Resource": "*"
+    }]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "execution_can_write_logs" {
+  role       = module.ecs_roles.execution_role_name
+  policy_arn = aws_iam_policy.execution.arn
+}
+
 resource "aws_ecs_service" "app" {
   name            = local.identifier
   cluster         = var.ecs_cluster_id

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
@@ -21,6 +21,10 @@ resource "aws_iam_role" "execution" {
   EOF
 }
 
+output "execution_role_name" {
+  value = aws_iam_role.execution.name
+}
+
 output "execution_role_arn" {
   value = aws_iam_role.execution.arn
 }


### PR DESCRIPTION
Also add permissions such that Fargate can push to CloudWatch. Add a missing output from the roles module so we get the name of the execution role.