### PR TITLE
egress-proxy: switch to using the fargate version

### DIFF
--- a/terraform/modules/hub/data.tf
+++ b/terraform/modules/hub/data.tf
@@ -25,8 +25,3 @@ data "aws_ami" "ubuntu_focal" {
 data "aws_caller_identity" "account" {}
 
 data "aws_region" "region" {}
-
-locals {
-  egress_proxy_url               = "egress-proxy.${local.root_domain}:8080"
-  egress_proxy_url_with_protocol = "http://${local.egress_proxy_url}"
-}

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -83,7 +83,7 @@
       },
       {
         "Name": "JAVA_OPTS",
-        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"egress-proxy.${domain}\" -Dhttp.proxyPort=\"8080\" -Dhttps.proxyHost=\"egress-proxy.${domain}\" -Dhttps.proxyPort=\"8080\" -Dhttp.nonProxyHosts=\"www.${domain}|config-v2-fargate.${domain}|policy-fargate.${domain}|saml-soap-proxy-fargate.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
+        "Value": "-Dservice.name=saml-engine ${jvm_options} -XX:+HeapDumpOnOutOfMemoryError -Dhttp.proxyHost=\"${egress_proxy_host}\" -Dhttp.proxyPort=\"${egress_proxy_port}\" -Dhttps.proxyHost=\"${egress_proxy_host}\" -Dhttps.proxyPort=\"${egress_proxy_port}\" -Dhttp.nonProxyHosts=\"www.${domain}|config-v2-fargate.${domain}|policy-fargate.${domain}|saml-soap-proxy-fargate.${domain}\" -Dnetworkaddress.cache.ttl=5 -Dnetworkaddress.cache.negative.ttl=5"
       },
       {
         "Name": "REDIS_HOST",

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -35,6 +35,8 @@ module "saml_engine_fargate" {
       memory_hard_limit                = var.saml_engine_memory_hard_limit
       jvm_options                      = var.jvm_options
       log_level                        = var.hub_saml_engine_log_level
+      egress_proxy_host                = "${aws_service_discovery_service.egress_proxy_fargate.name}.${aws_service_discovery_private_dns_namespace.hub_apps.name}"
+      egress_proxy_port                = "8080"
   })
   container_name    = "nginx"
   container_port    = "8443"

--- a/terraform/modules/hub/modules/ecs_asg/asg.tf
+++ b/terraform/modules/hub/modules/ecs_asg/asg.tf
@@ -1,30 +1,12 @@
-locals {
-  egress_proxy_url = "egress-proxy.${var.domain}:8080"
-
-  egress_proxy_url_with_protocol = "${
-    var.use_egress_proxy
-    ? "http://${local.egress_proxy_url}"
-    : ""
-  }"
-
-  journalbeat_egress_proxy_setting = "${
-    var.use_egress_proxy
-    ? "proxy_url: ${local.egress_proxy_url_with_protocol}"
-    : ""
-  }"
-}
-
 data "template_file" "cloud_init" {
   template = file("${path.module}/files/cloud-init.sh")
 
   vars = {
-    cluster                          = local.identifier
-    egress_proxy_url_with_protocol   = local.egress_proxy_url_with_protocol
-    journalbeat_egress_proxy_setting = local.journalbeat_egress_proxy_setting
-    logit_elasticsearch_url          = var.logit_elasticsearch_url
-    logit_api_key                    = var.logit_api_key
-    ecs_agent_image_identifier       = var.ecs_agent_image_identifier
-    tools_account_id                 = var.tools_account_id
+    cluster                    = local.identifier
+    logit_elasticsearch_url    = var.logit_elasticsearch_url
+    logit_api_key              = var.logit_api_key
+    ecs_agent_image_identifier = var.ecs_agent_image_identifier
+    tools_account_id           = var.tools_account_id
   }
 }
 

--- a/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
+++ b/terraform/modules/hub/modules/ecs_asg/files/cloud-init.sh
@@ -11,20 +11,8 @@ function run-until-success() {
   done
 }
 
-CURL="curl"
-if [ -n "${egress_proxy_url_with_protocol}" ]; then
-  CURL="curl --proxy ${egress_proxy_url_with_protocol}"
-fi
-
 # Apt
 echo 'Configuring apt'
-mkdir -p /etc/apt/apt.conf.d
-if [ -n "${egress_proxy_url_with_protocol}" ]; then
-  cat << EOF > /etc/apt/apt.conf.d/egress.conf
-Acquire::http::Proxy "${egress_proxy_url_with_protocol}/";
-Acquire::https::Proxy "${egress_proxy_url_with_protocol}/";
-EOF
-fi
 run-until-success "apt-get update --yes"
 run-until-success "apt-get dist-upgrade --yes"
 
@@ -100,7 +88,7 @@ cat <<EOF > journalbeat-oss-6.8.3-amd64.deb.sha512
 685e571638a3422e8b1c6f6aa7c15db8bf8fa9b91ecfedb4ce7c26dedc418e90b558a37711af2a547cb5025de17361d2fed1042be2d0871d22ec78037f7225a6  journalbeat-oss-6.8.3-amd64.deb
 EOF
 
-$CURL --silent --fail \
+curl --silent --fail \
       -L -O \
       "https://$elastic_beats/journalbeat/journalbeat-oss-6.8.3-amd64.deb"
 
@@ -131,7 +119,6 @@ processors:
     overwrite_keys: false
 
 output.elasticsearch:
-  ${journalbeat_egress_proxy_setting}
   hosts: ["https://${logit_elasticsearch_url}:443"]
   headers:
     Apikey: ${logit_api_key}

--- a/terraform/modules/hub/modules/ecs_asg/variables.tf
+++ b/terraform/modules/hub/modules/ecs_asg/variables.tf
@@ -26,10 +26,6 @@ variable "additional_instance_role_policy_arns" {
 
 variable "instance_type" {}
 
-variable "use_egress_proxy" {
-  default = false
-}
-
 variable "logit_api_key" {}
 variable "logit_elasticsearch_url" {}
 variable "ecs_agent_image_identifier" {}


### PR DESCRIPTION
We currently have two egress-proxy services deployed (one on ECS/EC2 and
one on ECS/Fargate).

The EC2 version uses a Classic ELB to forward traffic to tasks.

The fargate version has DNS service discovery enabled so that traffic can be
sent directly to the running tasks.

This changes the saml-engine tasks to use the addresses of the
discovered fargate tasks and removes the use of the egress proxy from
the remaining ec2 clusters (which both have open egress to 80/443 anyway).