### PR TITLE
HUB-843: Create S3 bucket for hub key rotation

### DIFF
--- a/terraform/modules/hub-key-rotation/s3.tf
+++ b/terraform/modules/hub-key-rotation/s3.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "hub_key_rotation" {
+  bucket = "govukverify-${var.environment}-hub-key-rotation"
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}

--- a/terraform/modules/hub-key-rotation/variables.tf
+++ b/terraform/modules/hub-key-rotation/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  description = "Name of the environment; {staging,integration,prod}"
+}


### PR DESCRIPTION
**See the companion PR on verify-infrastructure-config here: https://github.com/alphagov/verify-infrastructure-config/pull/483**

This adds a module for an S3 bucket for the new hub key rotation
procedure. The module is invoked from the verify-infrastructure-config
repo for each environment.