### PR TITLE
[HUB-979] Add aws-terraform Dockerfile

### DIFF
--- a/dockerfiles/aws-terraform/Dockerfile
+++ b/dockerfiles/aws-terraform/Dockerfile
@@ -1,0 +1,17 @@
+ARG ubuntu_digest
+ARG terraform_digest
+ARG terraform_version
+
+FROM hashicorp/terraform@${terraform_digest} as terraform
+FROM ubuntu@${ubuntu_digest}
+
+LABEL terraform="${terraform_version}"
+
+RUN apt-get update  --yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes awscli jq curl dnsutils unzip git
+
+WORKDIR /tmp
+
+COPY --from=terraform /bin/terraform /bin/terraform
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
In order to run verify-terraform we now 100% need to be using the latest
rekeyed versions of terraform after the codecov.io issue.

Sadly, the aws-terraform containers vendored by autom8 don't really
touch anything below 0.14 (with the correct keys).

We're still using 0.12, and 0.11 in some places so we need to support
these for the time being until we get around to upgrading.

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>