### PR TITLE
HUB-748 Remove hosted instance of Sentry BUT NOT YET

### DIFF
--- a/dockerfiles/verify-sentry/Dockerfile
+++ b/dockerfiles/verify-sentry/Dockerfile
@@ -1,1 +1,0 @@
-FROM sentry:9.1.2-onbuild

--- a/dockerfiles/verify-sentry/requirements.txt
+++ b/dockerfiles/verify-sentry/requirements.txt
@@ -1,1 +1,0 @@
-https://github.com/getsentry/sentry-auth-github/archive/43f6b270b3fac32326518a78be77562ebe5abacf.zip

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -57,7 +57,6 @@ locals {
 locals {
   egress_proxy_allowlist_list = [
     "o451922\\.ingest\\.sentry\\.io",                        # Cloud Sentry
-    "sentry\\.tools\\.signin\\.service\\.gov\\.uk",          # Tools Sentry
     replace(local.event_emitter_api_gateway[0], ".", "\\."), # API Gateway
     var.splunk_hostname,                                     # Splunk
   ]


### PR DESCRIPTION
DO NOT MERGE until all the ducks are lined up.

Now that we use the cloud version of Sentry we don't need to host our own version.  Sending `staging` events to the cloud version is more cost effective than running an ec2 instance and database etc.

This should remove anything that is used solely by the hosted instance.  Variables remain for use by with the cloud instance.