### PR TITLE
Stop haproxy from trying to bind to 0.0.0.0

### DIFF
--- a/dockerfiles/haproxy-static-ingress-fargate/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-fargate/haproxy.cfg.tpl
@@ -26,7 +26,7 @@ resolvers vpcdns
 
 frontend nlb
     mode tcp
-    bind *:$BIND_PORT accept-proxy
+    bind :$BIND_PORT accept-proxy
     default_backend alb
 
 backend alb

--- a/dockerfiles/haproxy-static-ingress-tls-fargate/haproxy.cfg.tpl
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/haproxy.cfg.tpl
@@ -28,7 +28,7 @@ resolvers vpcdns
 
 frontend nlb
     mode http
-    bind *:$BIND_PORT accept-proxy ssl crt /tmp/tls/chain.pem
+    bind :$BIND_PORT accept-proxy ssl crt /tmp/tls/chain.pem
     default_backend alb
 
 backend alb


### PR DESCRIPTION
In a fargate world binding to 0.0.0.0 is not allowed. Hopefully this is
the fix.