### PR TITLE
Upgrade prometheus AMI to Focal

### DIFF
--- a/terraform/modules/hub/data.tf
+++ b/terraform/modules/hub/data.tf
@@ -10,6 +10,18 @@ data "aws_ami" "ubuntu_bionic" {
   }
 }
 
+data "aws_ami" "ubuntu_focal" {
+  most_recent = true
+
+  # canonical
+  owners = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+}
+
 data "aws_caller_identity" "account" {}
 
 data "aws_region" "region" {}

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -8,7 +8,7 @@ apt-get update  --yes
 apt-get upgrade --yes
 
 # AWS SSM Agent
-# Installed by default on Ubuntu Bionic AMIs via Snap
+# Installed by default on Ubuntu Focal AMIs via Snap
 echo 'Configuring AWS SSM'
 mkdir -p /etc/amazon/ssm
 cat <<EOF > /etc/amazon/ssm/seelog.xml

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -339,7 +339,7 @@ data "template_file" "prometheus_cloud_init" {
 resource "aws_instance" "prometheus" {
   count = var.number_of_prometheus_apps
 
-  ami                  = data.aws_ami.ubuntu_bionic.id
+  ami                  = data.aws_ami.ubuntu_focal.id
   instance_type        = "t3.large"
   subnet_id            = element(aws_subnet.internal.*.id, count.index)
   iam_instance_profile = aws_iam_instance_profile.prometheus.name


### PR DESCRIPTION
This upgrades the Prometheus AMI to focal fossa, the latest Ubuntu LTS
release.

This only upgrades Prometheus; we might want to upgrade the rest of
the ECS nodes, or they might become obsoleted by fargate.

I suspect there isn't much to do but it will probably be worth pausing
production to make sure there aren't any issues in staging when it
gets deployed.