### PR TITLE
Set CloudWatch log group retention to a week

### DIFF
--- a/terraform/modules/hub/fargate-ecs.tf
+++ b/terraform/modules/hub/fargate-ecs.tf
@@ -3,7 +3,8 @@ resource "aws_ecs_cluster" "fargate-ecs-cluster" {
 }
 
 resource "aws_cloudwatch_log_group" "fargate-logs" {
-  name = "${var.deployment}-hub"
+  name              = "${var.deployment}-hub"
+  retention_in_days = 7
 }
 resource "aws_cloudwatch_log_subscription_filter" "csls-subscription" {
   name            = "${var.deployment}-hub-csls"


### PR DESCRIPTION
This group is subscribed to CSLS, we don't need to retain logs for long. Keep a
7 day buffer in case CSLS breaks or something.

Right now it retains logs indefinitely but we almost certainly do not want that