### PR TITLE
accounts: trust big concourse

### DIFF
--- a/terraform/modules/hub/deployer.tf
+++ b/terraform/modules/hub/deployer.tf
@@ -9,7 +9,10 @@ resource "aws_iam_role" "deployer" {
       {
         "Action": "sts:AssumeRole",
         "Principal": {
-          "AWS": "arn:aws:iam::${var.tools_account_id}:role/concourse-worker"
+          "AWS": [
+            "arn:aws:iam::${var.tools_account_id}:role/concourse-worker",
+            "arn:aws:iam::047969882937:role/cd-verify-concourse-worker"
+          ]
         },
         "Effect": "Allow"
       }


### PR DESCRIPTION
we are moving pipelines away from the verify specific concourse to the
centrally managed concourse and so require trusting the new verify
concourse workers.