### PR TITLE
Revert "[untested] parse JSON logs in fluentbit"

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -4,11 +4,7 @@
     "image": "906394416424.dkr.ecr.eu-west-2.amazonaws.com/aws-for-fluent-bit:latest",
     "name": "log_router",
     "firelensConfiguration": {
-      "type": "fluentbit",
-      "options": {
-        "config-file-type": "file",
-        "config-file-value": "/fluent-bit/configs/parse-json.conf"
-      }
+      "type": "fluentbit"
     },
     "logConfiguration": {
       "logDriver": "awslogs",


### PR DESCRIPTION
Reverts alphagov/verify-infrastructure#428

This didn't work, it caused log shipping to (mostly) fail.