### PR TITLE
metadata: remove container limits

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata.json
+++ b/terraform/modules/hub/files/tasks/metadata.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${image_identifier}",
-    "cpu": 256,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {


### PR DESCRIPTION
let the limits for metadata be dictated by the fargate task definition
not the container definition