### PR TITLE
Add temporary hack to make fluentbit successfully send to Elasticsearch

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -47,7 +47,7 @@
         "Name": "es",
         "Host": "${logit_elasticsearch_url}",
         "Port": "443",
-        "Path": "/_bulk?apikey=${logit_api_key}",
+        "Path": "/_bulk?apikey=${logit_api_key}#",
         "tls": "on"
       }
     }
@@ -122,7 +122,7 @@
         "Name": "es",
         "Host": "${logit_elasticsearch_url}",
         "Port": "443",
-        "Path": "/_bulk?apikey=${logit_api_key}",
+        "Path": "/_bulk?apikey=${logit_api_key}#",
         "tls": "on"
       }
     }


### PR DESCRIPTION
So we need to specify this special `apikey` parameter, but we don't have a good
way to configure fluentbit or fluentd's elasticsearch plugins to do that.
We can set the Path variable but it turns out that's just a prefix for the rest
of the path.
Here's the evil bit:
If we add a hash at the end, the extra `/_bulk` added on will be part of the
anchor and will be ignored by the HTTP library.
TODO: This is tech debt that we need to kill, probably with a migration to
Splunk.