### PR TITLE
Remove ingress cluster

### DIFF
--- a/dashboards/Hub-ECS.json
+++ b/dashboards/Hub-ECS.json
@@ -1304,7 +1304,7 @@
         {
           "alias": "Metadata Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
+            "ClusterName": "prod",
             "ServiceName": "prod-metadata"
           },
           "expression": "",
@@ -1315,26 +1315,6 @@
           "namespace": "AWS/ECS",
           "period": "",
           "refId": "G",
-          "region": "eu-west-2",
-          "returnData": false,
-          "statistics": [
-            "Maximum"
-          ]
-        },
-        {
-          "alias": "Ingress Beat Exporter",
-          "dimensions": {
-            "ClusterName": "prod-ingress",
-            "ServiceName": "prod-beat-exporter"
-          },
-          "expression": "",
-          "highResolution": false,
-          "id": "",
-          "matchExact": true,
-          "metricName": "MemoryUtilization",
-          "namespace": "AWS/ECS",
-          "period": "",
-          "refId": "H",
           "region": "eu-west-2",
           "returnData": false,
           "statistics": [
@@ -1810,7 +1790,7 @@
         {
           "alias": "Metadata Task",
           "dimensions": {
-            "ClusterName": "prod-ingress",
+            "ClusterName": "prod",
             "ServiceName": "prod-metadata"
           },
           "expression": "",
@@ -1821,26 +1801,6 @@
           "namespace": "AWS/ECS",
           "period": "",
           "refId": "G",
-          "region": "eu-west-2",
-          "returnData": false,
-          "statistics": [
-            "Maximum"
-          ]
-        },
-        {
-          "alias": "Ingress Beat Exporter",
-          "dimensions": {
-            "ClusterName": "prod-ingress",
-            "ServiceName": "prod-beat-exporter"
-          },
-          "expression": "",
-          "highResolution": false,
-          "id": "",
-          "matchExact": true,
-          "metricName": "CPUUtilization",
-          "namespace": "AWS/ECS",
-          "period": "",
-          "refId": "H",
           "region": "eu-west-2",
           "returnData": false,
           "statistics": [

--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -1,6 +1,3 @@
-# analytics
-#
-# frontend applications are run on the ingress asg
 
 resource "aws_security_group" "analytics_task" {
   name        = "${var.deployment}-analytics-task"

--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -27,7 +27,6 @@ locals {
   clusters = [
     "prometheus",
     "egress-proxy",
-    "ingress",
     "static-ingress",
   ]
 }

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -4,8 +4,6 @@
 #   - config
 #   - saml proxy
 #   - policy
-#
-# frontend applications are run on the ingress asg
 
 resource "aws_security_group" "frontend_task" {
   name        = "${var.deployment}-frontend-task"

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -1,6 +1,3 @@
-# metadata
-#
-# frontend applications are run on the ingress asg
 
 resource "aws_security_group" "metadata_task" {
   name        = "${var.deployment}-metadata-task"

--- a/terraform/modules/hub/ingress.tf
+++ b/terraform/modules/hub/ingress.tf
@@ -292,31 +292,3 @@ resource "aws_route53_record" "ingress_www" {
   }
 }
 
-module "ingress_ecs_asg" {
-  source = "./modules/ecs_asg"
-
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "ingress"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps * 2
-  domain              = local.root_domain
-  instance_type       = var.ingress_instance_type
-
-  ecs_agent_image_identifier = local.ecs_agent_image_identifier
-  tools_account_id           = var.tools_account_id
-
-  additional_instance_security_group_ids = [
-    aws_security_group.ingress.id,
-    aws_security_group.scraped_by_prometheus.id,
-    aws_security_group.can_connect_to_container_vpc_endpoint.id,
-  ]
-
-  logit_api_key           = var.logit_api_key
-  logit_elasticsearch_url = var.logit_elasticsearch_url
-}
-
-resource "aws_ecs_cluster" "ingress" {
-  name = "${var.deployment}-ingress"
-}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -184,10 +184,6 @@ variable "instance_type" {
   default = "t3.medium"
 }
 
-variable "ingress_instance_type" {
-  default = "t3.medium"
-}
-
 variable "config_instance_type" {
   default = "t3.medium"
 }


### PR DESCRIPTION
all the components using the ingress cluster are now in fargate so we
can destroy the redundent ec2 instances and associated ecs resources.

Merge along with: https://github.com/alphagov/verify-infrastructure-config/pull/355