### PR TITLE
Adjust lifecycle of lb target group

### DIFF
--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -31,6 +31,10 @@ resource "aws_lb_target_group" "task" {
   depends_on = [
     "aws_lb.app",
   ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener" "http" {


### PR DESCRIPTION
Changing the name has broken the terraform updates for this target group.
Hopefully creating the new one first will allow the update and subsequent
deletion of the old one.