### PR TITLE
Fixes for running awslogs containers on our EC2 ECS instances

### DIFF
--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -215,6 +215,7 @@ ExecStart=/usr/bin/docker run \
   --env=ECS_ENABLE_TASK_IAM_ROLE=true \
   --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald", "awslogs"]' \
+  --env='ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true' \
   --env="ECS_LOGLEVEL=warn" \
   ${ecs_agent_image_identifier}
 


### PR DESCRIPTION
* ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true is something that ecs-init's
  RPM package would be setting for us.
* The 169.254.170.2 IP is the ECS metadata API that ecs-agent exposes that
  other contains expect to be able to route to. The addition here is a modified
  copy of what we do in the normal non-Prometheus ECS instance user data.

A lot of this will hopefully become less relevant shortly as we hope to move a
lot of things (maybe even all of it) to using Fargate so we stop managing this
level as I'm having to do here.