### PR TITLE
A no-op formatting change to make the build go green

### DIFF
--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -76,5 +76,4 @@ openssl req -x509 \
 
 envsubst > /tmp/nginx.conf < /tmp/nginx.conf.tpl
 
-
 exec nginx -g 'daemon off;' -c /tmp/nginx.conf

--- a/dockerfiles/squid/docker-entrypoint.sh
+++ b/dockerfiles/squid/docker-entrypoint.sh
@@ -3,7 +3,6 @@ set -ueo pipefail
 
 allowlist="${ALLOWLIST:-${WHITELIST:?ALLOWLIST not set}}"
 allowlist="$(echo "$allowlist" | base64 -d)"
-
 all_acls=""
 
 for regex in $allowlist; do


### PR DESCRIPTION
Recent changes to pipeline resources require signed commits and some old
commits that still linger as the most recent in the concourse resources
weren't signed. This should cover some of the ensuing errors.