### PR TITLE
Swap the IP mappings to the new fargate service for static ingress

### DIFF
--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -199,17 +199,17 @@ resource "aws_lb" "static_ingress" {
 
   subnet_mapping {
     subnet_id     = element(aws_subnet.ingress.*.id, 0)
-    allocation_id = element(aws_eip.ingress.*.id, 0)
+    allocation_id = ""
   }
 
   subnet_mapping {
     subnet_id     = element(aws_subnet.ingress.*.id, 1)
-    allocation_id = element(aws_eip.ingress.*.id, 1)
+    allocation_id = ""
   }
 
   subnet_mapping {
     subnet_id     = element(aws_subnet.ingress.*.id, 2)
-    allocation_id = element(aws_eip.ingress.*.id, 2)
+    allocation_id = ""
   }
 }
 
@@ -257,7 +257,21 @@ resource "aws_lb" "static_ingress_fargate" {
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true
-  subnets                          = aws_subnet.ingress.*.id
+
+  subnet_mapping {
+    subnet_id     = element(aws_subnet.ingress.*.id, 0)
+    allocation_id = element(aws_eip.ingress.*.id, 0)
+  }
+
+  subnet_mapping {
+    subnet_id     = element(aws_subnet.ingress.*.id, 1)
+    allocation_id = element(aws_eip.ingress.*.id, 1)
+  }
+
+  subnet_mapping {
+    subnet_id     = element(aws_subnet.ingress.*.id, 2)
+    allocation_id = element(aws_eip.ingress.*.id, 2)
+  }
 }
 
 resource "aws_lb_target_group" "static_ingress_http_fargate" {


### PR DESCRIPTION
Based on the output from `terraform plan` this is going to replace both NLBs and associated listeners (a destroy followed by a create operation). There will definitely be downtime.