### PR TITLE
Allow saml-engine-fargate to see saml-engine parameters

### DIFF
--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -195,6 +195,7 @@ resource "aws_iam_policy" "saml_engine_parameter_execution" {
         "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}-hub-signing-private-key",
         "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}-primary-hub-encryption-private-key",
         "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}-secondary-hub-encryption-private-key",
+        "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/saml-engine/*",
         "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-hub-key"
       ]
     }]


### PR DESCRIPTION
The way the execution roles is set up, saml-engine gets access to
`parameter/$DEPLOYMENT/saml-engine/*` but saml-engine-fargate gets
access to `parameter/$DEPLOYMENT/saml-engine-fargate/*`.  This
explicitly allows saml-engine-fargate to access
`parameter/$DEPLOYMENT/saml-engine/*` so that it can get things like the
splunk-token.