### PR TITLE
[untested] parse JSON logs in fluentbit

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -4,7 +4,11 @@
     "image": "906394416424.dkr.ecr.eu-west-2.amazonaws.com/aws-for-fluent-bit:latest",
     "name": "log_router",
     "firelensConfiguration": {
-      "type": "fluentbit"
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "file",
+        "config-file-value": "/fluent-bit/configs/parse-json.conf"
+      }
     },
     "logConfiguration": {
       "logDriver": "awslogs",


### PR DESCRIPTION
We have some config in journalbeat to parse JSON.  I suspect we need
to do something similar for fluentbit?  I found this config snippet
here:
https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/master/examples/fluent-bit/parse-json
and I wondered if we just whack it in whether it will just make things
work.