### PR TITLE
Remove saml engine ec2

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -29,7 +29,6 @@ locals {
     "egress-proxy",
     "ingress",
     "static-ingress",
-    "saml-engine",
     "policy",
     "saml-soap-proxy",
   ]

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -55,24 +55,20 @@ locals {
 }
 
 locals {
-  egress_proxy_whitelist_list = [
-    "eu-west-2\\.ec2\\.archive\\.ubuntu\\.com",              # Apt
-    "security\\.ubuntu\\.com",                               # Apt
-    "artifacts\\.elastic\\.co",                              # Journalbeat
-    replace(var.logit_elasticsearch_url, ".", "\\."),        # Logit
+  egress_proxy_allowlist_list = [
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
   ]
 
-  egress_proxy_whitelist = join(" ", local.egress_proxy_whitelist_list)
+  egress_proxy_allowlist = join(" ", local.egress_proxy_allowlist_list)
 }
 
 data "template_file" "egress_proxy_task_def" {
   template = file("${path.module}/files/tasks/squid.json")
 
   vars = {
-    whitelist_base64 = base64encode(local.egress_proxy_whitelist)
+    allowlist_base64 = base64encode(local.egress_proxy_allowlist)
     image_identifier = "${local.tools_account_ecr_url_prefix}-verify-squid@${var.squid_image_digest}"
     deployment       = var.deployment
     region           = data.aws_region.region.id

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -11,7 +11,6 @@
         "hostPort": 8443
       }
     ],
-    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -12,8 +12,8 @@
       }
     ],
     "environment": [{
-      "Name": "WHITELIST",
-      "Value": "${whitelist_base64}"
+      "Name": "ALLOWLIST",
+      "Value": "${allowlist_base64}"
     }],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -130,13 +130,6 @@ module "policy_can_connect_to_config_fargate_v2" {
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
-module "policy_can_connect_to_saml_engine" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.policy_ecs_asg.instance_sg_id
-  destination_sg_id = module.saml_engine.lb_sg_id
-}
-
 module "policy_can_connect_to_saml_engine_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -1,44 +1,4 @@
