### PR TITLE
Try sending new Fargate app logs to Splunk via CSLS instead

### DIFF
--- a/terraform/modules/hub/fargate-ecs.tf
+++ b/terraform/modules/hub/fargate-ecs.tf
@@ -1,3 +1,13 @@
 resource "aws_ecs_cluster" "fargate-ecs-cluster" {
   name = var.deployment
 }
+
+resource "aws_cloudwatch_log_group" "fargate-logs" {
+  name = "${var.deployment}-hub"
+}
+resource "aws_cloudwatch_log_subscription_filter" "csls-subscription" {
+  name            = "${var.deployment}-hub-csls"
+  log_group_name  = aws_cloudwatch_log_group.fargate-logs.name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
+}

--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -1,23 +1,5 @@
 [
   {
-    "essential": true,
-    "image": "906394416424.dkr.ecr.eu-west-2.amazonaws.com/aws-for-fluent-bit:latest",
-    "name": "log_router",
-    "firelensConfiguration": {
-      "type": "fluentbit"
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "config-firelens",
-        "awslogs-create-group": "true"
-      }
-    },
-    "memoryReservation": 50
-  },
-  {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
     "cpu": 896,
@@ -42,15 +24,12 @@
       }
     ],
     "logConfiguration": {
-      "logDriver": "awsfirelens",
+      "logDriver": "awslogs",
       "options": {
-        "Name": "es",
-        "Host": "${logit_elasticsearch_url}",
-        "Logstash_Format": "True",
-        "Logstash_Prefix": "fluentbit",
-        "Port": "443",
-        "Path": "/_bulk?apikey=${logit_api_key}#",
-        "tls": "on"
+        "awslogs-group": "${deployment}-hub",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "config-nginx",
+        "awslogs-create-group": "true"
       }
     }
   },
@@ -119,13 +98,12 @@
       "Timeout": 5
     },
     "logConfiguration": {
-      "logDriver": "awsfirelens",
+      "logDriver": "awslogs",
       "options": {
-        "Name": "es",
-        "Host": "${logit_elasticsearch_url}",
-        "Port": "443",
-        "Path": "/_bulk?apikey=${logit_api_key}#",
-        "tls": "on"
+        "awslogs-group": "${deployment}-hub",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "config",
+        "awslogs-create-group": "true"
       }
     }
   }

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -109,8 +109,6 @@ data "template_file" "config_task_def_fargate" {
     metadata_object_key      = local.metadata_object_key
     memory_hard_limit        = var.config_memory_hard_limit
     jvm_options              = var.jvm_options
-    logit_elasticsearch_url  = var.logit_elasticsearch_url
-    logit_api_key            = var.logit_api_key
   }
 }
 
@@ -185,7 +183,7 @@ module "config-fargate" {
   ecs_cluster_id             = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu                        = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.config_memory_hard_limit + 250 + 50, 4096) / 1024) * 1024
+  memory  = ceil(max(var.config_memory_hard_limit + 250, 4096) / 1024) * 1024
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.scraped_by_prometheus.id,

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -37,21 +37,6 @@ resource "aws_iam_policy" "execution_logs" {
           "logs:CreateLogGroup"
         ],
         "Resource": "*"
-      },
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:GetRepositoryPolicy",
-          "ecr:DescribeRepositories",
-          "ecr:ListImages",
-          "ecr:DescribeImages",
-          "ecr:BatchGetImage"
-        ],
-        "Resource": [
-          "arn:aws:ecr:eu-west-2:906394416424:repository/aws-for-fluent-bit"
-        ]
       }
     ]
   }

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -58,6 +58,10 @@ variable "logit_elasticsearch_url" {
   description = "URL for logit.io elasticsearch, format: $guid-es.logit.io"
 }
 
+variable "cls_destination_arn" {
+  description = "ARN of the CSLS destination to send logs to"
+}
+
 variable "event_emitter_api_gateway_url" {
   description = "URL for Event Emitter API Gateway"
 }


### PR DESCRIPTION
Via CSLS and not directly because of Splunk reliability concerns.

This is in a large part a revert to pre-#424 functionality, but with the
addition of a terraform'd log group and subscription filter.