### PR TITLE
Add generic hub_fargate_microservice security group

### DIFF
--- a/terraform/modules/hub/hub.tf
+++ b/terraform/modules/hub/hub.tf
@@ -1,0 +1,6 @@
+resource "aws_security_group" "hub_fargate_microservice" {
+  name        = "${var.deployment}-hub-fargate-microservice"
+  description = "${var.deployment}-hub-fargate-microservice"
+
+  vpc_id = aws_vpc.hub.id
+}

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -81,6 +81,7 @@ module "config_fargate_v2" {
   additional_task_security_group_ids = [
     aws_security_group.scraped_by_prometheus.id,
     aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    aws_security_group.hub_fargate_microservice.id,
   ]
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
 }

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -93,11 +93,11 @@ module "prometheus_can_talk_to_policy" {
   port = 8443
 }
 
-module "prometheus_can_talk_to_config_v2" {
+module "prometheus_can_talk_to_hub_fargate_microservices" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.config_fargate_v2.task_sg_id
+  destination_sg_id = aws_security_group.hub_fargate_microservice.id
 
   port = 8443
 }


### PR DESCRIPTION
It feels like a lot of duplication that prometheus has to be allowed
to specifically talk to each hub app individually.  This creates a new
security group, hub_fargate_microservice, which is intended to be
added as an additional_task_security_group_ids to each fargate app.
It allows prometheus to talk to 8443 on any app that has this security
group.  Longer term, we will only need 1 SG rule where previously we
needed 5 or 6.