### PR TITLE
Lock the version of the ecs-fargate-app module.

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy_attachment" "config-fargate_task_can_read_metadata
 }
 
 module "config-fargate" {
-  source = "./modules/ecs_fargate_app"
+  source = "git::https://github.com/alphagov/verify-infrastructure//terraform/modules/hub/modules/ecs_fargate_app?ref=b0682b601cc17013cff670223cb8cd75e9a54e65"
 
   deployment = var.deployment
   app        = "config"


### PR DESCRIPTION
While we make "breaking" changes to the module we need config to not
break until we move over to the newer world.

This should be a no-op.