### PR TITLE
AUT-923: Keep dashboards module up-to-date

### DIFF
--- a/terraform/modules/dashboards/main.tf
+++ b/terraform/modules/dashboards/main.tf
@@ -2,7 +2,7 @@ data "template_file" "service_tickets_dashboard" {
   template = file("${path.module}/service_tickets_dashboard.json.tpl")
 
   vars = {
-    deployment = "${var.deployment}"
-    source     = "${var.data_source}"
+    deployment = var.deployment
+    source     = var.data_source
   }
 }

--- a/terraform/modules/dashboards/outputs.tf
+++ b/terraform/modules/dashboards/outputs.tf
@@ -1,3 +1,3 @@
 output "service_tickets_dashboard_rendered" {
-  value = "${data.template_file.service_tickets_dashboard.rendered}"
+  value = data.template_file.service_tickets_dashboard.rendered
 }

--- a/terraform/modules/dashboards/service_tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/service_tickets_dashboard.json.tpl
@@ -59,13 +59,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${source}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 4,
         "w": 12,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -80,6 +88,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -187,13 +198,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${source}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 4,
         "w": 12,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -208,6 +227,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -313,13 +335,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${source}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 4,
         "w": 12,
         "x": 0,
         "y": 4
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -334,6 +364,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -401,7 +434,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "verify",


### PR DESCRIPTION
deploy-grafana job failed because the commit (https://github.com/alphagov/verify-infrastructure/commit/516b3d7bfcd349e9886623defade6138430b0d10) was not signed. This change removes interpolation-only expressions from dashboards module and keeps service_tickets_dashboard.json.tpl up-to-date.

Author: @adityapahuja