### PR TITLE
HUB-733 Terraform updates to specify SENTRY_ENV

### DIFF
--- a/terraform/modules/hub/files/tasks/frontend.json
+++ b/terraform/modules/hub/files/tasks/frontend.json
@@ -58,6 +58,9 @@
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/sentry-dsn"
       }, {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      }, {
         "name": "ZENDESK_TOKEN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/frontend/zendesk-token"
       }, {

--- a/terraform/modules/hub/files/tasks/hub-config.json
+++ b/terraform/modules/hub/files/tasks/hub-config.json
@@ -50,6 +50,10 @@
     ],
     "secrets": [
       {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      },
+      {
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
       }

--- a/terraform/modules/hub/files/tasks/hub-policy.json
+++ b/terraform/modules/hub/files/tasks/hub-policy.json
@@ -54,6 +54,10 @@
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
       },
       {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      },
+      {
         "name": "EVENT_EMITTER_ACCESS_KEY_ID",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/policy/event-emitter-access-key-id"
       },

--- a/terraform/modules/hub/files/tasks/hub-saml-engine.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-engine.json
@@ -49,6 +49,10 @@
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
       },
       {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      },
+      {
         "name": "HUB_SIGNING_PRIVATE_KEY",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}-hub-signing-private-key"
       },

--- a/terraform/modules/hub/files/tasks/hub-saml-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-proxy.json
@@ -54,6 +54,10 @@
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
       },
       {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      },
+      {
         "name": "EVENT_EMITTER_ACCESS_KEY_ID",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-proxy/event-emitter-access-key-id"
       },

--- a/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
+++ b/terraform/modules/hub/files/tasks/hub-saml-soap-proxy.json
@@ -54,6 +54,10 @@
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/ecs-app-shared/sentry-dsn"
       },
       {
+        "name": "SENTRY_ENV",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/sentry-env"
+      },
+      {
         "name": "EVENT_EMITTER_ACCESS_KEY_ID",
         "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/saml-soap-proxy/event-emitter-access-key-id"
       },

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -16,6 +16,7 @@ locals  {
     asset_host                         = var.asset_host
     asset_prefix                       = "${element(split(":", var.image_digest),1)}/assets/"
     sentry_dsn                         = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/${local.service}/sentry-dsn"
+    sentry_env                         = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/sentry-env"
     hub_environments                   = var.hub_environments
     hub_environments_legacy            = var.hub_environments_legacy
     hub_config_host                    = "https://config-v2-fargate.${local.hub_deployment}${var.hub_host}:443"


### PR DESCRIPTION
Sentry now provides a mechnism for reporting environments.  But
environments to sentry are different to the way some of our apps run.
e.g. Rails apps always run in a production environment which is reported
to sentry.  Sentry then sets the environment to production even if the
app in question is running in our staging or integration environments.