### PR TITLE
hub deployer role: deny ability to release elastic IPs

### DIFF
--- a/terraform/modules/hub/deployer.tf
+++ b/terraform/modules/hub/deployer.tf
@@ -24,3 +24,19 @@ resource "aws_iam_role_policy_attachment" "deployer_administrator_access" {
   role       = aws_iam_role.deployer.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+
+resource "aws_iam_role_policy" "deployer_deny_release_address" {
+  role       = aws_iam_role.deployer.name
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "ec2:ReleaseAddress",
+        "Resource": "*",
+        "Effect": "Deny"
+      }
+    ]
+  }
+  EOF
+}


### PR DESCRIPTION
https://trello.com/c/lQs5jsln

We don't want this happening accidentally as our IPs tend to be specially
blessed elsewhere.