### PR TITLE
matomo: match fargate task size with task def

### DIFF
--- a/terraform/modules/hub/files/matomo/matomo-task-def.json
+++ b/terraform/modules/hub/files/matomo/matomo-task-def.json
@@ -1,7 +1,7 @@
 [
   {
     "cpu": 3072,
-    "memory": 12288,
+    "memory": 7168,
     "essential": true,
     "image": "${image_and_tag}",
     "name": "matomo",

--- a/terraform/modules/hub/matomo.tf
+++ b/terraform/modules/hub/matomo.tf
@@ -87,8 +87,8 @@ resource "aws_ecs_task_definition" "matomo_task_def" {
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.matomo_execution.arn
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 512
-  memory                   = 2048
+  cpu                      = 4096
+  memory                   = 8192
 
   volume {
     name = local.volume_name


### PR DESCRIPTION
requested fargate task limits must match container requests for
cpu/memory.