### PR TITLE
scaling: scale-in and scale-down prod apps

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_service" "analytics_fargate" {
   cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
   task_definition = aws_ecs_task_definition.analytics_fargate.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_analytics_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -108,7 +108,7 @@ resource "aws_ecs_service" "egress_proxy_fargate" {
   cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
   task_definition = aws_ecs_task_definition.egress_proxy_fargate.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_egress_proxy_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/files/tasks/analytics.json
+++ b/terraform/modules/hub/files/tasks/analytics.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 256,
-    "memory": 512,
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "config",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "policy",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "saml-engine",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "saml-proxy",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -2,8 +2,6 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
-    "cpu": 896,
-    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -36,8 +34,6 @@
   {
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": ${memory_hard_limit},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/squid.json
+++ b/terraform/modules/hub/files/tasks/squid.json
@@ -2,8 +2,6 @@
   {
     "name": "squid",
     "image": "${image_identifier}",
-    "cpu": 1024,
-    "memory": 3072,
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -75,7 +75,7 @@ module "config_fargate_v2" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.config_memory_hard_limit + 250, 4096) / 1024) * 1024
+  memory  = 4096
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -67,7 +67,7 @@ module "config_fargate_v2" {
   })
   container_name    = "nginx"
   container_port    = "8443"
-  number_of_tasks   = var.number_of_apps
+  number_of_tasks   = var.number_of_config_apps
   health_check_path = "/service-status"
   tools_account_id  = var.tools_account_id
   image_name        = "verify-config"

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -62,7 +62,6 @@ module "config_fargate_v2" {
       self_service_enabled     = var.self_service_enabled
       services_metadata_bucket = local.services_metadata_bucket
       metadata_object_key      = local.metadata_object_key
-      memory_hard_limit        = var.config_memory_hard_limit
       jvm_options              = var.jvm_options
       log_level                = var.hub_config_log_level
   })

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_service" "metadata_fargate" {
   cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
   task_definition = aws_ecs_task_definition.metadata_fargate.arn
 
-  desired_count                      = var.number_of_apps
+  desired_count                      = var.number_of_metadata_apps
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -48,7 +48,6 @@ module "policy_fargate" {
     region                        = data.aws_region.region.id
     account_id                    = data.aws_caller_identity.account.account_id
     event_emitter_api_gateway_url = var.event_emitter_api_gateway_url
-    memory_hard_limit             = var.policy_memory_hard_limit
     jvm_options                   = var.jvm_options
 
     redis_host = "rediss://${

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -65,7 +65,7 @@ module "policy_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.policy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  memory  = 4096
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -57,7 +57,7 @@ module "policy_fargate" {
   })
   container_name    = "nginx"
   container_port    = "8443"
-  number_of_tasks   = var.number_of_apps
+  number_of_tasks   = var.number_of_policy_apps
   health_check_path = "/service-status"
   tools_account_id  = var.tools_account_id
   image_name        = "verify-policy"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -32,7 +32,6 @@ module "saml_engine_fargate" {
       splunk_url                       = var.splunk_url
       rp_truststore_enabled            = var.rp_truststore_enabled
       certificates_config_cache_expiry = var.certificates_config_cache_expiry
-      memory_hard_limit                = var.saml_engine_memory_hard_limit
       jvm_options                      = var.jvm_options
       log_level                        = var.hub_saml_engine_log_level
       egress_proxy_host                = "${aws_service_discovery_service.egress_proxy_fargate.name}.${aws_service_discovery_private_dns_namespace.hub_apps.name}"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -39,7 +39,7 @@ module "saml_engine_fargate" {
   })
   container_name    = "nginx"
   container_port    = "8443"
-  number_of_tasks   = var.number_of_apps
+  number_of_tasks   = var.number_of_saml_engine_apps
   health_check_path = "/service-status"
   tools_account_id  = var.tools_account_id
   image_name        = "verify-saml-engine"

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -47,7 +47,7 @@ module "saml_engine_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.saml_engine_memory_hard_limit + 250, 4096) / 1024) * 1024
+  memory  = 4096
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -51,7 +51,6 @@ module "saml_proxy_fargate" {
       event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
       rp_truststore_enabled            = var.rp_truststore_enabled
       certificates_config_cache_expiry = var.certificates_config_cache_expiry
-      memory_hard_limit                = var.saml_proxy_memory_hard_limit
       jvm_options                      = var.jvm_options
       log_level                        = var.hub_saml_proxy_log_level
   })

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -56,7 +56,7 @@ module "saml_proxy_fargate" {
   })
   container_name    = "nginx"
   container_port    = "8443"
