### PR TITLE
Remove event emitter URL from egress proxy safelist

### DIFF
--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -51,14 +51,9 @@ resource "aws_security_group_rule" "egress_proxy_ingress_from_tasks" {
 }
 
 locals {
-  event_emitter_api_gateway = split("/", replace(var.event_emitter_api_gateway_url, "https://", ""))
-}
-
-locals {
   egress_proxy_allowlist_list = [
     "o451922\\.ingest\\.sentry\\.io",                        # Cloud Sentry
     "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
-    replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
   ]
 
   egress_proxy_allowlist = join(" ", local.egress_proxy_allowlist_list)


### PR DESCRIPTION
Based on @instantiator's review of both the code and the event system database,
saml-engine does not submit to the event system, so does not require this
safelist entry.