### PR TITLE
BAU allow log level to be set in config fargate task

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config-fargate.json
+++ b/terraform/modules/hub/files/tasks/hub-config-fargate.json
@@ -88,6 +88,10 @@
       {
         "Name": "METADATA_OBJECT_KEY",
         "Value": "${metadata_object_key}"
+      },
+      {
+        "Name": "LOG_LEVEL",
+        "Value": "${log_level}"
       }
     ],
     "healthCheck" : {

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -32,6 +32,7 @@ data "template_file" "config_task_def_fargate" {
     metadata_object_key      = local.metadata_object_key
     memory_hard_limit        = var.config_memory_hard_limit
     jvm_options              = var.jvm_options
+    log_level                = var.hub_config_log_level
   }
 }
 


### PR DESCRIPTION
Allow value in terraform `var.hub_config_log_level` to be set as log level in the new fargate task.
This was set in the 'old' config task, which has been replaced by a fargated version.