### PR TITLE
Create new index per day

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -50,6 +50,8 @@
       "options": {
         "Name": "es",
         "Host": "${logit_elasticsearch_url}",
+        "Logstash_Format": "True",
+        "Logstash_Prefix": "fluentbit",
         "Port": "443",
         "Path": "/_bulk?apikey=${logit_api_key}#",
         "tls": "on"


### PR DESCRIPTION
This sets things up so that we create a new elasticsearch index every
day for new logs.  This seems to be the logstashy way of doing
things... it means old indexes can be closed and archived and
elasticsearch can use storage more efficiently.