-  number_of_tasks   = var.number_of_apps
+  number_of_tasks   = var.number_of_saml_proxy_apps
   health_check_path = "/service-status"
   tools_account_id  = var.tools_account_id
   image_name        = "verify-saml-proxy"

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -64,7 +64,7 @@ module "saml_proxy_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.saml_proxy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  memory  = 4096
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -51,7 +51,6 @@ module "saml_soap_proxy_fargate" {
       event_emitter_api_gateway_url    = var.event_emitter_api_gateway_url
       rp_truststore_enabled            = var.rp_truststore_enabled
       certificates_config_cache_expiry = var.certificates_config_cache_expiry
-      memory_hard_limit                = var.saml_soap_proxy_memory_hard_limit
       jvm_options                      = var.jvm_options
       log_level                        = var.hub_saml_soap_proxy_log_level
   })

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -64,7 +64,7 @@ module "saml_soap_proxy_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = ceil(max(var.saml_proxy_memory_hard_limit + 250, 4096) / 1024) * 1024
+  memory  = 4096
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -56,7 +56,7 @@ module "saml_soap_proxy_fargate" {
   })
   container_name    = "nginx"
   container_port    = "8443"
-  number_of_tasks   = var.number_of_apps
+  number_of_tasks   = var.number_of_saml_soap_proxy_apps
   health_check_path = "/service-status"
   tools_account_id  = var.tools_account_id
   image_name        = "verify-saml-soap-proxy"

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -73,11 +73,11 @@ variable "prometheus_volume_size" {
 }
 
 variable "publically_accessible_from_cidrs" {
-  type = "list"
+  type = list
 }
 
 variable "mgmt_accessible_from_cidrs" {
-  type = "list"
+  type = list
 }
 
 variable "redis_cache_size" {

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -160,26 +160,6 @@ variable "jvm_options" {
   default = "-XX:InitialRAMPercentage=50 -XX:MaxRAMPercentage=80"
 }
 
-variable "config_memory_hard_limit" {
-  default = 3500
-}
-
-variable "saml_proxy_memory_hard_limit" {
-  default = 3500
-}
-
-variable "policy_memory_hard_limit" {
-  default = 3500
-}
-
-variable "saml_engine_memory_hard_limit" {
-  default = 3500
-}
-
-variable "saml_soap_proxy_memory_hard_limit" {
-  default = 3500
-}
-
 variable "instance_type" {
   default = "t3.medium"
 }

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -19,6 +19,51 @@ variable "number_of_frontend_apps" {
   default = 2
 }
 
+variable "number_of_config_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_analytics_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_saml_soap_proxy_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_metadata_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_saml_proxy_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_saml_engine_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_policy_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_egress_proxy_apps" {
+  type    = number
+  default = 2
+}
+
+variable "number_of_static_ingress_apps" {
+  type    = number
+  default = 2
+}
+
 variable "number_of_prometheus_apps" {
   default = 3
 }


### PR DESCRIPTION
## What

* Make vertical scale of applications consistent accross environments. 
* Simplify configuration by removing unnecessary resource limits
* Allow scaling-out each micro-service independently 

## Why

Currently the "vertical" size of containers in prod differs from the size in staging/integration, for example the "frontend" tasks run in 2vcpu 8GB container in production, and run in 2vcpu 4GB containers in staging. This complicates the deployment configuration with conditional statements, and means that the applications may behave significantly differently between environments, which can lead to problems being missed in staging.

This disparity came about because there was a need to scale verify, but due to the way ECS-on-EC2 was setup, it was easier to scale-up (bigger instances) than it was to scale-out (more instances). However now we have moved the micro-services to ECS-on-Fargate, no such complication exists and we can now scale-out (more instances) each application individually as desired.

## :warning: Merge in sync with...

* https://github.com/alphagov/verify-infrastructure-config/pull/363