### PR TITLE
Create ECS Fargate cluster for static ingress

### DIFF
--- a/dockerfiles/haproxy-static-ingress-fargate/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-fargate/Dockerfile
@@ -1,0 +1,15 @@
+FROM haproxy:2.0.14-alpine
+
+EXPOSE 4500
+
+RUN addgroup -S haproxy && \
+    adduser  -S -G haproxy haproxy && \
+    apk add --no-cache gettext
+
+WORKDIR /tmp
+
+USER haproxy
+
+COPY . /tmp
+
+ENTRYPOINT ["/tmp/docker-entrypoint.sh"]

--- a/dockerfiles/haproxy-static-ingress-fargate/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress-fargate/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env ash
+set -ueo pipefail
+
+: "${BACKEND:?BACKEND not set}"
+: "${BACKEND_PORT:?BACKEND_PORT not set}"
+: "${BIND_PORT:?BIND_PORT not set}"
+: "${RESOLVER:?RESOLVER not set}"
+
+envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl
+
+exec haproxy -f /tmp/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress-fargate/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-fargate/haproxy.cfg.tpl
@@ -1,0 +1,35 @@
+global
+    maxconn 10000
+    log stdout local0 warning
+    user haproxy
+    group haproxy
+
+defaults
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+    log global
+    option tcplog
+    maxconn 10000
+
+resolvers vpcdns
+    nameserver vpc ${RESOLVER}
+    resolve_retries 3
+    timeout resolve 1s
+    timeout retry   1s
+    hold valid 1s
+    hold timeout 0s
+    hold nx 0s
+    hold other 0s
+    hold refused 0s
+    hold obsolete 0s
+
+frontend nlb
+    mode tcp
+    bind *:$BIND_PORT accept-proxy
+    default_backend alb
+
+backend alb
+    mode tcp
+    balance roundrobin
+    server alb $BACKEND:$BACKEND_PORT resolvers vpcdns check inter 100 fastinter 100

--- a/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
@@ -1,0 +1,15 @@
+FROM haproxy:2.0.14-alpine
+
+EXPOSE 4500
+
+RUN addgroup -S haproxy && \
+    adduser  -S -G haproxy haproxy && \
+    apk add --no-cache gettext openssl ca-certificates
+
+WORKDIR /tmp
+
+USER haproxy
+
+COPY . /tmp
+
+ENTRYPOINT ["/tmp/docker-entrypoint.sh"]

--- a/dockerfiles/haproxy-static-ingress-tls-fargate/docker-entrypoint.sh
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env ash
+set -ueo pipefail
+
+: "${BACKEND:?BACKEND not set}"
+: "${BACKEND_PORT:?BACKEND_PORT not set}"
+: "${BIND_PORT:?BIND_PORT not set}"
+: "${RESOLVER:?RESOLVER not set}"
+
+envsubst > /tmp/haproxy.cfg < /tmp/haproxy.cfg.tpl
+
+mkdir -p /tmp/tls
+
+openssl req -x509 \
+            -nodes \
+            -newkey rsa:2048 \
+            -keyout /tmp/tls/key.pem \
+            -out    /tmp/tls/cert.pem \
+            -days   365 \
+            -subj "/C=GB/O=GDS"
+
+cat /tmp/tls/key.pem /tmp/tls/cert.pem > /tmp/tls/chain.pem
+
+echo /tmp/tls/chain.pem
+
+exec haproxy -f /tmp/haproxy.cfg

--- a/dockerfiles/haproxy-static-ingress-tls-fargate/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/haproxy.cfg.tpl
@@ -1,0 +1,46 @@
+global
+    ca-base /etc/ssl/certs
+    maxconn 10000
+    log stdout len 65535 format raw local0 info
+    user haproxy
+    group haproxy
+
+defaults
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+    log global
+    maxconn 10000
+    option persist
+    log-format '{"type":"haproxy","timestamp":%Ts,"http_status":%ST,"http_request":"%r","remote_addr":"%ci","bytes_read":%B,"upstream_addr":"%si","backend_name":"%b","retries":%rc,"bytes_uploaded":%U,"upstream_response_time":"%Tr","upstream_connect_time":"%Tc","session_duration":"%Tt","termination_state":"%ts","conc_cons":%fc,"frontend_name":"%f"}'
+
+resolvers vpcdns
+    nameserver vpc ${RESOLVER}
+    resolve_retries 3
+    timeout resolve 1s
+    timeout retry   1s
+    hold valid 1s
+    hold timeout 0s
+    hold nx 0s
+    hold other 0s
+    hold refused 0s
+    hold obsolete 0s
+
+frontend nlb
+    mode http
+    bind *:$BIND_PORT accept-proxy ssl crt /tmp/tls/chain.pem
+    default_backend alb
+
+backend alb
+    mode http
+    balance roundrobin
+    option forwardfor
+    http-request add-header x-client-ip %[src]
+    http-request add-header hub-forwarded-for %[src]
+
+    timeout check   250ms
+    timeout connect 250ms
+
+    server alb1 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100
+    server alb2 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100
+    server alb3 $BACKEND:$BACKEND_PORT resolvers vpcdns ssl verify required ca-file ca-certificates.crt check inter 1000 fastinter 100 downinter 100

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -84,6 +84,8 @@ scrape_configs:
           - "${deployment}-saml-engine-fargate.hub.local"
           - "${deployment}-saml-proxy-fargate.hub.local"
           - "${deployment}-saml-soap-proxy-fargate.hub.local"
