### PR TITLE
BAU: Correctly set php memory limit for matomo

### DIFF
--- a/dockerfiles/matomo/Dockerfile
+++ b/dockerfiles/matomo/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_image=matomo:3.13.5-fpm-alpine
 FROM ${base_image}
 
-RUN sed -i 's/memory_limit.*/memory_limit = 1G/' /usr/local/etc/php/php.ini-*
+COPY php-memory-limit.ini /usr/local/etc/php/conf.d/
 
 COPY z-php-fpm-process-manager.conf /usr/local/etc/php-fpm.d/z-php-fmp-process-manager.conf

--- a/dockerfiles/matomo/php-memory-limit.ini
+++ b/dockerfiles/matomo/php-memory-limit.ini
@@ -1,0 +1,1 @@
+memory_limit = 1G


### PR DESCRIPTION
The last attempt to update the memory limit failed as the php.ini file
was never loaded.

This creates a new custom ini file with just the new memory limit and
adds it to the directory that php scans for ini files.

I've tested this locally and the command `php -i | grep memory_limit`
shows that the new value has been loaded.