### PR TITLE
metadata: deploy fargate task in parallel

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 298,
+    "cpu": 256,
     "memory": 250,
     "essential": true,
     "portMappings": [

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -58,3 +58,66 @@ resource "aws_ecs_service" "metadata" {
     ]
   }
 }
+
+resource "aws_ecs_task_definition" "metadata_fargate" {
+  family                   = "${var.deployment}-metadata-fargate"
+  container_definitions    = data.template_file.metadata_task_def.rendered
+  network_mode             = "awsvpc"
+  execution_role_arn       = module.metadata_ecs_roles.execution_role_arn
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+}
+
+resource "aws_ecs_service" "metadata_fargate" {
+  name            = "${var.deployment}-metadata"
+  cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.metadata_fargate.arn
+
+  desired_count                      = var.number_of_apps
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ingress_metadata.arn
+    container_name   = "nginx"
+    container_port   = "8443"
+  }
+
+  network_configuration {
+    subnets = aws_subnet.internal.*.id
+    security_groups = [
+      aws_security_group.metadata_task.id,
+      aws_security_group.hub_fargate_microservice.id,
+      aws_security_group.can_connect_to_container_vpc_endpoint.id,
+    ]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.metadata_fargate.arn
+    port         = 8443
+  }
+}
+
+resource "aws_service_discovery_service" "metadata_fargate" {
+  name = "${var.deployment}-metadata"
+
+  description = "service discovery for ${var.deployment}-metadata-fargate instances"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+
+    dns_records {
+      ttl  = 60
+      type = "SRV"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 2
+  }
+}


### PR DESCRIPTION
deploy a metadata task to the fargate cluster.

task will serve traffic in parallel with ec2-based task, follow up PR will remove the ec2-based tasks.

lower the cpu value so it fits within fargate constaints.

leave the memory value as is for now so that ec2 based tasks are
unaffected, will remove the container limits in follow up PR.

service discovery is added for consistancy with other services and to
avoid problems if we need it in the future.