### PR TITLE
BAU: Don't set the user for haproxy

### DIFF
--- a/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
+++ b/dockerfiles/haproxy-static-ingress-tls-fargate/Dockerfile
@@ -7,8 +7,6 @@ RUN apk add --no-cache gettext openssl ca-certificates
 
 WORKDIR /tmp
 
-USER haproxy
-
 COPY . /tmp
 
 ENTRYPOINT ["/tmp/docker-entrypoint.sh"]


### PR DESCRIPTION
The current image built from the Dockerfile won't start due to an issue
with the user. Not setting the user in the Dockerfile reverts to the
same behaviour as the previous good image.