### PR TITLE
BAU: Set nginx-tls image /etc/hosts owner in entrypoint

### DIFF
--- a/dockerfiles/nginx-tls/Dockerfile
+++ b/dockerfiles/nginx-tls/Dockerfile
@@ -3,12 +3,9 @@ FROM ${base_image}
 
 EXPOSE 8443
 
-RUN apk add --no-cache gettext openssl && \
-    chown nginx /etc/hosts
+RUN apk add --no-cache gettext openssl
 
 WORKDIR /tmp
-
-USER nginx
 
 COPY . /tmp
 

--- a/dockerfiles/nginx-tls/docker-entrypoint.sh
+++ b/dockerfiles/nginx-tls/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env ash
 set -ueo pipefail
 
+chown nginx /etc/hosts
+sed -e 's/\(^nginx.*\:\)\/sbin\/nologin/\1\/bin\/sh/' -i /etc/passwd
+su nginx
+
 location_blocks="${LOCATION_BLOCKS:?LOCATION_BLOCKS not set}"
 location_blocks="$(echo "$location_blocks" | base64 -d)"
 export location_blocks


### PR DESCRIPTION
Since we started building the nginx-tls image in the pipeline with the
vito/oci-build-task image, the `build-nginx-tls` [Concourse job has been
failing](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub/jobs/build-nginx-tls/builds/9).

The build attempts to change the owner of the `/etc/hosts` directory to
`nginx`. This fails with the error message:

        `chown: /etc/hosts: Read-only file system`

The oci-build-task uses [BuildKit](https://github.com/moby/buildkit) directly under the hood, rather than
with Docker. I believe this is causing the issue.

It seems that `/etc/hosts` is treated specially by the build runtime,
and BuildKit does not allow writes to the dir. There is some discussion
of it in [this issue.](https://github.com/moby/buildkit/issues/1267).

It seems that [you need to manually turn BuildKit on in Docker](https://docs.docker.com/develop/develop-images/build_enhancements/), which
would explain why this has only just broken.

To get around this issue, we can change the owner of `/etc/hosts` after
the build, in the entrypoint script. To do this we need to be the root
user, which is why the `USER nginx` instruction has been removed from the
Dockerfile.

Once the owner of `/etc/hosts` has been changed we can switch to the
`nginx` user. To do this from the entrypoint script the nginx user
needs to have a login shell set. That's what the `sed` command is doing.

I'm not 100% sure that this is the right approach for this. I'm not sure
why the `/etc/hosts` dir needs to be owned by nginx in the first place,
but it's probably been done for a good reason. But the simplest fix
would be to not change the ownership at all. Thoughts or better ideas
welcome.