### PR TITLE
Revert egress proxy changes around the saml-engine ECS agent, replace with VPC Endpoint

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -63,7 +63,6 @@ locals {
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
-    "logs\\.${data.aws_region.region.id}\\.amazonaws\\.com", # CloudWatch, for shipping logs to Splunk via CSLS
   ]
 
   egress_proxy_whitelist = join(" ", local.egress_proxy_whitelist_list)

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -12,12 +12,6 @@ locals {
     ? "proxy_url: ${local.egress_proxy_url_with_protocol}"
     : ""
   }"
-
-  ecs_agent_proxy_config = "${
-    var.use_egress_proxy
-    ? "--env=HTTP_PROXY=${local.egress_proxy_url_with_protocol} --env=NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock"
-    : ""
-  }"
 }
 
 data "template_file" "cloud_init" {
@@ -30,7 +24,6 @@ data "template_file" "cloud_init" {
     logit_elasticsearch_url          = var.logit_elasticsearch_url
     logit_api_key                    = var.logit_api_key
     ecs_agent_image_identifier       = var.ecs_agent_image_identifier
-    ecs_agent_proxy_config           = local.ecs_agent_proxy_config
     tools_account_id                 = var.tools_account_id
   }
 }

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -217,7 +217,6 @@ ExecStart=/usr/bin/docker run \
   --env='ECS_AVAILABLE_LOGGING_DRIVERS=["journald", "awslogs"]' \
   --env='ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true' \
   --env="ECS_LOGLEVEL=warn" \
-  ${ecs_agent_proxy_config} \
   ${ecs_agent_image_identifier}
 
 ExecStop=/usr/bin/docker stop -t 120 ecs-agent

--- a/terraform/modules/hub/vpc.tf
+++ b/terraform/modules/hub/vpc.tf
@@ -155,6 +155,18 @@ resource "aws_vpc_endpoint" "ecs" {
   private_dns_enabled = true
 }
 
+resource "aws_vpc_endpoint" "cloudwatch-logs" {
+  vpc_id            = aws_vpc.hub.id
+  service_name      = "com.amazonaws.eu-west-2.logs"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = aws_subnet.internal.*.id
+
+  security_group_ids = [aws_security_group.container_vpc_endpoint.id]
+
+  private_dns_enabled = true
+}
+
 resource "aws_vpc_endpoint" "ssm" {
   vpc_id            = aws_vpc.hub.id
   service_name      = "com.amazonaws.eu-west-2.ssm"


### PR DESCRIPTION
This reverts commit 4095faa79c1ed2e6de583c435975ba00eff48b5b.
This reverts commit 2311f8f66b68791900bbf1177edba6d728572519.

It turns out to do that we would need to safelist a bunch of things in the egress
proxy such as ECS, ECS-A (Agent?), ECS-T (Telemetry?), SSM, and probably more
like ECR.