### PR TITLE
Add permissions to get FireLens image for fluentbit

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -28,15 +28,32 @@ resource "aws_iam_policy" "execution_logs" {
   policy = <<-EOF
   {
     "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:CreateLogGroup"
-      ],
-      "Resource": "*"
-    }]
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:DescribeImages",
+          "ecr:BatchGetImage"
+        ],
+        "Resource": [
+          "arn:aws:ecr:eu-west-2:906394416424:repository/aws-for-fluent-bit",
+        ]
+      }
+    ]
   }
   EOF
 }


### PR DESCRIPTION
We got CannotPullContainerError: Error response from daemon: pull access denied for 906394416424.dkr.ecr.us-west-2.amazonaws.com/aws-for-fluent-bit, repository does not exist or may require 'docker login'