### PR TITLE
egress-proxy: remove old ec2-cluster and elb

### DIFF
--- a/dashboards/Hub-ECS.json
+++ b/dashboards/Hub-ECS.json
@@ -1224,7 +1224,7 @@
         {
           "alias": "Egress Proxy Task",
           "dimensions": {
-            "ClusterName": "prod-egress-proxy",
+            "ClusterName": "prod",
             "ServiceName": "prod-egress-proxy"
           },
           "expression": "",
@@ -1235,26 +1235,6 @@
           "namespace": "AWS/ECS",
           "period": "",
           "refId": "C",
-          "region": "eu-west-2",
-          "returnData": false,
-          "statistics": [
-            "Maximum"
-          ]
-        },
-        {
-          "alias": "Egress Proxy Beat Exporter Task",
-          "dimensions": {
-            "ClusterName": "prod-egress-proxy",
-            "ServiceName": "prod-beat-exporter"
-          },
-          "expression": "",
-          "highResolution": false,
-          "id": "",
-          "matchExact": true,
-          "metricName": "MemoryUtilization",
-          "namespace": "AWS/ECS",
-          "period": "",
-          "refId": "D",
           "region": "eu-west-2",
           "returnData": false,
           "statistics": [
@@ -1670,7 +1650,7 @@
         {
           "alias": "Egress Proxy Task",
           "dimensions": {
-            "ClusterName": "prod-egress-proxy",
+            "ClusterName": "prod",
             "ServiceName": "prod-egress-proxy"
           },
           "expression": "",
@@ -1681,26 +1661,6 @@
           "namespace": "AWS/ECS",
           "period": "",
           "refId": "C",
-          "region": "eu-west-2",
-          "returnData": false,
-          "statistics": [
-            "Maximum"
-          ]
-        },
-        {
-          "alias": "Egress Proxy Beat Exporter Task",
-          "dimensions": {
-            "ClusterName": "prod-egress-proxy",
-            "ServiceName": "prod-beat-exporter"
-          },
-          "expression": "",
-          "highResolution": false,
-          "id": "",
-          "matchExact": true,
-          "metricName": "CPUUtilization",
-          "namespace": "AWS/ECS",
-          "period": "",
-          "refId": "D",
           "region": "eu-west-2",
           "returnData": false,
           "statistics": [

--- a/terraform/modules/hub/beat_exporter.tf
+++ b/terraform/modules/hub/beat_exporter.tf
@@ -25,7 +25,6 @@ resource "aws_ecs_task_definition" "beat_exporter" {
 locals {
   # FIXME is there a better way of doing this?
   clusters = [
-    "egress-proxy",
     "static-ingress",
   ]
 }

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -1,26 +1,3 @@
-module "egress_proxy_ecs_asg" {
-  source = "./modules/ecs_asg"
-
-  ami_id              = data.aws_ami.ubuntu_bionic.id
-  deployment          = var.deployment
-  cluster             = "egress-proxy"
-  vpc_id              = aws_vpc.hub.id
-  instance_subnets    = aws_subnet.internal.*.id
-  number_of_instances = var.number_of_apps
-  domain              = local.root_domain
-  instance_type       = var.instance_type
-
-  ecs_agent_image_identifier = local.ecs_agent_image_identifier
-  tools_account_id           = var.tools_account_id
-
-  logit_api_key           = var.logit_api_key
-  logit_elasticsearch_url = var.logit_elasticsearch_url
-
-  additional_instance_security_group_ids = [
-    aws_security_group.can_connect_to_container_vpc_endpoint.id,
-  ]
-}
-
 resource "aws_security_group" "egress_via_proxy" {
   name        = "${var.deployment}-egress-via-proxy"
   description = "${var.deployment}-egress-via-proxy"
@@ -38,28 +15,6 @@ resource "aws_security_group_rule" "egress_to_proxy_task" {
   # source is destination for egress rules
   source_security_group_id = aws_security_group.egress_proxy_task.id
   security_group_id        = aws_security_group.egress_via_proxy.id
-}
-
-# Egress proxy instance has to be able to access the internet directly (HTTP)
-resource "aws_security_group_rule" "egress_proxy_instance_egress_to_internet_over_http" {
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 80
-  to_port   = 80
-
-  security_group_id = module.egress_proxy_ecs_asg.instance_sg_id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
-# Egress proxy instance has to be able to access the internet directly (HTTPS)
-resource "aws_security_group_rule" "egress_proxy_instance_egress_to_internet_over_https" {
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 443
-  to_port   = 443
-
-  security_group_id = module.egress_proxy_ecs_asg.instance_sg_id
-  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 # Egress proxy task has to be able to access the internet directly (HTTP)
@@ -82,6 +37,17 @@ resource "aws_security_group_rule" "egress_proxy_task_egress_to_internet_over_ht
 
   security_group_id = aws_security_group.egress_proxy_task.id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "egress_proxy_ingress_from_tasks" {
+  type     = "ingress"
+  protocol = "tcp"
+
+  from_port = 8080
+  to_port   = 8080
+
+  security_group_id        = aws_security_group.egress_proxy_task.id
+  source_security_group_id = aws_security_group.egress_via_proxy.id
 }
 
 locals {
@@ -109,88 +75,6 @@ data "template_file" "egress_proxy_task_def" {
   }
 }
 
-resource "aws_elb" "egress_proxy" {
-  name            = "${var.deployment}-egress-proxy"
-  internal        = true
-  subnets         = aws_subnet.internal.*.id
-  security_groups = [aws_security_group.egress_proxy_lb.id]
-
-  listener {
-    instance_port     = 8080
-    instance_protocol = "tcp"
-    lb_port           = 8080
-    lb_protocol       = "tcp"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "TCP:8080"
-    interval            = 10
-  }
-
-  tags = {
-    Deployment = var.deployment
-  }
-}
-
-resource "aws_security_group" "egress_proxy_lb" {
-  name        = "${var.deployment}-egress-proxy-lb"
-  description = "${var.deployment}-egress-proxy-lb"
-
-  vpc_id = aws_vpc.hub.id
-}
-
-resource "aws_security_group_rule" "egress_proxy_instance_ingress_from_egress_proxy_lb_over_nonpriv_http" {
-  type     = "ingress"
-  protocol = "tcp"
-
-  from_port = 8080
-  to_port   = 8080
-
-  security_group_id        = module.egress_proxy_ecs_asg.instance_sg_id
-  source_security_group_id = aws_security_group.egress_proxy_lb.id
-}
-
-resource "aws_security_group_rule" "egress_proxy_lb_egress_to_egress_proxy_instance_over_nonpriv_http" {
-  type     = "egress"
-  protocol = "tcp"
-
-  from_port = 8080
-  to_port   = 8080
-
-  # source is destination for egress rules
-  source_security_group_id = module.egress_proxy_ecs_asg.instance_sg_id
-  security_group_id        = aws_security_group.egress_proxy_lb.id
-}
-
-resource "aws_security_group_rule" "egress_proxy_ingress_from_tasks" {
-  type     = "ingress"
-  protocol = "tcp"
-
-  from_port = 8080
-  to_port   = 8080
-
-  security_group_id        = aws_security_group.egress_proxy_task.id
-  source_security_group_id = aws_security_group.egress_via_proxy.id
-}
-
-resource "aws_security_group_rule" "egress_proxy_lb_ingress_from_egress_via_proxy_over_nonpriv_http" {
-  type     = "ingress"
-  protocol = "tcp"
-
-  from_port = 8080
-  to_port   = 8080
-
-  security_group_id        = aws_security_group.egress_proxy_lb.id
-  source_security_group_id = aws_security_group.egress_via_proxy.id
-}
-
-resource "aws_ecs_cluster" "egress_proxy" {
-  name = "${var.deployment}-egress-proxy"
-}
-
 module "egress_proxy_ecs_roles" {
   source = "./modules/ecs_iam_role_pair"
 
@@ -198,12 +82,6 @@ module "egress_proxy_ecs_roles" {
   service_name     = "egress-proxy"
   tools_account_id = var.tools_account_id
   image_name       = "verify-squid"
-}
-
-resource "aws_ecs_task_definition" "egress_proxy" {
-  family                = "${var.deployment}-egress-proxy"
-  container_definitions = data.template_file.egress_proxy_task_def.rendered
-  execution_role_arn    = module.egress_proxy_ecs_roles.execution_role_arn
 }
 
 resource "aws_ecs_task_definition" "egress_proxy_fargate" {
@@ -217,22 +95,6 @@ resource "aws_ecs_task_definition" "egress_proxy_fargate" {
 
   cpu    = 1024
   memory = 3072
-}
-
-resource "aws_ecs_service" "egress_proxy" {
-  name            = "${var.deployment}-egress-proxy"
-  cluster         = aws_ecs_cluster.egress_proxy.id
-  task_definition = aws_ecs_task_definition.egress_proxy.arn
-
-  desired_count                      = var.number_of_apps
-  deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
-
-  load_balancer {
-    elb_name       = aws_elb.egress_proxy.name
-    container_name = "squid"
-    container_port = "8080"
-  }
 }
 
 resource "aws_security_group" "egress_proxy_task" {
@@ -287,37 +149,3 @@ resource "aws_service_discovery_service" "egress_proxy_fargate" {
   }
 }
 
-resource "aws_route53_zone" "egress_proxy" {
-  name = "egress-proxy.${local.root_domain}."
-
-  vpc {
-    vpc_id = aws_vpc.hub.id
-  }
-
-  tags = {
-    Deployment = var.deployment
-  }
-}
-
-resource "aws_route53_record" "egress_proxy_lb" {
-  zone_id = aws_route53_zone.egress_proxy.zone_id
-  name    = "egress-proxy.${local.root_domain}."
-  type    = "A"
-
-  alias {
-    name                   = aws_elb.egress_proxy.dns_name
-    zone_id                = aws_elb.egress_proxy.zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_security_group_rule" "egress_via_proxy_egress_to_egress_proxy_lb_over_nonpriv_http" {
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 8080
-  to_port   = 8080
-
-  # source is destination for egress rules
-  source_security_group_id = aws_security_group.egress_proxy_lb.id
-  security_group_id        = aws_security_group.egress_via_proxy.id
-}

--- a/terraform/modules/hub/prometheus.tf
+++ b/terraform/modules/hub/prometheus.tf
@@ -48,29 +48,11 @@ module "prometheus_can_talk_to_prometheus_node_exporter" {
   port = 9100
 }
 
-module "prometheus_can_talk_to_egress_proxy_node_exporter" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.egress_proxy_ecs_asg.instance_sg_id
-
-  port = 9100
-}
-
 module "prometheus_can_talk_to_prometheus_beat_exporter" {
   source = "./modules/microservice_connection"
 
   source_sg_id      = aws_security_group.prometheus.id
   destination_sg_id = aws_security_group.prometheus.id
-
-  port = 9479
-}
-
-module "prometheus_can_talk_to_egress_proxy_beat_exporter" {
-  source = "./modules/microservice_connection"
-
-  source_sg_id      = aws_security_group.prometheus.id
-  destination_sg_id = module.egress_proxy_ecs_asg.instance_sg_id
 
   port = 9479
 }


### PR DESCRIPTION
egress-proxy is now running in fargate and uses dns service discovery
rather than an ELB for direct TCP connections.

this removes the redundent ec2-based ECS cluster, load balancer, tasks
and associated gubbins