### PR TITLE
HUB:981 add environment for support email

### DIFF
--- a/terraform/modules/self-service/files/task-def.json
+++ b/terraform/modules/self-service/files/task-def.json
@@ -93,6 +93,10 @@
         {
           "name": "NOTIFY_KEY",
           "valueFrom": "${notify_key}"
+        },
+        {
+          "name": "SUPPORT_EMAIL",
+          "valueFrom": "${support_email}"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
This adds an environment variable for support email in self-service [see ](https://govukverify.atlassian.net/browse/HUB-981)