### PR TITLE
Provide egress proxy config to ECS agent where required

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -63,7 +63,7 @@ locals {
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
-    "logs.${data.aws_region.region.id}.amazonaws.com",       # CloudWatch, for shipping logs to Splunk via CSLS
+    "logs\\.${data.aws_region.region.id}\\.amazonaws\\.com", # CloudWatch, for shipping logs to Splunk via CSLS
   ]
 
   egress_proxy_whitelist = join(" ", local.egress_proxy_whitelist_list)

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -12,6 +12,12 @@ locals {
     ? "proxy_url: ${local.egress_proxy_url_with_protocol}"
     : ""
   }"
+
+  ecs_agent_proxy_config = "${
+    var.use_egress_proxy
+    ? "--env=HTTP_PROXY=${local.egress_proxy_url_with_protocol} --env=NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock"
+    : ""
+  }"
 }
 
 data "template_file" "cloud_init" {
@@ -24,6 +30,7 @@ data "template_file" "cloud_init" {
     logit_elasticsearch_url          = var.logit_elasticsearch_url
     logit_api_key                    = var.logit_api_key
     ecs_agent_image_identifier       = var.ecs_agent_image_identifier
+    ecs_agent_proxy_config           = local.ecs_agent_proxy_config
     tools_account_id                 = var.tools_account_id
   }
 }

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -217,6 +217,7 @@ ExecStart=/usr/bin/docker run \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald", "awslogs"]' \
   --env='ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true' \
   --env="ECS_LOGLEVEL=warn" \
+  ${ecs_agent_proxy_config} \
   ${ecs_agent_image_identifier}
 
 ExecStop=/usr/bin/docker stop -t 120 ecs-agent


### PR DESCRIPTION
This will be responsible for pushing to CloudWatch now instead of journalbeat.

Also escape `.` in egress proxy safelist entry.