### PR TITLE
[prometheus] remove `apps` scrape job

### DIFF
--- a/terraform/modules/hub/files/prometheus/prometheus.yml
+++ b/terraform/modules/hub/files/prometheus/prometheus.yml
@@ -73,30 +73,6 @@ scrape_configs:
     dns_sd_configs:
       - names:
           - 'frontend.hub.local'
-  - job_name: apps
-    scheme: 'https'
-    metrics_path: '/prometheus/metrics'
-    tls_config:
-      insecure_skip_verify: true
-    ec2_sd_configs:
-      - region: eu-west-2
-        refresh_interval: 30s
-        port: 8443
-    relabel_configs:
-      - source_labels: [__meta_ec2_instance_id]
-        target_label: instance
-      - source_labels: [__meta_ec2_tag_Role]
-        target_label: role
-      - source_labels: [__meta_ec2_tag_Deployment]
-        regex: '^${deployment}$'
-        action: keep
-      - source_labels: [__meta_ec2_tag_Cluster]
-        regex: '(ingress|egress-proxy|)'
-        action: drop
-      - source_labels: [__meta_ec2_tag_Team]
-        target_label: team
-      - source_labels: [__meta_ec2_tag_Cluster]
-        target_label: job
   - job_name: fargate-apps
     metrics_path: '/prometheus/metrics'
     scheme: 'https'


### PR DESCRIPTION
This removes the `apps` scrape job.

The last real use this had was saml-soap-proxy.  In 7658e71f7aff we
removed the rule that matched saml-soap-proxy, but this had the
unintentional consequence of trying to scrape non-hub-app clusters
such as `prometheus` and `static-ingress`.

We should just get rid of the whole job, it's completely redundant.