### PR TITLE
Revert "A no-op formatting change to make the build go green"

### DIFF
--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -76,4 +76,5 @@ openssl req -x509 \
 
 envsubst > /tmp/nginx.conf < /tmp/nginx.conf.tpl
 
+
 exec nginx -g 'daemon off;' -c /tmp/nginx.conf

--- a/dockerfiles/squid/docker-entrypoint.sh
+++ b/dockerfiles/squid/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -ueo pipefail
 
 allowlist="${ALLOWLIST:-${WHITELIST:?ALLOWLIST not set}}"
 allowlist="$(echo "$allowlist" | base64 -d)"
+
 all_acls=""
 
 for regex in $allowlist; do


### PR DESCRIPTION
Fix the broken Hub build at https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub/jobs/build-verify-metadata/builds/113.

How:
Sign a commit that triggers job `build-nginx-tls` with a trusted signature.
This is another no-op that reverts commit [03a9e185](https://github.com/alphagov/verify-infrastructure/pull/549).

