### PR TITLE
Back out "Ship logs from (almost) all remaining Hub components to Splunk" until we're ready for it

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -36,8 +36,6 @@ data "template_file" "analytics_task_def" {
   vars = {
     nginx_image_identifier = "${local.tools_account_ecr_url_prefix}-verify-nginx-tls@${var.nginx_image_digest}"
     location_blocks_base64 = local.nginx_analytics_location_blocks_base64
-    deployment             = var.deployment
-    region                 = data.aws_region.region.id
   }
 }
 

--- a/terraform/modules/hub/cloudwatch_exporter.tf
+++ b/terraform/modules/hub/cloudwatch_exporter.tf
@@ -13,8 +13,6 @@ data "template_file" "cloudwatch_exporter_task_def" {
   vars = {
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-cloudwatch-exporter@${var.cloudwatch_exporter_image_digest}"
     config_base64    = base64encode(file("${path.module}/files/prometheus/cloudwatch_exporter.yml"))
-    deployment       = var.deployment
-    region           = data.aws_region.region.id
   }
 }
 

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -74,8 +74,6 @@ data "template_file" "egress_proxy_task_def" {
   vars = {
     whitelist_base64 = base64encode(local.egress_proxy_whitelist)
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-squid@${var.squid_image_digest}"
-    deployment       = var.deployment
-    region           = data.aws_region.region.id
   }
 }
 

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -16,15 +16,6 @@
         "Name": "LOCATION_BLOCKS",
         "Value": "${location_blocks_base64}"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "analytics-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
+++ b/terraform/modules/hub/files/tasks/cloudwatch-exporter.json
@@ -17,15 +17,6 @@
         "Value": "${config_base64}"
       }
     ],
-    "entryPoint": ["bash", "-c", "unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /config/config.yml; java -jar /cloudwatch_exporter.jar 9106 /config/config.yml"],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "cloudwatch-exporter",
-        "awslogs-create-group": "true"
-      }
-    }
+    "entryPoint": ["bash", "-c", "unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /config/config.yml; java -jar /cloudwatch_exporter.jar 9106 /config/config.yml"]
   }
 ]

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -22,16 +22,7 @@
         "containerName": "frontend",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "frontend-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "frontend",
@@ -181,15 +172,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "frontend",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/frontend_xlarge.json
+++ b/terraform/modules/hub/files/tasks/frontend_xlarge.json
@@ -22,16 +22,7 @@
         "containerName": "frontend",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "frontend-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "frontend",
@@ -181,15 +172,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "frontend",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -23,16 +23,7 @@
         "containerName": "config",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "config-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "config",
@@ -97,15 +88,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "config",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -23,16 +23,7 @@
         "containerName": "policy",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "policy-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "policy",
@@ -97,15 +88,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "policy",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -23,16 +23,7 @@
         "containerName": "saml-engine",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-engine-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "saml-engine",
@@ -113,15 +104,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-engine",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -23,16 +23,7 @@
         "containerName": "saml-proxy",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-proxy-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "saml-proxy",
@@ -101,15 +92,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-proxy",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -23,16 +23,7 @@
         "containerName": "saml-soap-proxy",
         "condition": "HEALTHY"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-soap-proxy-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   },
   {
     "name": "saml-soap-proxy",
@@ -101,15 +92,6 @@
       "Retries": 3,
       "StartPeriod": 10,
       "Timeout": 5
-    },
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "saml-soap-proxy",
-        "awslogs-create-group": "true"
-      }
     }
   }
 ]

