### PR TITLE
BAU: Create a separate task definition for config fargate

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -8,7 +8,7 @@ module "ecs_roles" {
 }
 
 resource "aws_ecs_task_definition" "app" {
-  family                   = local.identifier
+  family                   = "${local.identifier}-fargate"
   container_definitions    = var.task_definition
   execution_role_arn       = module.ecs_roles.execution_role_arn
   task_role_arn            = module.ecs_roles.task_role_arn


### PR DESCRIPTION
deploy-hub-[staging, integration and prod] job sometimes fails due to the following error message.

```
Error: ClientException: Too many concurrent attempts to create a new revision of the specified family.

  on ../../../../../verify-infrastructure/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf line 10, in resource "aws_ecs_task_definition" "app":
  10: resource "aws_ecs_task_definition" "app" {
```

Config (EC2) and Config (Fargate) are sharing the same task definition name (staging-config). This change updates Config (Fargate) to use a separate task definition name (staging-config-fargate). This will resolve "too many concurrent attempts" error.

Author: @adityapahuja