+          - "${deployment}-static-ingress-http.hub.local"
+          - "${deployment}-static-ingress-https.hub.local"
     relabel_configs:
       - source_labels: [__meta_dns_name]
         target_label: job

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -251,3 +251,280 @@ resource "aws_lb_listener" "static_ingress_https" {
     target_group_arn = aws_lb_target_group.static_ingress_https.arn
   }
 }
+
+resource "aws_lb" "static_ingress_fargate" {
+  name                             = "${var.deployment}-static-ingress-fargate"
+  load_balancer_type               = "network"
+  internal                         = false
+  enable_cross_zone_load_balancing = true
+  subnets                          = aws_subnet.ingress.*.id
+}
+
+resource "aws_lb_target_group" "static_ingress_http_fargate" {
+  name                 = "static-ingress-http-fargate"
+  port                 = 80
+  protocol             = "TCP"
+  vpc_id               = aws_vpc.hub.id
+  deregistration_delay = 30
+  target_type          = "ip"
+}
+
+resource "aws_lb_target_group" "static_ingress_https_fargate" {
+  name                 = "static-ingress-https-fargate"
+  port                 = 443
+  protocol             = "TLS"
+  vpc_id               = aws_vpc.hub.id
+  deregistration_delay = 30
+  target_type          = "ip"
+}
+
+resource "aws_lb_listener" "static_ingress_http_fargate" {
+  load_balancer_arn = aws_lb.static_ingress_fargate.arn
+  protocol          = "TCP"
+  port              = 80
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static_ingress_http_fargate.arn
+  }
+}
+
+resource "aws_lb_listener" "static_ingress_https_fargate" {
+  load_balancer_arn = aws_lb.static_ingress_fargate.arn
+  protocol          = "TLS"
+  port              = 443
+  certificate_arn   = var.wildcard_cert_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static_ingress_https_fargate.arn
+  }
+}
+
+resource "aws_ecs_task_definition" "static_ingress_http_fargate" {
+  family                   = "${var.deployment}-static-ingress-http-fargate"
+  container_definitions    = templatefile("${path.module}/files/tasks/static-ingress.json",
+    {
+      image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress-fargate@${var.static_ingress_fargate_image_digest}"
+      backend          = var.signin_domain
+      bind_port        = 80
+      backend_port     = 80
+      allocated_cpu    = 1024
+      allocated_memory = 2 * 1024
+      deployment       = var.deployment
+      region           = data.aws_region.region.id
+    })
+  execution_role_arn       = module.static_ingress_ecs_roles.execution_role_arn
+  task_role_arn            = module.static_ingress_ecs_roles.task_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 2 * 1024
+}
+
+resource "aws_ecs_task_definition" "static_ingress_https_fargate" {
+  family                = "${var.deployment}-static-ingress-https-fargate"
+  container_definitions = templatefile("${path.module}/files/tasks/static-ingress.json",
+  {
+    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-static-ingress-tls-fargate@${var.static_ingress_tls_fargate_image_digest}"
+    backend          = var.signin_domain
+    bind_port        = 443
+    backend_port     = 443
+    allocated_cpu    = 1024
+    allocated_memory = 3 * 1024
+    deployment       = var.deployment
+    region           = data.aws_region.region.id
+  })
+  execution_role_arn    = module.static_ingress_ecs_roles.execution_role_arn
+  task_role_arn         = module.static_ingress_ecs_roles.task_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 3 * 1024
+}
+
+resource "aws_security_group" "static_ingress_fargate_task" {
+  name        = "${var.deployment}-static-ingress-fargate"
+  description = "${var.deployment}-static-ingress-fargate"
+  vpc_id      = aws_vpc.hub.id
+}
+
+resource "aws_service_discovery_service" "static_ingress_http_fargate" {
+  name = "${var.deployment}-static-ingress-http-fargate"
+
+  description = "A service to allow Prometheus to discover ${var.deployment}-static-ingress-http-fargate instances"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+
+    dns_records {
+      ttl  = 60
+      type = "SRV"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 2
+  }
+}
+
+resource "aws_service_discovery_service" "static_ingress_https_fargate" {
+  name = "${var.deployment}-static-ingress-https-fargate"
+
+  description = "A service to allow Prometheus to discover ${var.deployment}-static-ingress-https-fargate instances"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+
+    dns_records {
+      ttl  = 60
+      type = "SRV"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 2
+  }
+}
+
+resource "aws_ecs_service" "static_ingress_http_fargate" {
+  name            = "${var.deployment}-static-ingress-http"
+  cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.static_ingress_http_fargate.arn
+
+  desired_count                      = var.number_of_apps
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.static_ingress_http_fargate.arn
+    container_name   = "static-ingress"
+    container_port   = "80"
+  }
+
+  network_configuration {
+    subnets = aws_subnet.internal.*.id
+    security_groups = [
+      aws_security_group.can_connect_to_container_vpc_endpoint.id,
+      aws_security_group.hub_fargate_microservice.id,
+      aws_security_group.static_ingress_fargate_task.id,
+    ]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.static_ingress_http_fargate.arn
+    port         = 80
+  }
+}
+
+resource "aws_ecs_service" "static_ingress_https_fargate" {
+  name            = "${var.deployment}-static-ingress-https"
+  cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.static_ingress_https_fargate.arn
+
+  desired_count                      = var.number_of_apps
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.static_ingress_https_fargate.arn
+    container_name   = "static-ingress"
+    container_port   = "443"
+  }
+
+  network_configuration {
+    subnets = aws_subnet.internal.*.id
+    security_groups = [
+      aws_security_group.can_connect_to_container_vpc_endpoint.id,
+      aws_security_group.hub_fargate_microservice.id,
+      aws_security_group.static_ingress_fargate_task.id,
+    ]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.static_ingress_https_fargate.arn
+    port         = 443
+  }
+}
+
+resource "aws_security_group_rule" "static_ingress_fargate_egress_to_internet_over_http" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 80
+  to_port   = 80
+
+  security_group_id = aws_security_group.static_ingress_fargate_task.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "static_ingress_fargate_egress_to_internet_over_https" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  security_group_id = aws_security_group.static_ingress_fargate_task.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "static_ingress_fargate_ingress_from_internet_over_http" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 80
+  to_port   = 80
+
+  security_group_id = aws_security_group.static_ingress_fargate_task.id
+
+  cidr_blocks = concat(
+    var.publically_accessible_from_cidrs,
+    formatlist("%s/32", aws_eip.egress.*.public_ip),
+    aws_subnet.ingress.*.cidr_block,
+  )
+
+  # adding the egress IPs is a hack to let us access metadata through egress proxy
+  # adding the ingress cidrs is so the network load balancer can healthcheck the boxes
+}
+
+resource "aws_security_group_rule" "static_ingress_fargate_ingress_from_internet_over_https" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  security_group_id = aws_security_group.static_ingress_fargate_task.id
+
+  cidr_blocks = concat(
+    var.publically_accessible_from_cidrs,
+    formatlist("%s/32", aws_eip.egress.*.public_ip),
+    aws_subnet.ingress.*.cidr_block,
+  )
+
+  # adding the egress IPs is a hack to let us access metadata through egress proxy
+  # adding the ingress cidrs is so the network load balancer can healthcheck the boxes
+}
+
+module "static_ingress_fargate_can_connect_to_ingress_http" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.static_ingress_fargate_task.id
+  destination_sg_id = aws_security_group.ingress.id
+
+  port = 80
+}
+
+module "static_ingress_fargate_can_connect_to_ingress_https" {
+  source = "./modules/microservice_connection"
+
+  source_sg_id      = aws_security_group.static_ingress_fargate_task.id
+  destination_sg_id = aws_security_group.ingress.id
+
+  port = 443
+}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -201,6 +201,8 @@ variable "ecs_agent_image_digest" {}
 variable "nginx_image_digest" {}
 variable "static_ingress_image_digest" {}
 variable "static_ingress_tls_image_digest" {}
+variable "static_ingress_fargate_image_digest" {}
+variable "static_ingress_tls_fargate_image_digest" {}
 variable "beat_exporter_image_digest" {}
 variable "cloudwatch_exporter_image_digest" {}
 variable "squid_image_digest" {}


### PR DESCRIPTION
Includes a duplication of the whole stack due to client-ip requirements. A
future commit will remap the EIPs to the new LB (likely triggering some
downtime).