### PR TITLE
prometheus: remove logit shipping

### DIFF
--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -25,7 +25,6 @@ resource "aws_ecs_task_definition" "beat_exporter" {
 locals {
   # FIXME is there a better way of doing this?
   clusters = [
-    "prometheus",
     "egress-proxy",
     "static-ingress",
   ]

--- a/terraform/modules/hub/fargate-ecs.tf
+++ b/terraform/modules/hub/fargate-ecs.tf
@@ -6,6 +6,7 @@ resource "aws_cloudwatch_log_group" "fargate-logs" {
   name              = "${var.deployment}-hub"
   retention_in_days = 7
 }
+
 resource "aws_cloudwatch_log_subscription_filter" "csls-subscription" {
   name            = "${var.deployment}-hub-csls"
   log_group_name  = aws_cloudwatch_log_group.fargate-logs.name

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -68,7 +68,7 @@ run-until-success apt-get install --yes docker.io
 cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd --log-driver journald --dns 10.0.0.2
+ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt awslogs-region=eu-west2 --log-opt awslogs-group ${cloudwatch_log_group} --dns 10.0.0.2
 EOF
 
 # Reload systemctl daemon to pick up new override files

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -68,7 +68,7 @@ run-until-success apt-get install --yes docker.io
 cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt awslogs-region=eu-west2 --log-opt awslogs-group ${cloudwatch_log_group} --dns 10.0.0.2
+ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt awslogs-region=eu-west-2 --log-opt awslogs-group ${cloudwatch_log_group} --dns 10.0.0.2
 EOF
 
 # Reload systemctl daemon to pick up new override files

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -76,51 +76,6 @@ systemctl stop docker
 systemctl daemon-reload
 systemctl enable --now docker
 
-# Journalbeat for log shipping
-echo 'Installing and configuring journalbeat'
-(
-elastic_beats="artifacts.elastic.co/downloads/beats"
-mkdir -p /tmp/journalbeat
-cd /tmp/journalbeat
-
-cat <<EOF > journalbeat-oss-6.8.3-amd64.deb.sha512
-685e571638a3422e8b1c6f6aa7c15db8bf8fa9b91ecfedb4ce7c26dedc418e90b558a37711af2a547cb5025de17361d2fed1042be2d0871d22ec78037f7225a6  journalbeat-oss-6.8.3-amd64.deb
-EOF
-
-curl --silent --fail \
-     -L -O \
-     "https://$elastic_beats/journalbeat/journalbeat-oss-6.8.3-amd64.deb"
-
-sha512sum -c journalbeat-oss-6.8.3-amd64.deb.sha512
-dpkg -i journalbeat-oss-6.8.3-amd64.deb
-)
-
-cat <<EOF > /etc/journalbeat/journalbeat.yml
-http.enabled: true
-
-journalbeat.inputs:
-- paths: []
-  seek: cursor
-
-logging.level: warning
-logging.to_files: false
-logging.to_syslog: true
-logging.json: true
-
-processors:
-- add_cloud_metadata: ~
-
-output.elasticsearch:
-  hosts: ["https://${logit_elasticsearch_url}:443"]
-  headers:
-    Apikey: ${logit_api_key}
-EOF
-# It seems that journalbeat is very unhappy if docker isn't running
-# when it starts, so let's update the systemd unit to reflect that
-sed -i -e 's/Wants=.*/& docker.service/' /lib/systemd/system/journalbeat.service
-sed -i -e 's/After=.*/& docker.service/' /lib/systemd/system/journalbeat.service
-systemctl enable --now journalbeat
-
 echo 'Installing prometheus node exporter'
 run-until-success apt-get install --yes prometheus-node-exporter
 mkdir /etc/systemd/system/prometheus-node-exporter.service.d

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -291,8 +291,6 @@ data "template_file" "prometheus_cloud_init" {
     prometheus_config          = data.template_file.prometheus_config.rendered
     deployment                 = var.deployment
     domain                     = local.root_domain
-    logit_elasticsearch_url    = var.logit_elasticsearch_url
-    logit_api_key              = var.logit_api_key
     cluster                    = aws_ecs_cluster.prometheus.name
     ecs_agent_image_identifier = local.ecs_agent_image_identifier
     tools_account_id           = var.tools_account_id

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -295,6 +295,7 @@ data "template_file" "prometheus_cloud_init" {
     ecs_agent_image_identifier = local.ecs_agent_image_identifier
     tools_account_id           = var.tools_account_id
     data_volume_size           = var.prometheus_volume_size
+    cloudwatch_log_group       = aws_cloudwatch_log_group.fargate-logs.name
   }
 }
 


### PR DESCRIPTION
The prometheus ECS cluster is not being migrated to Fargate.

All ECS container logs are being shipped to cloudwatch/splunk (including prometheus). 

Journal-beat is currently still shipping non-ECS container logs from the ECS EC2 instances (systemd unit logs etc) to Logit. We do not want to keep shipping things to Logit just for the auxiliary processes on the prometheus nodes. In the rare cases we need to investigate these other logs we can still use SSM to connect to the nodes and view the logs with `journalctl`

This change:

* removes the beat-exporter containers from the Prometheus cluster
* uninstalls the journal-beat processes from the nodes
* defaults the docker daemon to use the `awslogs` driver so that logs from anything running in Docker get shipped to the same log group as all other hub components.