### PR TITLE
AUT-817: Set up SAML SOAP Proxy on Fargate

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -110,6 +110,7 @@ scrape_configs:
           - "${deployment}-config-v2-fargate.hub.local"
           - "${deployment}-saml-engine-fargate.hub.local"
           - "${deployment}-saml-proxy-fargate.hub.local"
+          - "${deployment}-saml-soap-proxy-fargate.hub.local"
     relabel_configs:
       - source_labels: [__meta_dns_name]
         target_label: job

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -11,7 +11,7 @@
         "hostPort": 8443
       }
     ],
-    "links": ["saml-soap-proxy"],
+    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -151,6 +151,13 @@ module "policy_can_connect_to_saml_soap_proxy" {
   destination_sg_id = module.saml_soap_proxy.lb_sg_id
 }
 
+module "policy_can_connect_to_saml_soap_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.policy_ecs_asg.instance_sg_id
+  destination_sg_id = module.saml_soap_proxy_fargate.lb_sg_id
+}
+
 module "policy_can_connect_to_policy_redis" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -77,6 +77,13 @@ module "saml_engine_fargate_can_connect_to_saml_soap_proxy" {
   destination_sg_id = module.saml_soap_proxy.lb_sg_id
 }
 
+module "saml_engine_fargate_can_connect_to_saml_soap_proxy_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_engine_fargate.task_sg_id
+  destination_sg_id = module.saml_soap_proxy_fargate.lb_sg_id
+}
+
 resource "aws_iam_policy" "saml_engine_parameter_execution" {
   name = "${var.deployment}-saml-engine-parameter-execution"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -32,6 +32,16 @@ resource "aws_security_group_rule" "saml_soap_proxy_instance_egress_to_internet_
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "saml_soap_proxy_fargate_egress_to_internet_over_http" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 80
+  to_port   = 80
+
+  security_group_id = module.saml_soap_proxy_fargate.task_sg_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "saml_soap_proxy_instance_egress_to_internet_over_https" {
   type      = "egress"
   protocol  = "tcp"
@@ -39,6 +49,16 @@ resource "aws_security_group_rule" "saml_soap_proxy_instance_egress_to_internet_
   to_port   = 443
 
   security_group_id = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "saml_soap_proxy_fargate_egress_to_internet_over_https" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  security_group_id = module.saml_soap_proxy_fargate.task_sg_id
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
@@ -55,6 +75,17 @@ locals {
   LOCATIONS
 
   nginx_saml_soap_proxy_location_blocks_base64 = base64encode(local.saml_soap_proxy_location_blocks)
+
+  saml_soap_proxy_fargate_location_blocks = <<-LOCATIONS
+  location = /prometheus/metrics {
+    proxy_pass http://localhost:8081;
+    proxy_set_header Host saml-soap-proxy.${local.root_domain};
+  }
+  location / {
+    proxy_pass http://localhost:8080;
+    proxy_set_header Host saml-soap-proxy.${local.root_domain};
+  }
+  LOCATIONS
 }
 
 data "template_file" "saml_soap_proxy_task_def" {
@@ -64,6 +95,7 @@ data "template_file" "saml_soap_proxy_task_def" {
     image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
     nginx_image_identifier           = local.nginx_image_identifier
     domain                           = local.root_domain
+    optional_links                   = "\"links\": [\"saml-soap-proxy\"],"
     deployment                       = var.deployment
     location_blocks_base64           = local.nginx_saml_soap_proxy_location_blocks_base64
     region                           = data.aws_region.region.id
@@ -96,6 +128,50 @@ module "saml_soap_proxy" {
   image_name                 = "verify-saml-soap-proxy"
 }
 
+module "saml_soap_proxy_fargate" {
+  source = "./modules/ecs_fargate_app"
+
+  deployment = var.deployment
+  app        = "saml-soap-proxy"
+  domain     = local.root_domain
+  vpc_id     = aws_vpc.hub.id
+  lb_subnets = aws_subnet.internal.*.id
+  task_definition = templatefile("${path.module}/files/tasks/hub-saml-soap-proxy.json",
+    {
+      image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
+      nginx_image_identifier           = local.nginx_image_identifier
+      domain                           = local.root_domain
+      optional_links                   = ""
+      deployment                       = var.deployment
+      location_blocks_base64           = base64encode(local.saml_soap_proxy_fargate_location_blocks)
+      region                           = data.aws_region.region.id
+      account_id                       = data.aws_caller_identity.account.account_id
+      event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
+      rp_truststore_enabled            = var.rp_truststore_enabled
+      certificates_config_cache_expiry = var.certificates_config_cache_expiry
+      memory_hard_limit                = var.saml_soap_proxy_memory_hard_limit
+      jvm_options                      = var.jvm_options
+      log_level                        = var.hub_saml_soap_proxy_log_level
+  })
+  container_name    = "nginx"
+  container_port    = "8443"
+  number_of_tasks   = var.number_of_apps
+  health_check_path = "/service-status"
+  tools_account_id  = var.tools_account_id
+  image_name        = "verify-saml-soap-proxy"
+  certificate_arn   = var.wildcard_cert_arn
+  ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
+  cpu               = 2048
+  # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
+  memory  = ceil(max(var.saml_proxy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  subnets = aws_subnet.internal.*.id
+  additional_task_security_group_ids = [
+    aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    aws_security_group.hub_fargate_microservice.id,
+  ]
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+}
+
 resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
   name = "${var.deployment}-saml-soap-proxy-parameter-execution"
 
@@ -105,10 +181,13 @@ resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
     "Statement": [{
       "Effect": "Allow",
       "Action": [
+        "ssm:GetParameters",
+        "ssm:GetParameter",
         "kms:Decrypt"
       ],
       "Resource": [
-        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-soap-proxy-key"
+        "arn:aws:kms:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:alias/${var.deployment}-saml-soap-proxy-key",
+        "arn:aws:ssm:${data.aws_region.region.id}:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/saml-soap-proxy/*"
       ]
     }]
   }
@@ -120,10 +199,26 @@ resource "aws_iam_role_policy_attachment" "saml_soap_proxy_parameter_execution" 
   policy_arn = aws_iam_policy.saml_soap_proxy_parameter_execution.arn
 }
 
+resource "aws_iam_role_policy_attachment" "saml_soap_proxy_fargate_parameter_execution" {
+  role       = module.saml_soap_proxy_fargate.execution_role_name
+  policy_arn = aws_iam_policy.saml_soap_proxy_parameter_execution.arn
+
+  depends_on = [
+    module.saml_soap_proxy_fargate.execution_role_name
+  ]
+}
+
 module "saml_soap_proxy_can_connect_to_config_fargate_v2" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = module.config_fargate_v2.lb_sg_id
+}
+
+module "saml_soap_proxy_fargate_can_connect_to_config_fargate_v2" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
@@ -134,6 +229,13 @@ module "saml_soap_proxy_can_connect_to_policy" {
   destination_sg_id = module.policy.lb_sg_id
 }
 
+module "saml_soap_proxy_fargate_can_connect_to_policy" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
+  destination_sg_id = module.policy.lb_sg_id
+}
+
 module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
   source = "./modules/microservice_connection"
 
@@ -141,9 +243,23 @@ module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
   destination_sg_id = module.saml_engine_fargate.lb_sg_id
 }
 
+module "saml_soap_proxy_fargate_can_connect_to_saml_engine_fargate" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
+  destination_sg_id = module.saml_engine_fargate.lb_sg_id
+}
+
 module "saml_soap_proxy_can_connect_to_ingress_for_metadata" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
+  destination_sg_id = aws_security_group.ingress.id
+}
+
+module "saml_soap_proxy_fargate_can_connect_to_ingress_for_metadata" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
   destination_sg_id = aws_security_group.ingress.id
 }

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -161,6 +161,7 @@ data "aws_iam_policy_document" "saml_soap_proxy" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-soap-proxy-execution",
+        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${module.saml_soap_proxy_fargate.execution_role_name}",
       ]
     }
 
@@ -181,6 +182,10 @@ resource "aws_kms_key" "saml_soap_proxy" {
   deletion_window_in_days = 7
 
   policy = data.aws_iam_policy_document.saml_soap_proxy.json
+
+  depends_on = [
+    module.saml_soap_proxy_fargate.execution_role_name
+  ]
 }
 
 resource "aws_kms_alias" "saml_soap_proxy" {


### PR DESCRIPTION
This change sets up a new service called SAML SOAP Proxy Fargate. It will run on Fargate alongside with SAML SOAP Proxy running on EC2 instances.

Author: @adityapahuja