### PR TITLE
HUB-765: Alert on metadata signing certificate four week expiry

### DIFF
--- a/terraform/modules/dashboards/service_tickets_dashboard.json.tpl
+++ b/terraform/modules/dashboards/service_tickets_dashboard.json.tpl
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 96,
+  "id": 105,
   "links": [],
   "panels": [
     {
@@ -164,7 +164,7 @@
           {
             "evaluator": {
               "params": [
-                432000
+                2419200
               ],
               "type": "lt"
             },
@@ -189,7 +189,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "name": "[${deployment}] Metadata expires in under 5 days",
+        "name": "[${deployment}] Metadata Signing Certificate Expiry is Less than 4 Weeks",
         "noDataState": "no_data",
         "notifications": []
       },
@@ -213,7 +213,7 @@
         "y": 0
       },
       "hiddenSeries": false,
-      "id": 12,
+      "id": 13,
       "legend": {
         "avg": false,
         "current": false,
@@ -240,9 +240,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(verify_metadata_expiry/1000) - time()",
+          "expr": "verify_metadata_certificate_expiry{entity_id=\"metadata_signing_certificate\"} / 1000 - time()",
           "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -252,13 +256,14 @@
           "fill": true,
           "line": true,
           "op": "lt",
-          "value": 432000
+          "value": 2419200,
+          "yaxis": "left"
         }
       ],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Metadata Expiry",
+      "title": "Metadata Signing Certificate Expiry Time Left in Seconds",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -431,6 +436,143 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "alert": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                432000
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "[${deployment}] Metadata expires in under 5 days",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${source}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(verify_metadata_expiry/1000) - time()",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 432000
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Metadata Expiry",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -449,7 +591,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -474,7 +615,6 @@
   },
   "timezone": "",
   "title": "[${deployment}] Service Tickets",
-  "uid": "ndNZJXjmz",
-  "version": 2
-  
+  "uid": "Qbuh83jik",
+  "version": 6
 }


### PR DESCRIPTION
The policy at the moment is to alert to 2ndline if certificates have 2
weeks until their expiry.

We need to alert sooner for the metadata signing certificate as we would
never want to sign metadata with a certificate that has a shorter life
than the metadata itself.

This adds a new panel with an attached alert that will fire at the four
week mark. Unfortunately you can't add more than one alert to a panel,
so I've had to create a new one. It's not for looking at, just for
having an alert attached.