### PR TITLE
Shorten name of LB target group.

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "app" {
 }
 
 resource "aws_lb_target_group" "task" {
-  name                 = "${local.identifier}-fargate-task"
+  name                 = "${local.identifier}-fargate"
   port                 = "8443"
   protocol             = "HTTPS"
   target_type          = "ip"


### PR DESCRIPTION
Apparently the name is limited to 32 characters and integration pushes
the name over the limit in the new fargate config v2 service.