### PR TITLE
Fix ALB-related deprecation warnings

### DIFF
--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -185,8 +185,9 @@ resource "aws_lb_listener_rule" "ingress_metadata_sp" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/SAML2/metadata/sp"]
+    path_pattern {
+      values = ["/SAML2/metadata/sp"]
+    }
   }
 }
 
@@ -206,8 +207,9 @@ resource "aws_lb_listener_rule" "ingress_root" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/"]
+    path_pattern {
+      values = ["/"]
+    }
   }
 }
 
@@ -221,8 +223,9 @@ resource "aws_lb_listener_rule" "ingress_metadata" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/SAML2/metadata/*"]
+    path_pattern {
+      values = ["/SAML2/metadata/*"]
+    }
   }
 }
 
@@ -236,8 +239,9 @@ resource "aws_lb_listener_rule" "ingress_analytics" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/analytics*"]
+    path_pattern {
+      values = ["/analytics*"]
+    }
   }
 }
 
@@ -258,8 +262,9 @@ resource "aws_lb_listener_rule" "ingress_metrics" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/metrics*"]
+    path_pattern {
+      values = ["/metrics*"]
+    }
   }
 }
 

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -422,8 +422,9 @@ resource "aws_lb_listener_rule" "prometheus_https" {
   }
 
   condition {
-    field  = "host-header"
-    values = ["prom-${count.index + 1}.*"]
+    host_header {
+      values = ["prom-${count.index + 1}.*"]
+    }
   }
 }
 

--- a/terraform/modules/self-service/lb.tf
+++ b/terraform/modules/self-service/lb.tf
@@ -1,8 +1,8 @@
 resource "aws_lb" "self_service_edge" {
   load_balancer_type = "application"
 
-  name            = "${var.deployment}-${local.service}"
-  internal        = false
+  name     = "${var.deployment}-${local.service}"
+  internal = false
   security_groups = [
     aws_security_group.ingress.id,
     aws_security_group.egress.id
@@ -81,7 +81,8 @@ resource "aws_lb_listener_rule" "disable_health_check_from_public" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/healthcheck"]
+    path_pattern {
+      values = ["/healthcheck"]
+    }
   }
 }


### PR DESCRIPTION
We're getting deprecation warnings such as:

> Warning: "condition.0.values": [DEPRECATED] use 'host_header' or
> 'path_pattern' attribute instead

This is because of
https://github.com/terraform-providers/terraform-provider-aws/pull/8268
which landed in aws provider 2.42.0.

The fix is to change the syntax as described.