### PR TITLE
Switch to ECS Fargate platform version 1.4.0

### DIFF
--- a/terraform/modules/hub/analytics.tf
+++ b/terraform/modules/hub/analytics.tf
@@ -75,7 +75,8 @@ resource "aws_ecs_service" "analytics_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.ingress_analytics.arn

--- a/terraform/modules/hub/egress_proxy.tf
+++ b/terraform/modules/hub/egress_proxy.tf
@@ -106,7 +106,8 @@ resource "aws_ecs_service" "egress_proxy_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   network_configuration {
     subnets = aws_subnet.internal.*.id

--- a/terraform/modules/hub/hub_frontend.tf
+++ b/terraform/modules/hub/hub_frontend.tf
@@ -105,7 +105,8 @@ resource "aws_ecs_service" "frontend_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.ingress_frontend.arn

--- a/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
+++ b/terraform/modules/hub/modules/ecs_fargate_app/ecs.tf
@@ -35,7 +35,8 @@ resource "aws_ecs_service" "app" {
   deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
   deployment_maximum_percent         = var.deployment_max_percent
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.task.arn

--- a/terraform/modules/hub/static_ingress.tf
+++ b/terraform/modules/hub/static_ingress.tf
@@ -168,7 +168,8 @@ resource "aws_ecs_service" "static_ingress_http_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.static_ingress_http_fargate.arn
@@ -200,7 +201,8 @@ resource "aws_ecs_service" "static_ingress_https_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.static_ingress_https_fargate.arn

--- a/terraform/modules/metadata/metadata_ecs_service.tf
+++ b/terraform/modules/metadata/metadata_ecs_service.tf
@@ -39,7 +39,8 @@ resource "aws_ecs_service" "metadata_fargate" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 100
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = data.terraform_remote_state.hub.outputs.ingress_metadata_lb_target_group_arn

--- a/terraform/modules/self-service/cloudwatch.tf
+++ b/terraform/modules/self-service/cloudwatch.tf
@@ -19,6 +19,7 @@ resource "aws_cloudwatch_event_target" "scheduler_target" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.scheduler_task_def.arn
     launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
     network_configuration {
       security_groups = [
         aws_security_group.egress_over_https.id,

--- a/terraform/modules/self-service/ecs.tf
+++ b/terraform/modules/self-service/ecs.tf
@@ -89,11 +89,12 @@ resource "aws_ecs_task_definition" "scheduler_task_def" {
 
 
 resource "aws_ecs_service" "service" {
-  name            = local.service
-  task_definition = aws_ecs_task_definition.task_def.arn
-  cluster         = aws_ecs_cluster.cluster.id
-  desired_count   = 1
-  launch_type     = "FARGATE"
+  name             = local.service
+  task_definition  = aws_ecs_task_definition.task_def.arn
+  cluster          = aws_ecs_cluster.cluster.id
+  desired_count    = 1
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.task.id
@@ -114,11 +115,12 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_ecs_service" "migrations_service" {
-  name            = "${local.service}-migrations"
-  task_definition = aws_ecs_task_definition.migrations_task_def.arn
-  cluster         = aws_ecs_cluster.cluster.id
-  desired_count   = 0
-  launch_type     = "FARGATE"
+  name             = "${local.service}-migrations"
+  task_definition  = aws_ecs_task_definition.migrations_task_def.arn
+  cluster          = aws_ecs_cluster.cluster.id
+  desired_count    = 0
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   network_configuration {
     security_groups = [
@@ -132,11 +134,12 @@ resource "aws_ecs_service" "migrations_service" {
 }
 
 resource "aws_ecs_service" "scheduler_service" {
-  name            = "${local.service}-scheduler"
-  task_definition = aws_ecs_task_definition.scheduler_task_def.arn
-  cluster         = aws_ecs_cluster.cluster.id
-  desired_count   = 0
-  launch_type     = "FARGATE"
+  name             = "${local.service}-scheduler"
+  task_definition  = aws_ecs_task_definition.scheduler_task_def.arn
+  cluster          = aws_ecs_cluster.cluster.id
+  desired_count    = 0
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
 
   network_configuration {
     security_groups = [


### PR DESCRIPTION
From the current LATEST, which is 1.3.0. Updating this manually gets
ahead of AWS making this happen on the 8th of March (2021) when they
change the definition of LATEST.