### PR TITLE
BAU Reduce the low egress rate evaluation time period 

### DIFF
--- a/dashboards/Hub-ECS-Journeys.json
+++ b/dashboards/Hub-ECS-Journeys.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 123,
-  "iteration": 1617178676236,
+  "iteration": 1621237763057,
   "links": [],
   "panels": [
     {
@@ -280,7 +280,7 @@
             "evaluator": {
               "params": [
                 0,
-                4
+                6
               ],
               "type": "outside_range"
             },
@@ -683,5 +683,5 @@
   "timezone": "",
   "title": "Hub ECS Journeys",
   "uid": "UBaTMZJWz",
-  "version": 46
+  "version": 47
 }


### PR DESCRIPTION
Reduce the low egress rate evaluation time period in Grafana.

Evaluation didn't occur between midnight and 4am.
It now doesn't occur from midnight to 6am.

We've had a few cases of low egress rate reports in the early morning, where data vs. last month is probably less significant due to smaller volumes.

<img width="647" alt="Screenshot 2021-05-17 at 09 04 21" src="https://user-images.githubusercontent.com/137389/118453645-5dad2780-b6ef-11eb-9f29-52e82b2fea44.png">

