### PR TITLE
prometheus: fix log group iam

### DIFF
--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -189,10 +189,7 @@ resource "aws_iam_policy" "prometheus" {
           "logs:PutLogEvents"
         ],
         "Resource": [
-          "arn:aws:logs::${data.aws_caller_identity.account.account_id}:${var.deployment}-hub",
-          "arn:aws:logs::${data.aws_caller_identity.account.account_id}:${var.deployment}-hub:*",
-          "arn:aws:logs::${data.aws_caller_identity.account.account_id}:${var.deployment}-prometheus",
-          "arn:aws:logs::${data.aws_caller_identity.account.account_id}:${var.deployment}-prometheus:*"
+          "*"
         ]
       },
       {


### PR DESCRIPTION
## What

Grant full cloudwatch logs access to the iam profile in the prometheus ec2 nodes