### PR TITLE
matomo: default two instances

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -94,7 +94,7 @@ variable "matomo_archiving_cronitor_url" {
 
 variable "matomo_desired_count" {
   description = "number of matomo instances"
-  default     = 1
+  default     = 2
 }
 
 variable "analytics_endpoint" {


### PR DESCRIPTION
two instances is the min for a rolling deployment