### PR TITLE
AUT-854: Set up SAML Proxy in Fargate

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -109,6 +109,7 @@ scrape_configs:
       - names:
           - "${deployment}-config-v2-fargate.hub.local"
           - "${deployment}-saml-engine-fargate.hub.local"
+          - "${deployment}-saml-proxy-fargate.hub.local"
     relabel_configs:
       - source_labels: [__meta_dns_name]
         target_label: job

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -11,7 +11,7 @@
         "hostPort": 8443
       }
     ],
-    "links": ["saml-proxy"],
+    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -149,6 +149,13 @@ module "frontend_can_connect_to_saml_proxy" {
   destination_sg_id = module.saml_proxy.lb_sg_id
 }
 
+module "frontend_can_connect_to_saml_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.frontend_task.id
+  destination_sg_id = module.saml_proxy_fargate.lb_sg_id
+}
+
 resource "aws_iam_policy" "frontend_parameter_execution" {
   name = "${var.deployment}-frontend-parameter-execution"
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -151,6 +151,13 @@ module "policy_can_connect_to_saml_proxy" {
   destination_sg_id = module.saml_proxy.lb_sg_id
 }
 
+module "policy_can_connect_to_saml_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_ecs_asg.instance_sg_id
+  destination_sg_id = module.saml_proxy_fargate.lb_sg_id
+}
+
 module "policy_can_connect_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -147,6 +147,7 @@ module "saml_proxy_fargate" {
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    aws_security_group.hub_fargate_microservice.id,
   ]
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
 }

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -55,6 +55,17 @@ locals {
   LOCATIONS
 
   nginx_saml_proxy_location_blocks_base64 = base64encode(local.saml_proxy_location_blocks)
+
+  saml_proxy_fargate_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://localhost:8081;
+    proxy_set_header Host saml-proxy.${local.root_domain};
+  }
+  location / {
+    proxy_pass http://localhost:8080;
+    proxy_set_header Host saml-proxy.${local.root_domain};
+  }
+  LOCATIONS
 }
 
 data "template_file" "saml_proxy_task_def" {
@@ -64,6 +75,7 @@ data "template_file" "saml_proxy_task_def" {
     image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
     nginx_image_identifier           = local.nginx_image_identifier
     domain                           = local.root_domain
+    optional_links                   = "\"links\": [\"saml-proxy\"],"
     deployment                       = var.deployment
     location_blocks_base64           = local.nginx_saml_proxy_location_blocks_base64
     region                           = data.aws_region.region.id
@@ -96,6 +108,49 @@ module "saml_proxy" {
   image_name                 = "verify-saml-proxy"
 }
 
+module "saml_proxy_fargate" {
+  source = "./modules/ecs_fargate_app"
+
+  deployment = var.deployment
+  app        = "saml-proxy"
+  domain     = local.root_domain
+  vpc_id     = aws_vpc.hub.id
+  lb_subnets = aws_subnet.internal.*.id
+  task_definition = templatefile("${path.module}/files/tasks/hub-saml-proxy.json",
+    {
+      image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
+      nginx_image_identifier           = local.nginx_image_identifier
+      domain                           = local.root_domain
+      optional_links                   = ""
+      deployment                       = var.deployment
+      location_blocks_base64           = base64encode(local.saml_proxy_fargate_location_blocks)
+      region                           = data.aws_region.region.id
+      account_id                       = data.aws_caller_identity.account.account_id
+      event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
+      rp_truststore_enabled            = var.rp_truststore_enabled
+      certificates_config_cache_expiry = var.certificates_config_cache_expiry
+      memory_hard_limit                = var.saml_proxy_memory_hard_limit
+      jvm_options                      = var.jvm_options
+      log_level                        = var.hub_saml_proxy_log_level
+  })
+  container_name    = "nginx"
+  container_port    = "8443"
+  number_of_tasks   = var.number_of_apps
+  health_check_path = "/service-status"
+  tools_account_id  = var.tools_account_id
+  image_name        = "verify-saml-proxy"
+  certificate_arn   = var.wildcard_cert_arn
+  ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
+  cpu               = 2048
+  # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
+  memory  = ceil(max(var.saml_proxy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  subnets = aws_subnet.internal.*.id
+  additional_task_security_group_ids = [
+    aws_security_group.can_connect_to_container_vpc_endpoint.id,
+  ]
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+}
+
 resource "aws_iam_policy" "saml_proxy_parameter_execution" {
   name = "${var.deployment}-saml-proxy-parameter-execution"
 
@@ -105,10 +160,13 @@ resource "aws_iam_policy" "saml_proxy_parameter_execution" {
     "Statement": [{
       "Effect": "Allow",
       "Action": [
+        "ssm:GetParameters",
+        "ssm:GetParameter",
         "kms:Decrypt"
       ],
       "Resource": [
-        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-proxy-key"
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-proxy-key",
+        "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/saml-proxy/*"
       ]
     }]
   }
@@ -120,10 +178,22 @@ resource "aws_iam_role_policy_attachment" "saml_proxy_parameter_execution" {
   policy_arn = aws_iam_policy.saml_proxy_parameter_execution.arn
 }
 
+resource "aws_iam_role_policy_attachment" "saml_proxy_fargate_parameter_execution" {
+  role       = "${var.deployment}-saml-proxy-fargate-execution"
+  policy_arn = aws_iam_policy.saml_proxy_parameter_execution.arn
+}
+
 module "saml_proxy_can_connect_to_config_fargate_v2" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.config_fargate_v2.lb_sg_id
+}
+
+module "saml_proxy_fargate_can_connect_to_config_fargate_v2" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_proxy_fargate.task_sg_id
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
@@ -134,9 +204,23 @@ module "saml_proxy_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_proxy_fargate_can_connect_to_policy" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_proxy_fargate.task_sg_id
+  destination_sg_id = module.policy.lb_sg_id
+}
+
 module "saml_proxy_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = aws_security_group.ingress.id
+}
+
+module "saml_proxy_fargate_can_connect_to_ingress_for_metadata" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_proxy_fargate.task_sg_id
   destination_sg_id = aws_security_group.ingress.id
 }

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -180,7 +180,7 @@ resource "aws_iam_role_policy_attachment" "saml_proxy_parameter_execution" {
 }
 
 resource "aws_iam_role_policy_attachment" "saml_proxy_fargate_parameter_execution" {
-  role       = "${var.deployment}-saml-proxy-fargate-execution"
+  role       = module.saml_proxy_fargate.execution_role_name
   policy_arn = aws_iam_policy.saml_proxy_parameter_execution.arn
 }
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "saml_proxy" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-execution",
-        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-fargate-execution",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${module.saml_proxy_fargate.execution_role_name}",
       ]
     }
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -124,6 +124,7 @@ data "aws_iam_policy_document" "saml_proxy" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-execution",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-proxy-fargate-execution",
       ]
     }
 

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -22,6 +22,10 @@ output "task_role_name" {
   value = module.ecs_roles.task_role_name
 }
 
