### PR TITLE
AUT-777: Remove non-existent concourse worker role

### DIFF
--- a/terraform/modules/hub/deployer.tf
+++ b/terraform/modules/hub/deployer.tf
@@ -10,7 +10,6 @@ resource "aws_iam_role" "deployer" {
         "Action": "sts:AssumeRole",
         "Principal": {
           "AWS": [
-            "arn:aws:iam::${var.tools_account_id}:role/concourse-worker",
             "arn:aws:iam::047969882937:role/cd-verify-concourse-worker"
           ]
         },


### PR DESCRIPTION
Concourse worker role in Verify Tools account does not exist. This change removes it.

Author: @adityapahuja