### PR TITLE
BAU: Remove unused variables

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -184,26 +184,6 @@ variable "instance_type" {
   default = "t3.medium"
 }
 
-variable "config_instance_type" {
-  default = "t3.medium"
-}
-
-variable "saml_proxy_instance_type" {
-  default = "t3.medium"
-}
-
-variable "policy_instance_type" {
-  default = "t3.medium"
-}
-
-variable "saml_engine_instance_type" {
-  default = "t3.medium"
-}
-
-variable "saml_soap_proxy_instance_type" {
-  default = "t3.medium"
-}
-
 variable "throttling_enabled" {
   description = "Toggles the throttling of IDP traffic on frontend"
   default     = "false"


### PR DESCRIPTION
Hub applications are running on Fargate. There is no need to keep variables used for specifying instance type for hub applications.

Author: @adityapahuja