### PR TITLE
analytics: run in fargate

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -110,6 +110,8 @@ resource "aws_ecs_service" "analytics_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
+  launch_type = "FARGATE"
+
   load_balancer {
     target_group_arn = aws_lb_target_group.ingress_analytics.arn
     container_name   = "nginx"


### PR DESCRIPTION
## What

add missing fargate launch type to analytics service

## Why

Because I'm an idiot