### PR TITLE
Add CloudWatch to egress proxy safelist alongside Logit and Splunk direct

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -63,6 +63,7 @@ locals {
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
+    "logs.${data.aws_region.region.id}.amazonaws.com",       # CloudWatch, for shipping logs to Splunk via CSLS
   ]
 
   egress_proxy_whitelist = join(" ", local.egress_proxy_whitelist_list)


### PR DESCRIPTION
No idea why Splunk's direct endpoint is on here already. We're not using that though, we're pushing to Splunk via CW/CSLS.