### PR TITLE
Set up Policy in Fargate

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -108,6 +108,7 @@ scrape_configs:
     dns_sd_configs:
       - names:
           - "${deployment}-config-v2-fargate.hub.local"
+          - "${deployment}-policy-fargate.hub.local"
           - "${deployment}-saml-engine-fargate.hub.local"
           - "${deployment}-saml-proxy-fargate.hub.local"
           - "${deployment}-saml-soap-proxy-fargate.hub.local"

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -11,7 +11,7 @@
         "hostPort": 8443
       }
     ],
-    "links": ["policy"],
+    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -83,7 +83,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config.${domain}|config-v2-fargate.${domain}|policy.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config.${domain}|config-v2-fargate.${domain}|policy.${domain}|policy-fargate.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy-fargate.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "REDIS_HOST",

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -142,6 +142,13 @@ module "frontend_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "frontend_can_connect_to_policy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.frontend_task.id
+  destination_sg_id = module.policy_fargate.lb_sg_id
+}
+
 module "frontend_can_connect_to_saml_proxy_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -43,6 +43,26 @@ resource "aws_security_group_rule" "policy_instance_egress_to_internet_over_http
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "policy_task_egress_to_internet_over_http" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 80
+  to_port   = 80
+
+  security_group_id = module.policy_fargate.task_sg_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "policy_task_egress_to_internet_over_https" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  security_group_id = module.policy_fargate.task_sg_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 locals {
   policy_location_blocks = <<-LOCATIONS
   location = /prometheus/metrics {
@@ -56,12 +76,24 @@ locals {
   LOCATIONS
 
   nginx_policy_location_blocks_base64 = base64encode(local.policy_location_blocks)
+
+  policy_fargate_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://localhost:8081;
+    proxy_set_header Host policy.${local.root_domain};
+  }
+  location / {
+    proxy_pass http://localhost:8080;
+    proxy_set_header Host policy.${local.root_domain};
+  }
+  LOCATIONS
 }
 
 data "template_file" "policy_task_def" {
   template = file("${path.module}/files/tasks/hub-policy.json")
 
   vars = {
+    optional_links                = "\"links\": [\"policy\"],"
     image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-policy@${var.hub_policy_image_digest}"
     nginx_image_identifier        = local.nginx_image_identifier
     domain                        = local.root_domain
@@ -99,6 +131,51 @@ module "policy" {
   certificate_arn            = var.wildcard_cert_arn
 }
 
+module "policy_fargate" {
+  source = "./modules/ecs_fargate_app"
+
+  deployment = var.deployment
+  app        = "policy"
+  domain     = local.root_domain
+  vpc_id     = aws_vpc.hub.id
+  lb_subnets = aws_subnet.internal.*.id
+  task_definition = templatefile("${path.module}/files/tasks/hub-policy.json", {
+    optional_links                = ""
+    image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-policy@${var.hub_policy_image_digest}"
+    nginx_image_identifier        = local.nginx_image_identifier
+    domain                        = local.root_domain
+    deployment                    = var.deployment
+    location_blocks_base64        = base64encode(local.policy_fargate_location_blocks)
+    region                        = data.aws_region.region.id
+    account_id                    = data.aws_caller_identity.account.account_id
+    event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
+    memory_hard_limit             = var.policy_memory_hard_limit
+    jvm_options                   = var.jvm_options
+
+    redis_host = "rediss://${
+      aws_elasticache_replication_group.policy_session_store.primary_endpoint_address
+    }:6379"
+    log_level = var.hub_policy_log_level
+  })
+  container_name    = "nginx"
+  container_port    = "8443"
+  number_of_tasks   = var.number_of_apps
+  health_check_path = "/service-status"
+  tools_account_id  = var.tools_account_id
+  image_name        = "verify-policy"
+  certificate_arn   = var.wildcard_cert_arn
+  ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
+  cpu               = 2048
+  # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
+  memory  = ceil(max(var.policy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  subnets = aws_subnet.internal.*.id
+  additional_task_security_group_ids = [
+    aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    aws_security_group.hub_fargate_microservice.id,
+  ]
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+}
+
 resource "aws_iam_policy" "policy_parameter_execution" {
   name = "${var.deployment}-policy-parameter-execution"
 
@@ -108,10 +185,13 @@ resource "aws_iam_policy" "policy_parameter_execution" {
     "Statement": [{
       "Effect": "Allow",
       "Action": [
-        "kms:Decrypt"
+        "kms:Decrypt",
+        "ssm:GetParameters",
+        "ssm:GetParameter"
       ],
       "Resource": [
-        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-policy-key"
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-policy-key",
+        "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/policy/*"
       ]
     }]
   }
@@ -121,6 +201,13 @@ resource "aws_iam_policy" "policy_parameter_execution" {
 resource "aws_iam_role_policy_attachment" "policy_parameter_execution" {
   role       = "${var.deployment}-policy-execution"
   policy_arn = aws_iam_policy.policy_parameter_execution.arn
+}
+
+resource "aws_iam_role_policy_attachment" "policy_fargate_parameter_execution" {
+  role       = module.policy_fargate.execution_role_name
+  policy_arn = aws_iam_policy.policy_parameter_execution.arn
+
+  depends_on = [module.policy_fargate.execution_role_name]
 }
 
 module "policy_can_connect_to_config_fargate_v2" {
@@ -170,5 +257,55 @@ module "policy_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.policy_ecs_asg.instance_sg_id
+  destination_sg_id = aws_security_group.ingress.id
+}
+
+module "policy_fargate_can_connect_to_config_fargate_v2" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = module.config_fargate_v2.lb_sg_id
+}
+
+module "policy_fargate_can_connect_to_saml_engine_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = module.saml_engine_fargate.lb_sg_id
+}
+
+module "policy_fargate_can_connect_to_saml_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = module.saml_proxy_fargate.lb_sg_id
+}
+
+module "policy_fargate_can_connect_to_saml_soap_proxy" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = module.saml_soap_proxy.lb_sg_id
+}
+
+module "policy_fargate_can_connect_to_saml_soap_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = module.saml_soap_proxy_fargate.lb_sg_id
+}
+
+module "policy_fargate_can_connect_to_policy_redis" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
+  destination_sg_id = aws_security_group.policy_redis.id
+  port              = 6379
+}
+
+module "policy_fargate_can_connect_to_ingress_for_metadata" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_fargate.task_sg_id
   destination_sg_id = aws_security_group.ingress.id
 }

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -70,6 +70,13 @@ module "saml_engine_fargate_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_engine_fargate_can_connect_to_policy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
+  destination_sg_id = module.policy_fargate.lb_sg_id
+}
+
 module "saml_engine_fargate_can_connect_to_saml_soap_proxy" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -115,6 +115,13 @@ module "saml_proxy_fargate_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_proxy_fargate_can_connect_to_policy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_proxy_fargate.task_sg_id
+  destination_sg_id = module.policy_fargate.lb_sg_id
+}
+
 module "saml_proxy_fargate_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -236,6 +236,20 @@ module "saml_soap_proxy_fargate_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_soap_proxy_can_connect_to_policy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.policy_fargate.lb_sg_id
+}
+
+module "saml_soap_proxy_fargate_can_connect_to_policy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
+  destination_sg_id = module.policy_fargate.lb_sg_id
+}
+
 module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "policy" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-policy-execution",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${module.policy_fargate.execution_role_name}",
       ]
     }
 
@@ -105,6 +106,8 @@ resource "aws_kms_key" "policy" {
   deletion_window_in_days = 7
 
   policy = data.aws_iam_policy_document.policy.json
+
+  depends_on = [module.policy_fargate.execution_role_name]
 }
 
 resource "aws_kms_alias" "policy" {


### PR DESCRIPTION
This change sets up a new service called Policy Fargate. This service
will run in Fargate alongside Policy running on EC2 instances.