### PR TITLE
BAU: Change engine version to use major version

### DIFF
--- a/terraform/modules/self-service/db.tf
+++ b/terraform/modules/self-service/db.tf
@@ -1,7 +1,7 @@
 resource "aws_db_instance" "self_service" {
   name           = "selfservice"
   engine         = "postgres"
-  engine_version = "11.5"
+  engine_version = "11"
   storage_type   = "gp2"
 
   instance_class    = var.db_instance_class


### PR DESCRIPTION
This change is to [allow minor database engine version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html#USER_UpgradeDBInstance.Upgrading.AutoMinorVersionUpgrades) to happen automatically in Self service 

see https://github.com/alphagov/tech-ops/pull/177