-module "saml_engine_ecs_asg" {
-  source = "./modules/ecs_asg"
-
-  ami_id           = data.aws_ami.ubuntu_bionic.id
-  deployment       = var.deployment
-  cluster          = "saml-engine"
-  vpc_id           = aws_vpc.hub.id
-  instance_subnets = aws_subnet.internal.*.id
-
-  use_egress_proxy    = true
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.saml_engine_instance_type
-
-  ecs_agent_image_identifier = local.ecs_agent_image_identifier
-  tools_account_id           = var.tools_account_id
-
-  additional_instance_security_group_ids = [
-    aws_security_group.egress_via_proxy.id,
-    aws_security_group.scraped_by_prometheus.id,
-    aws_security_group.can_connect_to_container_vpc_endpoint.id,
-  ]
-
-  logit_api_key           = var.logit_api_key
-  logit_elasticsearch_url = var.logit_elasticsearch_url
-}
-
 locals {
-  saml_engine_location_blocks = <<-LOCATIONS
-  location = /prometheus/metrics {
-    proxy_pass http://saml-engine:8081;
-    proxy_set_header Host saml-engine.${local.root_domain};
-  }
-  location / {
-    proxy_pass http://saml-engine:8080;
-    proxy_set_header Host saml-engine.${local.root_domain};
-  }
-  LOCATIONS
-
-  nginx_saml_engine_location_blocks_base64 = base64encode(local.saml_engine_location_blocks)
-
   saml_engine_fargate_location_blocks = <<-LOCATIONS
   location = /prometheus/metrics {
     proxy_pass http://localhost:8081;
@@ -49,47 +9,6 @@ locals {
     proxy_set_header Host saml-engine.${local.root_domain};
   }
   LOCATIONS
-}
-
-data "template_file" "saml_engine_task_def" {
-  template = file("${path.module}/files/tasks/hub-saml-engine.json")
-
-  vars = {
-    account_id                       = data.aws_caller_identity.account.account_id
-    deployment                       = var.deployment
-    domain                           = local.root_domain
-    optional_links                   = "\"links\": [\"saml-engine\"],"
-    image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
-    nginx_image_identifier           = local.nginx_image_identifier
-    region                           = data.aws_region.region.id
-    location_blocks_base64           = local.nginx_saml_engine_location_blocks_base64
-    redis_host                       = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
-    splunk_url                       = var.splunk_url
-    rp_truststore_enabled            = var.rp_truststore_enabled
-    certificates_config_cache_expiry = var.certificates_config_cache_expiry
-    memory_hard_limit                = var.saml_engine_memory_hard_limit
-    jvm_options                      = var.jvm_options
-    log_level                        = var.hub_saml_engine_log_level
-  }
-}
-
-module "saml_engine" {
-  source = "./modules/ecs_app"
-
-  deployment                 = var.deployment
-  cluster                    = "saml-engine"
-  domain                     = local.root_domain
-  vpc_id                     = aws_vpc.hub.id
-  lb_subnets                 = aws_subnet.internal.*.id
-  task_definition            = data.template_file.saml_engine_task_def.rendered
-  container_name             = "nginx"
-  container_port             = "8443"
-  number_of_tasks            = var.number_of_apps
-  health_check_path          = "/service-status"
-  tools_account_id           = var.tools_account_id
-  image_name                 = "verify-saml-engine"
-  instance_security_group_id = module.saml_engine_ecs_asg.instance_sg_id
-  certificate_arn            = var.wildcard_cert_arn
 }
 
 module "saml_engine_fargate" {
@@ -105,7 +24,6 @@ module "saml_engine_fargate" {
       account_id                       = data.aws_caller_identity.account.account_id
       deployment                       = var.deployment
       domain                           = local.root_domain
-      optional_links                   = ""
       image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
       nginx_image_identifier           = local.nginx_image_identifier
       region                           = data.aws_region.region.id
@@ -138,13 +56,6 @@ module "saml_engine_fargate" {
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
 }
 
-module "saml_engine_can_connect_to_config_fargate_v2" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
-  destination_sg_id = module.config_fargate_v2.lb_sg_id
-}
-
 module "saml_engine_fargate_can_connect_to_config_fargate_v2" {
   source = "./modules/microservice_connection"
 
@@ -152,25 +63,11 @@ module "saml_engine_fargate_can_connect_to_config_fargate_v2" {
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
-module "saml_engine_can_connect_to_policy" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
-  destination_sg_id = module.policy.lb_sg_id
-}
-
 module "saml_engine_fargate_can_connect_to_policy" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_engine_fargate.task_sg_id
   destination_sg_id = module.policy.lb_sg_id
-}
-
-module "saml_engine_can_connect_to_saml_soap_proxy" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
-  destination_sg_id = module.saml_soap_proxy.lb_sg_id
 }
 
 module "saml_engine_fargate_can_connect_to_saml_soap_proxy" {
@@ -204,22 +101,9 @@ resource "aws_iam_policy" "saml_engine_parameter_execution" {
   EOF
 }
 
-resource "aws_iam_role_policy_attachment" "saml_engine_parameter_execution" {
-  role       = "${var.deployment}-saml-engine-execution"
-  policy_arn = aws_iam_policy.saml_engine_parameter_execution.arn
-}
-
 resource "aws_iam_role_policy_attachment" "saml_engine_fargate_parameter_execution" {
   role       = "${var.deployment}-saml-engine-fargate-execution"
   policy_arn = aws_iam_policy.saml_engine_parameter_execution.arn
-}
-
-module "saml_engine_can_connect_to_saml_engine_redis" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
-  destination_sg_id = aws_security_group.saml_engine_redis.id
-  port              = 6379
 }
 
 module "saml_engine_fargate_can_connect_to_saml_engine_redis" {
@@ -228,13 +112,6 @@ module "saml_engine_fargate_can_connect_to_saml_engine_redis" {
   source_sg_id      = module.saml_engine_fargate.task_sg_id
   destination_sg_id = aws_security_group.saml_engine_redis.id
   port              = 6379
-}
-
-module "saml_engine_can_connect_to_ingress_for_metadata" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_ecs_asg.instance_sg_id
-  destination_sg_id = aws_security_group.ingress.id
 }
 
 module "saml_engine_fargate_can_connect_to_ingress_for_metadata" {

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -134,13 +134,6 @@ module "saml_soap_proxy_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
-module "saml_soap_proxy_can_connect_to_saml_engine" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  destination_sg_id = module.saml_engine.lb_sg_id
-}
-
 module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -8,7 +8,6 @@ data "aws_iam_policy_document" "hub_key" {
 
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-engine-execution",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-engine-fargate-execution",
       ]
     }

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -102,15 +102,6 @@ module "prometheus_can_talk_to_hub_fargate_microservices" {
   port = 8443
 }
 
-module "prometheus_can_talk_to_saml_engine" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.saml_engine_ecs_asg.instance_sg_id
-
-  port = 8443
-}
-
 module "prometheus_can_talk_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 


### PR DESCRIPTION
## Before merging

- [x] merge and deploy #487

## What is this

This removes everything associated with the old saml-engine app.

Now that saml-engine runs exclusively in fargate, there are a bunch of
services that no longer need to be in the egress-proxy allow list:

 - ubuntu updates (because there's no ubuntu instance to manage)
 - elasticsearch artefacts (because there's no journalbeat shipping
   logs)
 - logit (because logs go via cloudwatch to splunk now)

Also, replace usages of "whitelist" with "allowlist" in line with the
style guide:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#allow-list

