### PR TITLE
BAU: Upgrade Dockerfiles for Squid and HAProxy

### DIFF
--- a/dockerfiles/haproxy-static-ingress-fargate/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-fargate/Dockerfile
@@ -2,9 +2,7 @@ FROM ghcr.io/alphagov/verify/haproxy:2.0.20-alpine
 
 EXPOSE 4500
 
-RUN addgroup -S haproxy && \
-    adduser  -S -G haproxy haproxy && \
-    apk add --no-cache gettext
+RUN apk add --no-cache gettext
 
 WORKDIR /tmp
 

--- a/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
@@ -2,9 +2,7 @@ FROM ghcr.io/alphagov/verify/haproxy:2.0.20-alpine
 
 EXPOSE 4500
 
-RUN addgroup -S haproxy && \
-    adduser  -S -G haproxy haproxy && \
-    apk add --no-cache gettext openssl ca-certificates
+RUN apk add --no-cache gettext openssl ca-certificates
 
 WORKDIR /tmp
 

--- a/dockerfiles/squid/Dockerfile
+++ b/dockerfiles/squid/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/verify/alpine:3.11
 
-RUN apk add --no-cache squid=4.10-r0
+RUN apk add --no-cache squid=4.13-r0
 
 RUN    touch /etc/squid/squid.conf \
     && mkdir -p /squid \


### PR DESCRIPTION
Currently our builds for squid, haproxy-static-ingress-tls-fargate, haproxy-static-ingress-fargate [are failing.](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub?group=all). This should fix that.

Commits...

### BAU: Upgrade Squid to 4.13-r0
Our Squid docker image is failing to build as version 4.10-r0 is no
longer supported.

The version of squid available in Alpine 3.11 was upgraded to 4.13-r0 on
29/10/20 to fix security issues. See here for more details: https://git.alpinelinux.org/aports/commit/main/squid?h=3.11-stable&id=7300bf0a9813153ef15f97952cfb41a06e65769c

### BAU: Don't create haproxy user and group
We've recently bumped the ha-proxy version in the base image from
2.0.14-alpine to 2.0.20-alpine

The new base image already has the haproxy user and group created.
Trying to recreate them causes the build to fail. See the details here: https://hub.docker.com/layers/haproxy/library/haproxy/2.0.20-alpine/images/sha256-2b427725dc2811481107abc59fd78f62408607154b55892a26d63ba126cd2d1d?context=explore

