### PR TITLE
squid: permit ALLOWLIST instead of WHITELIST

### DIFF
--- a/dockerfiles/squid/docker-entrypoint.sh
+++ b/dockerfiles/squid/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env ash
 set -ueo pipefail
 
-whitelist="${WHITELIST:?WHITELIST not set}"
-whitelist="$(echo "$whitelist" | base64 -d)"
+allowlist="${ALLOWLIST:-${WHITELIST:?ALLOWLIST not set}}"
+allowlist="$(echo "$allowlist" | base64 -d)"
 
 all_acls=""
 
-for regex in $whitelist; do
+for regex in $allowlist; do
 all_acls="$(cat <<EOF
 $all_acls
 acl permitted_dest dstdom_regex ^${regex}$


### PR DESCRIPTION
I'm fiddling around with this code so this seems a good time to update
in line with the style guide:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#allow-list

This allows (but does not require) squid to be configured with
ALLOWLIST instead of WHITELIST.  A later PR can configure
terraform/ECS to actually use ALLOWLIST, but this change is going out
in stages.