### PR TITLE
HUB-738: Create new `metadata` module that deploys a new metadata service

### DIFF
--- a/terraform/modules/hub/gateways.tf
+++ b/terraform/modules/hub/gateways.tf
@@ -12,7 +12,7 @@ resource "aws_nat_gateway" "static_egress" {
   allocation_id = element(aws_eip.egress.*.id, count.index)
   subnet_id     = element(aws_subnet.egress.*.id, count.index)
 
-  depends_on = ["aws_internet_gateway.hub"]
+  depends_on = [aws_internet_gateway.hub]
 
   tags = {
     Deployment = var.deployment

--- a/terraform/modules/hub/hub_metadata.tf
+++ b/terraform/modules/hub/hub_metadata.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_task_definition" "metadata_fargate" {
 resource "aws_ecs_service" "metadata_fargate" {
   name            = "${var.deployment}-metadata"
   cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
-  task_definition = aws_ecs_task_definition.metadata_fargate.arn
+  task_definition = aws_ecs_task_definition.metadata_fargate[count.index].arn
 
   desired_count                      = var.number_of_metadata_apps
   deployment_minimum_healthy_percent = 50
@@ -66,7 +66,7 @@ resource "aws_ecs_service" "metadata_fargate" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.metadata_fargate.arn
+    registry_arn = aws_service_discovery_service.metadata_fargate[count.index].arn
     port         = 8443
   }
 }

--- a/terraform/modules/hub/kms.tf
+++ b/terraform/modules/hub/kms.tf
@@ -71,7 +71,7 @@ resource "aws_kms_key" "frontend" {
 
 resource "aws_kms_alias" "frontend" {
   name          = "alias/${var.deployment}-frontend-key"
-  target_key_id = "${aws_kms_key.frontend.key_id}"
+  target_key_id = aws_kms_key.frontend.key_id
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -149,7 +149,7 @@ resource "aws_kms_key" "saml_proxy" {
 
 resource "aws_kms_alias" "saml_proxy" {
   name          = "alias/${var.deployment}-saml-proxy-key"
-  target_key_id = "${aws_kms_key.saml_proxy.key_id}"
+  target_key_id = aws_kms_key.saml_proxy.key_id
 }
 
 data "aws_iam_policy_document" "saml_soap_proxy" {

--- a/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/lb.tf
@@ -29,7 +29,7 @@ resource "aws_lb_target_group" "task" {
   }
 
   depends_on = [
-    "aws_lb.app",
+    aws_lb.app,
   ]
 
   lifecycle {

--- a/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/variables.tf
@@ -13,7 +13,7 @@ variable "image_name" {
 }
 
 variable "lb_subnets" {
-  type = "list"
+  type = list
 }
 
 locals {
@@ -53,7 +53,7 @@ variable "health_check_http_codes" {
 }
 
 variable "ecs_cluster_id" {
-  type = "string"
+  type = string
 }
 
 variable "cpu" {

--- a/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
+++ b/terraform/modules/hub/modules/ecs_iam_role_pair/variables.tf
@@ -7,11 +7,7 @@ variable "image_name" {
 }
 
 locals {
-  image_name = "${
-    length(var.image_name) == 0
-    ? var.service_name
-    : var.image_name
-  }"
+  image_name = length(var.image_name) == 0 ? var.service_name : var.image_name
 }
 
 data "aws_caller_identity" "account" {}

--- a/terraform/modules/hub/outputs.tf
+++ b/terraform/modules/hub/outputs.tf
@@ -17,3 +17,31 @@ output "public_subnet_ids" {
 output "config_fargate_v2_lb_sg_id" {
   value = module.config_fargate_v2.lb_sg_id
 }
+
+output "fargate_ecs_cluster_id" {
+  value = aws_ecs_cluster.fargate-ecs-cluster.id
+}
+
+output "hub_fargate_microservice_security_group_id" {
+  value = aws_security_group.hub_fargate_microservice.id
+}
+
+output "hub_apps_private_dns_namespace_id" {
+  value = aws_service_discovery_private_dns_namespace.hub_apps.id
+}
+
+output "ingress_https_lb_listener_arn" {
+  value = aws_lb_listener.ingress_https.arn
+}
+
+output "metadata_ecs_execution_role_arn" {
+  value = module.metadata_ecs_roles.execution_role_arn
+}
+
+output "metadata_task_security_group_id" {
+  value = aws_security_group.metadata_task.id
+}
+
+output "ingress_metadata_lb_target_group_arn" {
+  value = aws_lb_target_group.ingress_metadata.arn
+}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -209,8 +209,8 @@ variable "throttling_enabled" {
 }
 
 variable "manage_metadata" {
-  description = "A flag to deploy the metadata and associated infrastructure. Used while moving metadata release to a separate pipeline"
-  default     = true
+  description = "A flag to deploy the metadata and associated infrastructure. Used while moving metadata release to a separate pipeline. Use 1 for true and 0 for false"
+  default     = 1
 }
 
 variable "hub_config_image_digest" {}

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -208,6 +208,11 @@ variable "throttling_enabled" {
   default     = "false"
 }
 
+variable "manage_metadata" {
+  description = "A flag to deploy the metadata and associated infrastructure. Used while moving metadata release to a separate pipeline"
+  default     = true
+}
+
 variable "hub_config_image_digest" {}
 variable "hub_policy_image_digest" {}
 variable "hub_saml_proxy_image_digest" {}

--- a/terraform/modules/metadata/files/metadata.json
+++ b/terraform/modules/metadata/files/metadata.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "nginx",
+    "image": "${image_identifier}",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8443,
+        "hostPort": 8443
+      }
+    ],
+    "environment": [{
+      "Name": "DEPLOYMENT",
+      "Value": "${deployment}"
+    }],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${deployment}-hub",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "metadata-nginx",
+        "awslogs-create-group": "true"
+      }
+    }
+  }
+]

--- a/terraform/modules/metadata/metadata_ecs_service.tf
+++ b/terraform/modules/metadata/metadata_ecs_service.tf
@@ -1,45 +1,38 @@
+data "aws_region" "region" {}
 
-resource "aws_security_group" "metadata_task" {
-  name        = "${var.deployment}-metadata-task"
-  description = "${var.deployment}-metadata-task"
+data "terraform_remote_state" "hub" {
+  backend = "s3"
 
-  vpc_id = aws_vpc.hub.id
+  config = {
+    bucket = "govukverify-tfstate-${var.deployment}"
+    key    = "hub.tfstate"
+    region = "eu-west-2"
+  }
 }
 
 data "template_file" "metadata_task_def" {
-  template = file("${path.module}/files/tasks/metadata.json")
+  template = file("${path.module}/files/metadata.json")
 
   vars = {
     deployment       = var.deployment
     region           = data.aws_region.region.id
-    image_identifier = "${local.tools_account_ecr_url_prefix}-verify-metadata@${var.hub_metadata_image_digest}"
+    image_identifier = "${var.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/platform-deployer-verify-metadata@${var.hub_metadata_image_digest}"
   }
-}
-
-module "metadata_ecs_roles" {
-  source = "./modules/ecs_iam_role_pair"
-
-  deployment       = var.deployment
-  service_name     = "metadata"
-  tools_account_id = var.tools_account_id
-  image_name       = "verify-metadata"
 }
 
 resource "aws_ecs_task_definition" "metadata_fargate" {
   family                   = "${var.deployment}-metadata-fargate"
   container_definitions    = data.template_file.metadata_task_def.rendered
   network_mode             = "awsvpc"
-  execution_role_arn       = module.metadata_ecs_roles.execution_role_arn
+  execution_role_arn       = data.terraform_remote_state.hub.outputs.metadata_ecs_execution_role_arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 256
   memory                   = 512
-
-  count = var.manage_metadata
 }
 
 resource "aws_ecs_service" "metadata_fargate" {
-  name            = "${var.deployment}-metadata"
-  cluster         = aws_ecs_cluster.fargate-ecs-cluster.id
+  name            = "${var.deployment}-metadata-from-metadata-pipeline"
+  cluster         = data.terraform_remote_state.hub.outputs.fargate_ecs_cluster_id
   task_definition = aws_ecs_task_definition.metadata_fargate.arn
 
   desired_count                      = var.number_of_metadata_apps
@@ -48,20 +41,18 @@ resource "aws_ecs_service" "metadata_fargate" {
 
   launch_type = "FARGATE"
 
-  count = var.manage_metadata
-
   load_balancer {
-    target_group_arn = aws_lb_target_group.ingress_metadata.arn
+    target_group_arn = data.terraform_remote_state.hub.outputs.ingress_metadata_lb_target_group_arn
     container_name   = "nginx"
     container_port   = "8443"
   }
 
   network_configuration {
-    subnets = aws_subnet.internal.*.id
+    subnets = data.terraform_remote_state.hub.outputs.internal_subnet_ids
     security_groups = [
-      aws_security_group.metadata_task.id,
-      aws_security_group.hub_fargate_microservice.id,
-      aws_security_group.can_connect_to_container_vpc_endpoint.id,
+      data.terraform_remote_state.hub.outputs.metadata_task_security_group_id,
+      data.terraform_remote_state.hub.outputs.hub_fargate_microservice_security_group_id,
+      data.terraform_remote_state.hub.outputs.can_connect_to_container_vpc_endpoint,
     ]
   }
 
@@ -72,14 +63,13 @@ resource "aws_ecs_service" "metadata_fargate" {
 }
 
 resource "aws_service_discovery_service" "metadata_fargate" {
-  name = "${var.deployment}-metadata"
+  name = "${var.deployment}-metadata-from-metadata-pipeline"
 
   description = "service discovery for ${var.deployment}-metadata-fargate instances"
 
-  count = var.manage_metadata
-
   dns_config {
-    namespace_id = aws_service_discovery_private_dns_namespace.hub_apps.id
+
+    namespace_id = data.terraform_remote_state.hub.outputs.hub_apps_private_dns_namespace_id
 
     dns_records {
       ttl  = 60

--- a/terraform/modules/metadata/variables.tf
+++ b/terraform/modules/metadata/variables.tf
@@ -1,0 +1,14 @@
+variable "deployment" {
+  description = "Name of the deployment; {staging|integration|prod}"
+}
+
+variable "tools_account_id" {
+  description = "AWS account id of the tools account, where docker images will be pulled from"
+}
+
+variable "number_of_metadata_apps" {
+  type    = number
+  default = 2
+}
+
+variable "hub_metadata_image_digest" {}


### PR DESCRIPTION
**See this related PR: https://github.com/alphagov/verify-infrastructure-config/pull/397**

This creates a new module, metadata. The point of this is to allow the
metadata ECS service to be applied separately from the hub terraform -
the ultimate goal being a separate build/deploy pipeline for the
metadata rather than being part of the hub pipeline.

This also adds some config to the hub module to allow the metadata
config to be "turned off" on an environment basis. This is to allow
migration of the metadata to the new pipeline by environment. The
default specified is maintain the current behaviour, making these
changes a no-op.

A few more outputs have also been specified in the hub module - this so
they can be picked up by the new metadata module via the `remote_state`
data.

There will be a separate PR on the verify-infrastructure-config repo
that will invoke the new metadata module as well as configure the
current hub module to stop managing the metadata infrastructure per
environment.

The new module will create a new metadata service which is identical to
the existing service managed by the hub terraform module. This service
is placed in the same load balancer group as the original service. At
this point both services will be receiving traffic. We can then update
the config (set `manage_metadata` to false) to destroy the original
service.

This also upgrades Terraform to v0.13. The refactor of the metadata
terraform out of the hub terraform uses a feature not available in v0.12
(`count`). Upgrading has meant a few changes to other syntax issues are
required, which are addressed here.