### PR TITLE
frontend: removing ec2-based frontend tasks

### DIFF
--- a/dashboards/Hub-ECS.json
+++ b/dashboards/Hub-ECS.json
@@ -1264,8 +1264,8 @@
         {
           "alias": "Frontend Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
-            "ServiceName": "prod-frontend-v2"
+            "ClusterName": "prod",
+            "ServiceName": "prod-frontend"
           },
           "expression": "",
           "highResolution": false,
@@ -1284,7 +1284,7 @@
         {
           "alias": "Analytics Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
+            "ClusterName": "prod",
             "ServiceName": "prod-analytics"
           },
           "expression": "",
@@ -1770,8 +1770,8 @@
         {
           "alias": "Frontend Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
-            "ServiceName": "prod-frontend-v2"
+            "ClusterName": "prod",
+            "ServiceName": "prod-frontend"
           },
           "expression": "",
           "highResolution": false,
@@ -1790,7 +1790,7 @@
         {
           "alias": "Analytics Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
+            "ClusterName": "prod",
             "ServiceName": "prod-analytics"
           },
           "expression": "",

--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -172,7 +172,7 @@ groups:
       message: |
         We're seeing elevated CPU utilisation on the ingress nodes.
     expr: |
-      aws_ecs_cpuutilization_average{cluster_name="prod-ingress", service_name="prod-frontend-v2"} > 80
+      aws_ecs_cpuutilization_average{cluster_name="prod", service_name="prod-frontend"} > 80
     for: 5m
   - alert: FrontendConnectionErrors
     labels: *infraticket

--- a/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
+++ b/terraform/modules/hub/files/prometheus/cloudwatch_exporter.yml
@@ -42,7 +42,7 @@ metrics:
   aws_dimensions: [ServiceName, ClusterName]
   aws_dimension_select:
     ServiceName:
-      - prod-frontend-v2
+      - prod-frontend
     ClusterName:
-      - prod-ingress
+      - prod
   aws_statistics: [Average]

--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": ${nginx_cpu},
-    "memory": ${nginx_memory},
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "frontend",
     "image": "${image_identifier}",
-    "cpu": ${frontend_cpu},
-    "memory": ${frontend_memory},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -94,8 +94,8 @@ resource "aws_ecs_task_definition" "frontend_fargate" {
   network_mode             = "awsvpc"
   execution_role_arn       = module.frontend_ecs_roles.execution_role_arn
   requires_compatibilities = ["FARGATE"]
-  cpu                      = var.ingress_instance_type == "t3.xlarge" ? 2048 : 1024
-  memory                   = var.ingress_instance_type == "t3.xlarge" ? 16384 : 2048
+  cpu                      = 1024
+  memory                   = 2048
 }
 
 resource "aws_ecs_service" "frontend_fargate" {
@@ -103,7 +103,7 @@ resource "aws_ecs_service" "frontend_fargate" {
   cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
   task_definition = aws_ecs_task_definition.frontend_fargate.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_frontend_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -76,10 +76,6 @@ data "template_file" "frontend_task_def" {
     publish_hub_config_enabled = var.publish_hub_config_enabled
     log_level                  = var.hub_frontend_log_level
     throttling_enabled         = var.throttling_enabled
-    nginx_cpu                  = var.ingress_instance_type == "t3.xlarge" ? 1024 : 256
-    nginx_memory               = var.ingress_instance_type == "t3.xlarge" ? 1024 : 256
-    frontend_cpu               = var.ingress_instance_type == "t3.xlarge" ? 1024 : 768
-    frontend_memory            = var.ingress_instance_type == "t3.xlarge" ? 14066 : 1792
   }
 }
 

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -14,6 +14,11 @@ variable "number_of_apps" {
   default = 2
 }
 
+variable "number_of_frontend_apps" {
+  type    = number
+  default = 2
+}
+
 variable "number_of_prometheus_apps" {
   default = 3
 }


### PR DESCRIPTION
## What

* Fixes cloudwatch metric collection for analytics and frontend tasks
* Removes the container-level cpu/mem constaints to simplify configuration (these are only required for ec2-tasks)
* Removes the old ec2-tasks
* Changes scaling to be based on the number of frontend instances, instead of basing scaling on combination of the number_of_apps and the now redundent ingress_instance_type

## :warning: Before merging

Ensure https://github.com/alphagov/verify-infrastructure/pull/509 is merged and deployed to production first!!!: 

Deploy at same time as https://github.com/alphagov/verify-infrastructure-config/pull/354