### PR TITLE
Add saml-engine fargate app

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -108,6 +108,7 @@ scrape_configs:
     dns_sd_configs:
       - names:
           - "${deployment}-config-v2-fargate.hub.local"
+          - "${deployment}-saml-engine-fargate.hub.local"
     relabel_configs:
       - source_labels: [__meta_dns_name]
         target_label: job

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -11,7 +11,7 @@
         "hostPort": 8443
       }
     ],
-    "links": ["saml-engine"],
+    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -137,6 +137,13 @@ module "policy_can_connect_to_saml_engine" {
   destination_sg_id = module.saml_engine.lb_sg_id
 }
 
+module "policy_can_connect_to_saml_engine_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_ecs_asg.instance_sg_id
+  destination_sg_id = module.saml_engine_fargate.lb_sg_id
+}
+
 module "policy_can_connect_to_saml_proxy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -207,6 +207,11 @@ resource "aws_iam_role_policy_attachment" "saml_engine_parameter_execution" {
   policy_arn = aws_iam_policy.saml_engine_parameter_execution.arn
 }
 
+resource "aws_iam_role_policy_attachment" "saml_engine_fargate_parameter_execution" {
+  role       = "${var.deployment}-saml-engine-fargate-execution"
+  policy_arn = aws_iam_policy.saml_engine_parameter_execution.arn
+}
+
 module "saml_engine_can_connect_to_saml_engine_redis" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -38,6 +38,17 @@ locals {
   LOCATIONS
 
   nginx_saml_engine_location_blocks_base64 = base64encode(local.saml_engine_location_blocks)
+
+  saml_engine_fargate_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://localhost:8081;
+    proxy_set_header Host saml-engine.${local.root_domain};
+  }
+  location / {
+    proxy_pass http://localhost:8080;
+    proxy_set_header Host saml-engine.${local.root_domain};
+  }
+  LOCATIONS
 }
 
 data "template_file" "saml_engine_task_def" {
@@ -47,6 +58,7 @@ data "template_file" "saml_engine_task_def" {
     account_id                       = data.aws_caller_identity.account.account_id
     deployment                       = var.deployment
     domain                           = local.root_domain
+    optional_links                   = "\"links\": [\"saml-engine\"],"
     image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
     nginx_image_identifier           = local.nginx_image_identifier
     region                           = data.aws_region.region.id
@@ -80,10 +92,61 @@ module "saml_engine" {
   certificate_arn            = var.wildcard_cert_arn
 }
 
+module "saml_engine_fargate" {
+  source = "./modules/ecs_fargate_app"
+
+  deployment = var.deployment
+  app        = "saml-engine"
+  domain     = local.root_domain
+  vpc_id     = aws_vpc.hub.id
+  lb_subnets = aws_subnet.internal.*.id
+  task_definition = templatefile("${path.module}/files/tasks/hub-saml-engine.json",
+    {
+      account_id                       = data.aws_caller_identity.account.account_id
+      deployment                       = var.deployment
+      domain                           = local.root_domain
+      optional_links                   = ""
+      image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
+      nginx_image_identifier           = local.nginx_image_identifier
+      region                           = data.aws_region.region.id
+      location_blocks_base64           = base64encode(local.saml_engine_fargate_location_blocks)
+      redis_host                       = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
+      splunk_url                       = var.splunk_url
+      rp_truststore_enabled            = var.rp_truststore_enabled
+      certificates_config_cache_expiry = var.certificates_config_cache_expiry
+      memory_hard_limit                = var.saml_engine_memory_hard_limit
+      jvm_options                      = var.jvm_options
+      log_level                        = var.hub_saml_engine_log_level
+  })
+  container_name    = "nginx"
+  container_port    = "8443"
+  number_of_tasks   = var.number_of_apps
+  health_check_path = "/service-status"
+  tools_account_id  = var.tools_account_id
+  image_name        = "verify-saml-engine"
+  certificate_arn   = var.wildcard_cert_arn
+  ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
+  cpu               = 2048
+  # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
+  memory  = ceil(max(var.saml_engine_memory_hard_limit + 250, 4096) / 1024) * 1024
+  subnets = aws_subnet.internal.*.id
+  additional_task_security_group_ids = [
+    aws_security_group.can_connect_to_container_vpc_endpoint.id,
+  ]
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+}
+
 module "saml_engine_can_connect_to_config_fargate_v2" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
+  destination_sg_id = module.config_fargate_v2.lb_sg_id
+}
+
+module "saml_engine_fargate_can_connect_to_config_fargate_v2" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
@@ -94,10 +157,24 @@ module "saml_engine_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_engine_fargate_can_connect_to_policy" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
+  destination_sg_id = module.policy.lb_sg_id
+}
+
 module "saml_engine_can_connect_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
+  destination_sg_id = module.saml_soap_proxy.lb_sg_id
+}
+
+module "saml_engine_fargate_can_connect_to_saml_soap_proxy" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
   destination_sg_id = module.saml_soap_proxy.lb_sg_id
 }
 
@@ -137,9 +214,24 @@ module "saml_engine_can_connect_to_saml_engine_redis" {
   port              = 6379
 }
 
+module "saml_engine_fargate_can_connect_to_saml_engine_redis" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
+  destination_sg_id = aws_security_group.saml_engine_redis.id
+  port              = 6379
+}
+
 module "saml_engine_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
+  destination_sg_id = aws_security_group.ingress.id
+}
+
+module "saml_engine_fargate_can_connect_to_ingress_for_metadata" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
   destination_sg_id = aws_security_group.ingress.id
 }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -132,6 +132,7 @@ module "saml_engine_fargate" {
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    aws_security_group.hub_fargate_microservice.id,
   ]
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
 }

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -141,6 +141,13 @@ module "saml_soap_proxy_can_connect_to_saml_engine" {
   destination_sg_id = module.saml_engine.lb_sg_id
 }
 
+module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.saml_engine_fargate.lb_sg_id
+}
+
 module "saml_soap_proxy_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "hub_key" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-engine-execution",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-engine-fargate-execution",
       ]
     }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -111,15 +111,6 @@ module "prometheus_can_talk_to_saml_engine" {
   port = 8443
 }
 
-module "prometheus_can_talk_to_saml_engine_fargate" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.saml_engine_fargate.task_sg_id
-
-  port = 8443
-}
-
 module "prometheus_can_talk_to_saml_proxy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -111,6 +111,15 @@ module "prometheus_can_talk_to_saml_engine" {
   port = 8443
 }
 
+module "prometheus_can_talk_to_saml_engine_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.prometheus.id
+  destination_sg_id = module.saml_engine_fargate.task_sg_id
+
+  port = 8443
+}
+
 module "prometheus_can_talk_to_saml_proxy" {
   source = "./modules/microservice_connection"
 


### PR DESCRIPTION
This (hopefully) adds a saml-engine app in fargate.  Nothing is hooked
up to it yet.

I've done a test terraform plan, it adds 26 resources, changes 0 and
destroys 0.

I tried to avoid duplicating the task definition file so we don't have
two parallel task definitions.  To do this I added an `optional_links`
parameter which can be removed when we're not running saml-engine in
EC2 any more.

For the new app I used the new terraform `tempatefile()` function in
favour of the now-deprecated `data.template_file` data source.