### PR TITLE
analytics: remove (ec2) analytics instances

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -49,13 +49,6 @@ module "analytics_ecs_roles" {
   tools_account_id = var.tools_account_id
 }
 
-resource "aws_ecs_task_definition" "analytics" {
-  family                = "${var.deployment}-analytics"
-  container_definitions = data.template_file.analytics_task_def.rendered
-  network_mode          = "awsvpc"
-  execution_role_arn    = module.analytics_ecs_roles.execution_role_arn
-}
-
 resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https" {
   type      = "egress"
   protocol  = "tcp"
@@ -64,31 +57,6 @@ resource "aws_security_group_rule" "analytics_task_egress_to_internet_over_https
 
   security_group_id = aws_security_group.analytics_task.id
   cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_ecs_service" "analytics" {
-  name            = "${var.deployment}-analytics"
-  cluster         = aws_ecs_cluster.ingress.id
-  task_definition = aws_ecs_task_definition.analytics.arn
-
-  desired_count                      = var.number_of_apps
-  deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
-
-  load_balancer {
-    target_group_arn = aws_lb_target_group.ingress_analytics.arn
-    container_name   = "nginx"
-    container_port   = "8443"
-  }
-
-  network_configuration {
-    subnets = aws_subnet.internal.*.id
-
-    security_groups = [
-      aws_security_group.analytics_task.id,
-      aws_security_group.can_connect_to_container_vpc_endpoint.id,
-    ]
-  }
 }
 
 resource "aws_ecs_task_definition" "analytics_fargate" {

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -3,7 +3,7 @@
     "name": "nginx",
     "image": "${nginx_image_identifier}",
     "cpu": 256,
-    "memory": 250,
+    "memory": 512,
     "essential": true,
     "portMappings": [
       {


### PR DESCRIPTION
analytics now runs in fargate, we can remove the old ec2-based instances
and alter the task definition to use the full memory available in the
fargate task.

I have checked the logs for the new fargate `staging-analytics` task to ensure that it was receiving requests, so removing the old tasks should cause very little (if any) failed requests to matomo.