### PR TITLE
Shorten the length of the static ingress load balancer name

### DIFF
--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -253,7 +253,7 @@ resource "aws_lb_listener" "static_ingress_https" {
 }
 
 resource "aws_lb" "static_ingress_fargate" {
-  name                             = "${var.deployment}-static-ingress-fargate"
+  name                             = "static-ingress-fargate"
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true


### PR DESCRIPTION
AWS limits the length of the name to 32 characters, and "integration" is
making it too long.