### PR TITLE
HUB-957: Increase matomo's php-fpm max_children

### DIFF
--- a/dockerfiles/matomo/Dockerfile
+++ b/dockerfiles/matomo/Dockerfile
@@ -1,0 +1,4 @@
+ARG base_image=matomo:3.13.5-fpm-alpine
+FROM ${base_image}
+
+COPY z-php-fpm-process-manager.conf /usr/local/etc/php-fpm.d/z-php-fmp-process-manager.conf

--- a/dockerfiles/matomo/z-php-fpm-process-manager.conf
+++ b/dockerfiles/matomo/z-php-fpm-process-manager.conf
@@ -1,0 +1,4 @@
+[www]
+pm.max_children = 20
+pm.start_servers = 20
+pm.max_spare_servers = 20


### PR DESCRIPTION
We were previously just vendoring this Matomo base image. This allows us
to build it and slip in an extra config file.

This `z` prefix on the config file is important as the config files in
the directory are read alphabetically and we need this to overwrite the
values set in `www.conf`.

The new config file ups our max_children from 5 (the default) to 20.
This is being done due to issues with process starvation when the Matomo
GUI was sending long running requests to the backend.

`start_servers` is set to 20 too so we don't have to warm up if a new
Matomo task starts up during a busy period.

`max_spare_servers` can't be less than `start_servers`.

If the processes are left idle for a while php-fpm should kill them.

PR for build/push of this [Dockerfile is here](https://github.com/alphagov/verify-infrastructure-config/pull/573).