### PR TITLE
HUB-1013: Provide GitHub API key and env to metadata exporter

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -14,7 +14,13 @@
     "entryPoint": [
       "bash",
       "-c",
-      "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment}"
+      "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment} -e ${deployment}"
+    ],
+    "secrets": [
+      {
+        "name": "GITHUB_API_TOKEN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/metadata-exporter/github-read-only-api-token"
+      }
     ],
     "environment": [{
       "Name": "APP_ENV",

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -16,6 +16,8 @@ data "template_file" "metadata_exporter_task_def" {
     deployment       = var.deployment
     region           = data.aws_region.region.id
     environment      = var.metadata_exporter_environment
+    region           = data.aws_region.region.id
+    account_id       = data.aws_caller_identity.account.account_id
   }
 }
 


### PR DESCRIPTION
The metadata exporter [has been updated to check the source certs found
in the metadata repo against those published at the federation endpoint](https://github.com/alphagov/metadata-exporter/pull/18).
The metadata repo is private, so we need to provide a GitHub token.