### PR TITLE
AUT-817: Remove SAML SOAP Proxy from EC2 instances

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -29,7 +29,6 @@ locals {
     "egress-proxy",
     "ingress",
     "static-ingress",
-    "saml-soap-proxy",
   ]
 }
 

--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -96,9 +96,6 @@ scrape_configs:
       - source_labels: [__meta_ec2_tag_Team]
         target_label: team
       - source_labels: [__meta_ec2_tag_Cluster]
-        regex: 'saml-soap-proxy'
-        action: keep
-      - source_labels: [__meta_ec2_tag_Cluster]
         target_label: job
   - job_name: fargate-apps
     metrics_path: '/prometheus/metrics'

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -83,7 +83,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config-v2-fargate.${domain}|policy-fargate.${domain}|saml-soap-proxy.${domain}|saml-soap-proxy-fargate.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config-v2-fargate.${domain}|policy-fargate.${domain}|saml-soap-proxy-fargate.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "REDIS_HOST",

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -11,7 +11,6 @@
         "hostPort": 8443
       }
     ],
-    ${optional_links}
     "environment": [
       {
         "Name": "LOCATION_BLOCKS",

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -125,13 +125,6 @@ module "policy_fargate_can_connect_to_saml_proxy_fargate" {
   destination_sg_id = module.saml_proxy_fargate.lb_sg_id
 }
 
-module "policy_fargate_can_connect_to_saml_soap_proxy" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.policy_fargate.task_sg_id
-  destination_sg_id = module.saml_soap_proxy.lb_sg_id
-}
-
 module "policy_fargate_can_connect_to_saml_soap_proxy_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -70,13 +70,6 @@ module "saml_engine_fargate_can_connect_to_policy_fargate" {
   destination_sg_id = module.policy_fargate.lb_sg_id
 }
 
