### PR TITLE
HUB-1057 Automate Prometheus Rebooting

### DIFF
--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -166,7 +166,6 @@ function run-until-success() {
 
 # Make sure unattended upgrades is available and we automatically reboot at 3:00
 # as required in HUB-1057.
-echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean true | debconf-set-selections
 run-until-success "apt-get install --yes unattended-upgrades update-notifier-common"
 cat >> /etc/apt/apt.conf.d/50unattended-upgrades <<'EOF'
 Unattended-Upgrade::Automatic-Reboot "true";

--- a/terraform/modules/hub/files/cloud-init/prometheus.sh
+++ b/terraform/modules/hub/files/cloud-init/prometheus.sh
@@ -164,6 +164,17 @@ function run-until-success() {
   done
 }
 
+# Make sure unattended upgrades is available and we automatically reboot at 3:00
+# as required in HUB-1057.
+echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean true | debconf-set-selections
+run-until-success "apt-get install --yes unattended-upgrades update-notifier-common"
+cat >> /etc/apt/apt.conf.d/50unattended-upgrades <<'EOF'
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "false";
+Unattended-Upgrade::Automatic-Reboot-Time "03:00";
+Unattended-Upgrade::SyslogEnable "true";
+EOF
+
 # ECS
 echo 'Running ECS using Docker'
 mkdir -p /etc/ecs

--- a/terraform/modules/hub/files/prometheus/alerts.yml
+++ b/terraform/modules/hub/files/prometheus/alerts.yml
@@ -110,9 +110,10 @@ groups:
     labels: *infraticket
     annotations:
       message: |
-        An instance has installed an upgrade which requires a reboot to take effect.
+        An instance has installed an upgrade and the automatic reboot has not run.
     expr: |
       node_reboot_required == 1
+    for: 24h
   - alert: NtpOffsetTooGreat
     labels: *infraticket
     annotations:


### PR DESCRIPTION
I've added a few options to the unattended upgrade configuration to automatically reboot these instances at 0300 if there's any updates to apply, it'll also log the output to syslog so we can see it in CloudWatch and track any reboots/issue with reboot needed. I could have done this another way but I thought this option was much simpler for whoever is taking this over to unpick further down the line in an already complex mess of infrastructure code.

Unattended upgrade should pick up the file `/var/run/reboot-required` like we check for in `/usr/bin/instance-reboot-required-metric.sh` and reboot *without confirmation* at 0300. Then when the machine comes back up that'll be no longer there so `/usr/bin/instance-reboot-required-metric.sh` won't set `node_reboot_required` to 1 anymore and therefore won't fire the alert to slack.

If for some reason, the reboot doesn't happen and `/var/run/reboot-required` sits around longer than 24 hours, alertmanager will fire the alert to slack and someone will have to go manually reboot these in concourse!