### PR TITLE
egress-proxy: deploy task to fargate cluster

### DIFF
--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -3,7 +3,7 @@
     "name": "squid",
     "image": "${image_identifier}",
     "cpu": 1024,
-    "memory": 3500,
+    "memory": 3072,
     "essential": true,
     "portMappings": [
       {


### PR DESCRIPTION
creates a fargate egress-proxy task.

lowers container memory limit a little to fit in the 3072 fargate task
size.

we will be moving away from a "classic" ELB, so there's some prep for
that:

creates/updates security groups ready for either connecting via NLB or
directly (both of which will require security groups on the task to
allow ingress rather than on the load balancer since NLBs don't accept
security groups).

Adds service discovery for consitancy with other tasks and so that we
can connect directly.

This does not put anything "live" yet, just gets the task setup. A
follow up PR will direct traffic to the task once it's working.