### PR TITLE
BAU: Increase memory available to Matomo PHP

### DIFF
--- a/dockerfiles/matomo/Dockerfile
+++ b/dockerfiles/matomo/Dockerfile
@@ -1,4 +1,6 @@
 ARG base_image=matomo:3.13.5-fpm-alpine
 FROM ${base_image}
 
+RUN sed -i 's/memory_limit.*/memory_limit = 1G/' /usr/local/etc/php/php.ini-*
+
 COPY z-php-fpm-process-manager.conf /usr/local/etc/php-fpm.d/z-php-fmp-process-manager.conf


### PR DESCRIPTION
We've seen a few errors in the archiving logs and the docs seem to
suggest they may be caused by the server running out of memory.

We currently have the memory limit available to php set to 128MB. This
bumps it to 1G.

It's worth noting that this limit is per process, not an overall limit.
Having said that we consistently use just 2% of available memory so
even a nearly ten fold increase in use should be manageable.