### PR TITLE
HUB-738: Remove metadata-image-digest variable

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -219,7 +219,6 @@ variable "hub_saml_proxy_image_digest" {}
 variable "hub_saml_soap_proxy_image_digest" {}
 variable "hub_saml_engine_image_digest" {}
 variable "hub_frontend_image_digest" {}
-variable "hub_metadata_image_digest" {}
 
 variable "ecs_agent_image_digest" {}
 variable "nginx_image_digest" {}


### PR DESCRIPTION
**See companion PR here: https://github.com/alphagov/verify-infrastructure-config/pull/424**

Now that the metadata pipeline is managing the build and deploy of
metadata, we can stop giving the hub terraform this variable as it no
longer uses it for anything.