### PR TITLE
metadata: remove ec2-based metadata tasks

### DIFF
--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -28,37 +28,6 @@ module "metadata_ecs_roles" {
   image_name       = "verify-metadata"
 }
 
-resource "aws_ecs_task_definition" "metadata" {
-  family                = "${var.deployment}-metadata"
-  container_definitions = data.template_file.metadata_task_def.rendered
-  network_mode          = "awsvpc"
-  execution_role_arn    = module.metadata_ecs_roles.execution_role_arn
-}
-
-resource "aws_ecs_service" "metadata" {
-  name            = "${var.deployment}-metadata"
-  cluster         = aws_ecs_cluster.ingress.id
-  task_definition = aws_ecs_task_definition.metadata.arn
-
-  desired_count                      = var.number_of_apps
-  deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
-
-  load_balancer {
-    target_group_arn = aws_lb_target_group.ingress_metadata.arn
-    container_name   = "nginx"
-    container_port   = "8443"
-  }
-
-  network_configuration {
-    subnets = aws_subnet.internal.*.id
-    security_groups = [
-      aws_security_group.metadata_task.id,
-      aws_security_group.can_connect_to_container_vpc_endpoint.id,
-    ]
-  }
-}
-
 resource "aws_ecs_task_definition" "metadata_fargate" {
   family                   = "${var.deployment}-metadata-fargate"
   container_definitions    = data.template_file.metadata_task_def.rendered


### PR DESCRIPTION
metadata is being served from fargate tasks now, so we can remove the
ec2-based tasks