-module "saml_engine_fargate_can_connect_to_saml_soap_proxy" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_engine_fargate.task_sg_id
-  destination_sg_id = module.saml_soap_proxy.lb_sg_id
-}
-
 module "saml_engine_fargate_can_connect_to_saml_soap_proxy_fargate" {
   source = "./modules/microservice_connection"
 

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -1,37 +1,3 @@
-module "saml_soap_proxy_ecs_asg" {
-  source = "./modules/ecs_asg"
-
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "saml-soap-proxy"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.saml_soap_proxy_instance_type
-
-  ecs_agent_image_identifier = local.ecs_agent_image_identifier
-  tools_account_id           = var.tools_account_id
-
-  additional_instance_security_group_ids = [
-    aws_security_group.scraped_by_prometheus.id,
-    aws_security_group.can_connect_to_container_vpc_endpoint.id,
-  ]
-
-  logit_api_key           = var.logit_api_key
-  logit_elasticsearch_url = var.logit_elasticsearch_url
-}
-
-resource "aws_security_group_rule" "saml_soap_proxy_instance_egress_to_internet_over_http" {
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 80
-  to_port   = 80
-
-  security_group_id = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "saml_soap_proxy_fargate_egress_to_internet_over_http" {
   type      = "egress"
   protocol  = "tcp"
@@ -39,16 +5,6 @@ resource "aws_security_group_rule" "saml_soap_proxy_fargate_egress_to_internet_o
   to_port   = 80
 
   security_group_id = module.saml_soap_proxy_fargate.task_sg_id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_security_group_rule" "saml_soap_proxy_instance_egress_to_internet_over_https" {
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 443
-  to_port   = 443
-
-  security_group_id = module.saml_soap_proxy_ecs_asg.instance_sg_id
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
@@ -63,19 +19,6 @@ resource "aws_security_group_rule" "saml_soap_proxy_fargate_egress_to_internet_o
 }
 
 locals {
-  saml_soap_proxy_location_blocks = <<-LOCATIONS
-  location = /prometheus/metrics {
-    proxy_pass http://saml-soap-proxy:8081;
-    proxy_set_header Host saml-soap-proxy.${local.root_domain};
-  }
-  location / {
-    proxy_pass http://saml-soap-proxy:8080;
-    proxy_set_header Host saml-soap-proxy.${local.root_domain};
-  }
-  LOCATIONS
-
-  nginx_saml_soap_proxy_location_blocks_base64 = base64encode(local.saml_soap_proxy_location_blocks)
-
   saml_soap_proxy_fargate_location_blocks = <<-LOCATIONS
   location = /prometheus/metrics {
     proxy_pass http://localhost:8081;
@@ -86,46 +29,6 @@ locals {
     proxy_set_header Host saml-soap-proxy.${local.root_domain};
   }
   LOCATIONS
-}
-
-data "template_file" "saml_soap_proxy_task_def" {
-  template = file("${path.module}/files/tasks/hub-saml-soap-proxy.json")
-
-  vars = {
-    image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
-    nginx_image_identifier           = local.nginx_image_identifier
-    domain                           = local.root_domain
-    optional_links                   = "\"links\": [\"saml-soap-proxy\"],"
-    deployment                       = var.deployment
-    location_blocks_base64           = local.nginx_saml_soap_proxy_location_blocks_base64
-    region                           = data.aws_region.region.id
-    account_id                       = data.aws_caller_identity.account.account_id
-    event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
-    rp_truststore_enabled            = var.rp_truststore_enabled
-    certificates_config_cache_expiry = var.certificates_config_cache_expiry
-    memory_hard_limit                = var.saml_soap_proxy_memory_hard_limit
-    jvm_options                      = var.jvm_options
-    log_level                        = var.hub_saml_soap_proxy_log_level
-  }
-}
-
-module "saml_soap_proxy" {
-  source = "./modules/ecs_app"
-
-  deployment                 = var.deployment
-  cluster                    = "saml-soap-proxy"
-  domain                     = local.root_domain
-  vpc_id                     = aws_vpc.hub.id
-  lb_subnets                 = aws_subnet.internal.*.id
-  task_definition            = data.template_file.saml_soap_proxy_task_def.rendered
-  container_name             = "nginx"
-  container_port             = "8443"
-  number_of_tasks            = var.number_of_apps
-  health_check_path          = "/service-status"
-  tools_account_id           = var.tools_account_id
-  instance_security_group_id = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  certificate_arn            = var.wildcard_cert_arn
-  image_name                 = "verify-saml-soap-proxy"
 }
 
 module "saml_soap_proxy_fargate" {
@@ -141,7 +44,6 @@ module "saml_soap_proxy_fargate" {
       image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
       nginx_image_identifier           = local.nginx_image_identifier
       domain                           = local.root_domain
-      optional_links                   = ""
       deployment                       = var.deployment
       location_blocks_base64           = base64encode(local.saml_soap_proxy_fargate_location_blocks)
       region                           = data.aws_region.region.id
@@ -194,25 +96,9 @@ resource "aws_iam_policy" "saml_soap_proxy_parameter_execution" {
   EOF
 }
 
-resource "aws_iam_role_policy_attachment" "saml_soap_proxy_parameter_execution" {
-  role       = "${var.deployment}-saml-soap-proxy-execution"
-  policy_arn = aws_iam_policy.saml_soap_proxy_parameter_execution.arn
-}
-
 resource "aws_iam_role_policy_attachment" "saml_soap_proxy_fargate_parameter_execution" {
   role       = module.saml_soap_proxy_fargate.execution_role_name
   policy_arn = aws_iam_policy.saml_soap_proxy_parameter_execution.arn
-
-  depends_on = [
-    module.saml_soap_proxy_fargate.execution_role_name
-  ]
-}
-
-module "saml_soap_proxy_can_connect_to_config_fargate_v2" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
 module "saml_soap_proxy_fargate_can_connect_to_config_fargate_v2" {
@@ -222,13 +108,6 @@ module "saml_soap_proxy_fargate_can_connect_to_config_fargate_v2" {
   destination_sg_id = module.config_fargate_v2.lb_sg_id
 }
 
-module "saml_soap_proxy_can_connect_to_policy_fargate" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  destination_sg_id = module.policy_fargate.lb_sg_id
-}
-
 module "saml_soap_proxy_fargate_can_connect_to_policy_fargate" {
   source = "./modules/microservice_connection"
 
@@ -236,25 +115,11 @@ module "saml_soap_proxy_fargate_can_connect_to_policy_fargate" {
   destination_sg_id = module.policy_fargate.lb_sg_id
 }
 
-module "saml_soap_proxy_can_connect_to_saml_engine_fargate" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  destination_sg_id = module.saml_engine_fargate.lb_sg_id
-}
-
 module "saml_soap_proxy_fargate_can_connect_to_saml_engine_fargate" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = module.saml_soap_proxy_fargate.task_sg_id
   destination_sg_id = module.saml_engine_fargate.lb_sg_id
-}
-
-module "saml_soap_proxy_can_connect_to_ingress_for_metadata" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = module.saml_soap_proxy_ecs_asg.instance_sg_id
-  destination_sg_id = aws_security_group.ingress.id
 }
 
 module "saml_soap_proxy_fargate_can_connect_to_ingress_for_metadata" {

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -162,7 +162,6 @@ data "aws_iam_policy_document" "saml_soap_proxy" {
 
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${var.deployment}-saml-soap-proxy-execution",
         "arn:aws:iam::${data.aws_caller_identity.account.account_id}:role/${module.saml_soap_proxy_fargate.execution_role_name}",
       ]
     }
@@ -184,10 +183,6 @@ resource "aws_kms_key" "saml_soap_proxy" {
   deletion_window_in_days = 7
 
   policy = data.aws_iam_policy_document.saml_soap_proxy.json
-
-  depends_on = [
-    module.saml_soap_proxy_fargate.execution_role_name
-  ]
 }
 
 resource "aws_kms_alias" "saml_soap_proxy" {

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -93,15 +93,6 @@ module "prometheus_can_talk_to_hub_fargate_microservices" {
   port = 8443
 }
 
-module "prometheus_can_talk_to_saml_soap_proxy" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.saml_soap_proxy_ecs_asg.instance_sg_id
-
-  port = 8443
-}
-
 module "prometheus_can_talk_to_ingress_for_scraping_metadata" {
   source = "./modules/microservice_connection"
 


### PR DESCRIPTION
SAML SOAP Proxy on Fargate is live and is processing SAML messages. This change removes SAML SOAP Proxy from EC2 instances.

Author: @adityapahuja