+output "execution_role_name" {
+  value = module.ecs_roles.execution_role_name
+}
+
 resource "aws_ecs_service" "app" {
   name            = local.identifier
   cluster         = var.ecs_cluster_id
@@ -40,7 +44,7 @@ resource "aws_ecs_service" "app" {
   }
 
   network_configuration {
-    subnets         = var.subnets
+    subnets = var.subnets
     security_groups = concat(
       var.additional_task_security_group_ids,
       [aws_security_group.task.id],

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -120,6 +120,15 @@ module "prometheus_can_talk_to_saml_proxy" {
   port = 8443
 }
 
+module "prometheus_can_talk_to_saml_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.prometheus.id
+  destination_sg_id = module.saml_proxy_fargate.task_sg_id
+
+  port = 8443
+}
+
 module "prometheus_can_talk_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -120,15 +120,6 @@ module "prometheus_can_talk_to_saml_proxy" {
   port = 8443
 }
 
-module "prometheus_can_talk_to_saml_proxy_fargate" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.saml_proxy_fargate.task_sg_id
-
-  port = 8443
-}
-
 module "prometheus_can_talk_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 


### PR DESCRIPTION
This change sets up a new service called SAML Proxy Fargate. This service will run in Fargate alongside with SAML Proxy running on EC2 instances.

Author: @adityapahuja