### PR TITLE
HUB-981: support email added to other task files

### DIFF
--- a/terraform/modules/self-service/files/migrations-task-def.json
+++ b/terraform/modules/self-service/files/migrations-task-def.json
@@ -94,6 +94,10 @@
         {
           "name": "NOTIFY_KEY",
           "valueFrom": "${notify_key}"
+        },
+        {
+          "name": "SUPPORT_EMAIL",
+          "valueFrom": "${support_email}"
         }
       ],
       "logConfiguration": {

--- a/terraform/modules/self-service/files/scheduler-task-def.json
+++ b/terraform/modules/self-service/files/scheduler-task-def.json
@@ -94,6 +94,10 @@
         {
           "name": "NOTIFY_KEY",
           "valueFrom": "${notify_key}"
+        },
+        {
+          "name": "SUPPORT_EMAIL",
+          "valueFrom": "${support_email}"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
All the task files appear to need the SUPPORT_EMAIL b'cos it is defined in the context of the self-service rails app 