### PR TITLE
BAU: Remove Splunk vars from saml-engine

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -58,7 +58,6 @@ locals {
   egress_proxy_allowlist_list = [
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
-    var.splunk_hostname,                                     # Splunk
   ]
 
   egress_proxy_allowlist = join(" ", local.egress_proxy_allowlist_list)

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -59,10 +59,6 @@
       {
         "name": "SECONDARY_HUB_ENCRYPTION_PRIVATE_KEY",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}-secondary-hub-encryption-private-key"
-      },
-      {
-        "name": "SPLUNK_TOKEN",
-        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-engine/splunk-token"
       }
     ],
     "entryPoint": [
@@ -86,14 +82,6 @@
       {
         "Name": "REDIS_HOST",
         "Value": "${redis_host}"
-      },
-      {
-        "Name": "SPLUNK_URL",
-        "Value": "${splunk_url}"
-      },
-      {
-        "Name": "SPLUNK_SOURCE",
-        "Value": "verify-hub_saml-engine_${deployment}"
       },
       {
         "Name": "RP_TRUSTSTORE_ENABLED",

--- a/terraform/modules/hub/hub_saml_engine.tf
+++ b/terraform/modules/hub/hub_saml_engine.tf
@@ -30,7 +30,6 @@ module "saml_engine_fargate" {
       region                           = data.aws_region.region.id
       location_blocks_base64           = base64encode(local.saml_engine_fargate_location_blocks)
       redis_host                       = "rediss://${aws_elasticache_replication_group.saml_engine_replay_cache.primary_endpoint_address}:6379"
-      splunk_url                       = var.splunk_url
       rp_truststore_enabled            = var.rp_truststore_enabled
       certificates_config_cache_expiry = var.certificates_config_cache_expiry
       jvm_options                      = var.jvm_options

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -131,14 +131,6 @@ variable "analytics_endpoint" {
   description = "Analytics endpoint"
 }
 
-variable "splunk_url" {
-  description = "Splunk http event collector endpoint, used by saml-engine"
-}
-
-variable "splunk_hostname" {
-  description = "Splunk hostname, used by saml-engine's egress proxy"
-}
-
 variable "ab_test_file" {
   description = "File containing percentage values for variant and control"
   default     = "deactivated_ab_test.yml"


### PR DESCRIPTION
**Not to be merged before this hub PR: https://github.com/alphagov/verify-hub/pull/477**

These vars were being provided to saml-engine so that our fork of the
splunk java-logging library could consume them and ship logs to Splunk.
We were using the appender on one particular class. This was set up when
all the application logs went to Kibana.

As all the app logs now go to Splunk anyway, we no longer need the
special use case with the library and can drop it from the hub.