### PR TITLE
AUT-854: Update Frontend to use SAML Proxy in Fargate

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -149,7 +149,7 @@
       "Value": "${zendesk_username}"
     }, {
       "Name": "SAML_PROXY_HOST",
-      "Value": "https://saml-proxy.${domain}:443"
+      "Value": "https://saml-proxy-fargate.${domain}:443"
     }, {
       "Name": "VERIFY_PRODUCT_PAGE",
       "Value": "https://govuk-verify.cloudapps.digital/"

--- a/terraform/modules/hub/files/tasks/frontend_xlarge.json
+++ b/terraform/modules/hub/files/tasks/frontend_xlarge.json
@@ -149,7 +149,7 @@
       "Value": "${zendesk_username}"
     }, {
       "Name": "SAML_PROXY_HOST",
-      "Value": "https://saml-proxy.${domain}:443"
+      "Value": "https://saml-proxy-fargate.${domain}:443"
     }, {
       "Name": "VERIFY_PRODUCT_PAGE",
       "Value": "https://govuk-verify.cloudapps.digital/"


### PR DESCRIPTION
SAML Proxy is up and running in Fargate. It is time to update Verify Frontend to use SAML Proxy in Fargate.

Author: @adityapahuja