--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -19,15 +19,6 @@
     "environment": [{
       "Name": "APP_ENV",
       "Value": "${environment}"
-    }],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "metadata-exporter",
-        "awslogs-create-group": "true"
-      }
-    }
+    }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -14,15 +14,6 @@
     "environment": [{
       "Name": "DEPLOYMENT",
       "Value": "${deployment}"
-    }],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "metadata-nginx",
-        "awslogs-create-group": "true"
-      }
-    }
+    }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/prometheus.json
+++ b/terraform/modules/hub/files/tasks/prometheus.json
@@ -31,15 +31,6 @@
       "sh",
       "-c",
       "set -ueo pipefail; unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; unset AWS_EXECUTION_ENV; echo $CONFIG_BASE64 | base64 -d > /etc/prometheus/prometheus.yml; echo $ALERTS_BASE64 | base64 -d > /etc/prometheus/alerts.yml; prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=120d --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles --web.external-url=${external_url}"
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "prometheus",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   }
 ]

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -14,15 +14,6 @@
     "environment": [{
       "Name": "WHITELIST",
       "Value": "${whitelist_base64}"
-    }],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "squid",
-        "awslogs-create-group": "true"
-      }
-    }
+    }]
   }
 ]

--- a/terraform/modules/hub/files/tasks/static-ingress.json
+++ b/terraform/modules/hub/files/tasks/static-ingress.json
@@ -35,15 +35,6 @@
         "namespace": "net.ipv4.ip_unprivileged_port_start",
         "value": "0"
       }
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${deployment}-hub",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "static-ingress-${bind_port}",
-        "awslogs-create-group": "true"
-      }
-    }
+    ]
   }
 ]

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -14,7 +14,6 @@ data "template_file" "metadata_task_def" {
 
   vars = {
     deployment       = var.deployment
-    region           = data.aws_region.region.id
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-metadata@${var.hub_metadata_image_digest}"
   }
 }

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -14,7 +14,6 @@ data "template_file" "metadata_exporter_task_def" {
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-metadata-exporter@${var.metadate_exporter_image_digest}"
     signin_domain    = var.signin_domain
     deployment       = var.deployment
-    region           = data.aws_region.region.id
     environment      = var.metadata_exporter_environment
   }
 }

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -22,6 +22,32 @@ output "task_role_name" {
   value = module.ecs_roles.task_role_name
 }
 
+resource "aws_iam_policy" "execution_logs" {
+  name = "${local.identifier}-execution-logs"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "execution_can_write_logs" {
+  role       = module.ecs_roles.execution_role_name
+  policy_arn = aws_iam_policy.execution_logs.arn
+}
+
 resource "aws_ecs_service" "app" {
   name            = local.identifier
   cluster         = var.ecs_cluster_id

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/execution_role.tf
@@ -66,14 +66,6 @@ resource "aws_iam_policy" "execution" {
         "arn:aws:ssm:eu-west-2:${local.account_id}:parameter/${var.deployment}/${var.service_name}/*",
         "arn:aws:ssm:eu-west-2:${local.account_id}:parameter/${var.deployment}/ecs-app-shared/*"
       ]
-    }, {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:CreateLogGroup"
-      ],
-      "Resource": "*"
     }]
   }
   EOF

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -445,8 +445,6 @@ data "template_file" "prometheus_task_def" {
     config_base64    = base64encode(data.template_file.prometheus_config.rendered)
     alerts_base64    = base64encode(file("${path.module}/files/prometheus/alerts.yml"))
     external_url     = "https://prom-${count.index + 1}.${local.mgmt_domain}"
-    deployment       = var.deployment
-    region           = data.aws_region.region.id
   }
 }
 

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -113,8 +113,6 @@ data "template_file" "static_ingress_http_task_def" {
     backend_port     = 80
     allocated_cpu    = local.allocated_cpu_for_http
     allocated_memory = local.allocated_memory_for_http
-    deployment       = var.deployment
-    region           = data.aws_region.region.id
   }
 }
 
@@ -128,8 +126,6 @@ data "template_file" "static_ingress_https_task_def" {
     backend_port     = 443
     allocated_cpu    = local.allocated_cpu_for_https
     allocated_memory = local.allocated_memory_for_https
-    deployment       = var.deployment
-    region           = data.aws_region.region.id
   }
 }
 


### PR DESCRIPTION
Reverts alphagov/verify-infrastructure#444

So this works now, but it's a big bang change log shipping from Logit to Splunk suddenly kind of thing. We should probably figure out exactly when to do it, which is likely not at the same time as me taking leave. I've looked at the dashboards in Logit and now have some idea of how they'd be replicated in Splunk.