### PR TITLE
analytics: add analytics task to fargate cluster

### DIFF
--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 298,
+    "cpu": 256,
     "memory": 250,
     "essential": true,
     "portMappings": [


### PR DESCRIPTION
deploy second set of analytics tasks into the shared fargate ecs
cluster.

the tasks are connected to the existing target group so will serve
traffic in parallel with the existing EC2 tasks.

Due to fargate cpu/memory constraints the task definition cpu requests
are lowered a little to fit.

The memory requests are left as is for now as they are tuned to fit a
certain number of tasks onto the EC2 instances. A follow up PR will
alter these values to use the maximum memory for the task once
EC2-service is removed.