### PR TITLE
[hub] restore container-level memory limits

### DIFF
--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -2,6 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -34,6 +35,7 @@
   {
     "name": "config",
     "image": "${image_identifier}",
+    "memory": ${memory_limit_mb - 250},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -2,6 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -34,6 +35,7 @@
   {
     "name": "policy",
     "image": "${image_identifier}",
+    "memory": ${memory_limit_mb - 250},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -2,6 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -34,6 +35,7 @@
   {
     "name": "saml-engine",
     "image": "${image_identifier}",
+    "memory": ${memory_limit_mb - 250},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -2,6 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -34,6 +35,7 @@
   {
     "name": "saml-proxy",
     "image": "${image_identifier}",
+    "memory": ${memory_limit_mb - 250},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -2,6 +2,7 @@
   {
     "name": "nginx",
     "image": "${nginx_image_identifier}",
+    "memory": 250,
     "essential": true,
     "portMappings": [
       {
@@ -34,6 +35,7 @@
   {
     "name": "saml-soap-proxy",
     "image": "${image_identifier}",
+    "memory": ${memory_limit_mb - 250},
     "essential": true,
     "portMappings": [
       {

--- a/terraform/modules/hub/hub_config.tf
+++ b/terraform/modules/hub/hub_config.tf
@@ -54,6 +54,7 @@ module "config_fargate_v2" {
       image_identifier         = "${local.tools_account_ecr_url_prefix}-verify-config@${var.hub_config_image_digest}"
       nginx_image_identifier   = local.nginx_image_identifier
       domain                   = local.root_domain
+      memory_limit_mb          = 4096
       deployment               = var.deployment
       truststore_password      = var.truststore_password
       location_blocks_base64   = local.nginx_config_location_blocks_fargate_base64

--- a/terraform/modules/hub/hub_policy.tf
+++ b/terraform/modules/hub/hub_policy.tf
@@ -43,6 +43,7 @@ module "policy_fargate" {
     image_identifier              = "${local.tools_account_ecr_url_prefix}-verify-policy@${var.hub_policy_image_digest}"
     nginx_image_identifier        = local.nginx_image_identifier
     domain                        = local.root_domain
+    memory_limit_mb               = var.policy_memory_limit_mb
     deployment                    = var.deployment
     location_blocks_base64        = base64encode(local.policy_fargate_location_blocks)
     region                        = data.aws_region.region.id

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -24,6 +24,7 @@ module "saml_engine_fargate" {
       account_id                       = data.aws_caller_identity.account.account_id
       deployment                       = var.deployment
       domain                           = local.root_domain
+      memory_limit_mb                  = 4096
       image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-engine@${var.hub_saml_engine_image_digest}"
       nginx_image_identifier           = local.nginx_image_identifier
       region                           = data.aws_region.region.id

--- a/terraform/modules/hub/hub_saml_proxy.tf
+++ b/terraform/modules/hub/hub_saml_proxy.tf
@@ -44,6 +44,7 @@ module "saml_proxy_fargate" {
       image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-proxy@${var.hub_saml_proxy_image_digest}"
       nginx_image_identifier           = local.nginx_image_identifier
       domain                           = local.root_domain
+      memory_limit_mb                  = var.saml_proxy_memory_limit_mb
       deployment                       = var.deployment
       location_blocks_base64           = base64encode(local.saml_proxy_fargate_location_blocks)
       region                           = data.aws_region.region.id

--- a/terraform/modules/hub/hub_saml_soap_proxy.tf
+++ b/terraform/modules/hub/hub_saml_soap_proxy.tf
@@ -44,6 +44,7 @@ module "saml_soap_proxy_fargate" {
       image_identifier                 = "${local.tools_account_ecr_url_prefix}-verify-saml-soap-proxy@${var.hub_saml_soap_proxy_image_digest}"
       nginx_image_identifier           = local.nginx_image_identifier
       domain                           = local.root_domain
+      memory_limit_mb                  = 4096
       deployment                       = var.deployment
       location_blocks_base64           = base64encode(local.saml_soap_proxy_fargate_location_blocks)
       region                           = data.aws_region.region.id


### PR DESCRIPTION
These were removed in ad2410f.  However we have a theory that this
removal is causing the JVM to be unable to regulate its memory usage.
We use the options `-XX:InitialRAMPercentage=50
-XX:MaxRAMPercentage=80` to specify JVM RAM usage as a percentage of
available RAM, but the removal of these limits seems to have confused
the JVM about how much RAM is really available.

There are also similar reports on the AWS forums:
https://forums.aws.amazon.com/thread.jspa?threadID=297114

This sets each of the app nginxes to have 250 MiB of memory, and each
of the apps to have the rest of the task memory.  Happily, the new
`templatefile` function lets us do maths in the template to make this
easier to understand.

