### PR TITLE
HUB-1013: Provide GitHub API key and env to metadata exporter again

### DIFF
--- a/terraform/modules/hub/files/tasks/metadata-exporter.json
+++ b/terraform/modules/hub/files/tasks/metadata-exporter.json
@@ -14,7 +14,13 @@
     "entryPoint": [
       "bash",
       "-c",
-      "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment}"
+      "bundle exec bin/prometheus-metadata-exporter -m https://${signin_domain}/SAML2/metadata/federation -p 9199 --cas /tmp/cas/${deployment} -e ${deployment}"
+    ],
+    "secrets": [
+      {
+        "name": "GITHUB_API_TOKEN",
+        "valueFrom": "arn:aws:ssm:${region}:${account_id}:parameter/${deployment}/metadata-exporter/github-read-only-api-token"
+      }
     ],
     "environment": [{
       "Name": "APP_ENV",

--- a/terraform/modules/hub/metadata_exporter.tf
+++ b/terraform/modules/hub/metadata_exporter.tf
@@ -16,6 +16,8 @@ data "template_file" "metadata_exporter_task_def" {
     deployment       = var.deployment
     region           = data.aws_region.region.id
     environment      = var.metadata_exporter_environment
+    region           = data.aws_region.region.id
+    account_id       = data.aws_caller_identity.account.account_id
   }
 }
 


### PR DESCRIPTION
**Not to be merged before this metadata-exporter PR: https://github.com/alphagov/metadata-exporter/pull/23**

This puts back the reversion [of the original work](https://github.com/alphagov/verify-infrastructure/pull/593).

The metadata-exporter has been updated to fix the bug that caused the inital reversion. This will need to be merged once the metadata-exporter PR has been merged and the image built.