### PR TITLE
Make the memory limits of policy and saml proxy configurable

### DIFF
--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -65,7 +65,7 @@ module "policy_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = 8 * 1024
+  memory  = var.policy_memory_limit_mb
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -64,7 +64,7 @@ module "saml_proxy_fargate" {
   ecs_cluster_id    = aws_ecs_cluster.fargate-ecs-cluster.id
   cpu               = 2048
   # for a CPU of 2048 we need to set a RAM value between 4096 and 16384 (inclusive) that is a multiple of 1024.
-  memory  = 8 * 1024
+  memory  = var.saml_proxy_memory_limit_mb
   subnets = aws_subnet.internal.*.id
   additional_task_security_group_ids = [
     aws_security_group.can_connect_to_container_vpc_endpoint.id,

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -68,6 +68,16 @@ variable "number_of_prometheus_apps" {
   default = 3
 }
 
+variable "policy_memory_limit_mb" {
+  type    = number
+  default = 4 * 1024
+}
+
+variable "saml_proxy_memory_limit_mb" {
+  type    = number
+  default = 4 * 1024
+}
+
 variable "prometheus_volume_size" {
   default = 100
 }


### PR DESCRIPTION
Needs to be released with https://github.com/alphagov/verify-infrastructure-config/pull/367 to maintain status quo in production.