### PR TITLE
BAU Alert when rate of return from IDPs has decreased

### DIFF
--- a/dashboards/Hub-ECS-Journeys.json
+++ b/dashboards/Hub-ECS-Journeys.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 123,
-  "iteration": 1621237763057,
+  "iteration": 1624032198795,
   "links": [],
   "panels": [
     {
@@ -418,7 +418,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "🚨Alerts",
+      "title": "🚨 To IDP Alert",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -446,6 +446,179 @@
         {
           "format": "short",
           "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0.9
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0,
+                6
+              ],
+              "type": "outside_range"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B",
+                "now-1m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "30m",
+        "frequency": "1h",
+        "handler": 1,
+        "message": "📉The rate of return from IdPs has gone down compared to two weeks ago. Please take a look.",
+        "name": "Alert",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hub-prod-prom-1",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[1d])) / sum(rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[1d]))) / \n\n(sum(rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageReceiverApi_handleResponsePost_count[1d] offset 14d)) / sum(rate(uk_gov_ida_hub_samlproxy_resources_SamlMessageSenderApi_sendJsonAuthnRequestFromHub_count[1d] offset 14d)))",
+          "interval": "",
+          "intervalFactor": 10,
+          "legendFormat": "rate of return from IDPs v. 2w ago",
+          "refId": "A"
+        },
+        {
+          "expr": "hour()",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 0.9,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "🚨 From IDP Alert",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
           "logBase": 1,
           "max": null,
           "min": null,
@@ -683,5 +856,5 @@
   "timezone": "",
   "title": "Hub ECS Journeys",
   "uid": "UBaTMZJWz",
-  "version": 47
+  "version": 50
 }


### PR DESCRIPTION
About 50% of users getting to an IDP return to us, source:

<img width="500" alt="Screenshot 2021-06-18 at 17 16 12" src="https://user-images.githubusercontent.com/137389/122590282-3da7b580-d059-11eb-8717-6b00084397b8.png">

When Digi amended their functionality on 4th June, there was a drop in this return rate, see the right-hand side of the graph ☝️ .

When we compare this rate of return to 2 weeks prior, we can see a dip in the response rate, source:
<img width="500" alt="Screenshot 2021-06-18 at 17 33 26" src="https://user-images.githubusercontent.com/137389/122591827-6d57bd00-d05b-11eb-8225-2d5dd0c3c419.png">

It's this dip to below `0.9` that we want to alert on.

This PR introduces a new panel to the Grafana [Hub ECS Journeys Dashboard](https://grafana.tools.signin.service.gov.uk/d/UBaTMZJWz/hub-ecs-journeys?orgId=1&var-timerange=1h&from=now-2d&to=now&refresh=1m)
<img width="400" alt="Screenshot 2021-06-18 at 17 38 06" src="https://user-images.githubusercontent.com/137389/122592454-2e763700-d05c-11eb-8943-b5b0a2c43af8.png">

that checks outside 0000 and 0600hrs whether this rate is below 0.9, and alerts if true.

The check fires every hour, and evaluates for 30mins before alerting to 2nd-line slack.






