### PR TITLE
AUT-854: Update Frontend to use SAML Proxy in Fargate

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -149,7 +149,7 @@
       "Value": "${zendesk_username}"
     }, {
       "Name": "SAML_PROXY_HOST",
-      "Value": "https://saml-proxy.${domain}:443"
+      "Value": "https://saml-proxy-fargate.${domain}:443"
     }, {
       "Name": "VERIFY_PRODUCT_PAGE",
       "Value": "https://govuk-verify.cloudapps.digital/"

--- a/terraform/modules/hub/files/tasks/frontend_xlarge.json
+++ b/terraform/modules/hub/files/tasks/frontend_xlarge.json
@@ -149,7 +149,7 @@
       "Value": "${zendesk_username}"
     }, {
       "Name": "SAML_PROXY_HOST",
-      "Value": "https://saml-proxy.${domain}:443"
+      "Value": "https://saml-proxy-fargate.${domain}:443"
     }, {
       "Name": "VERIFY_PRODUCT_PAGE",
       "Value": "https://govuk-verify.cloudapps.digital/"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -42,7 +42,7 @@ resource "aws_security_group_rule" "saml_proxy_instance_egress_to_internet_over_
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "saml_proxy_task_egress_to_internet_over_http" {
+resource "aws_security_group_rule" "saml_proxy_fargate_egress_to_internet_over_http" {
   type      = "egress"
   protocol  = "tcp"
   from_port = 80
@@ -52,7 +52,7 @@ resource "aws_security_group_rule" "saml_proxy_task_egress_to_internet_over_http
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "saml_proxy_task_egress_to_internet_over_https" {
+resource "aws_security_group_rule" "saml_proxy_fargate_egress_to_internet_over_https" {
   type      = "egress"
   protocol  = "tcp"
   from_port = 443


### PR DESCRIPTION
This change also renames from saml_proxy_task_egress_to_internet_over_http[s] to saml_proxy_fargate_egress_to_internet_over_http[s].

Author: @adityapahuja