### PR TITLE
Remove unneeded security group

### DIFF
--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -79,7 +79,6 @@ module "config_fargate_v2" {
   memory  = ceil(max(var.config_memory_hard_limit + 250, 4096) / 1024) * 1024
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
-    aws_security_group.scraped_by_prometheus.id,
     aws_security_group.can_connect_to_container_vpc_endpoint.id,
   ]
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id


### PR DESCRIPTION
The `scraped_by_prometheus` security group grants access to port
9100 (node_exporter) and 9479 (beat-exporter), neither of which are
relevant for fargate apps.