### PR TITLE
BAU: Increase prometheus volume size

### DIFF
--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -75,7 +75,7 @@ variable "saml_proxy_memory_limit_mb" {
 }
 
 variable "prometheus_volume_size" {
-  default = 100
+  default = 120
 }
 
 variable "publically_accessible_from_cidrs" {


### PR DESCRIPTION
One of the prometheus ECS services is failing to start up with what
looks like an issue with disk space:

`err="persist head block: write compaction: write chunks: no space left on device"`

The prometheus services have a 100GB volume mapped into them that
prometheus writes to. This volume for prom-1 is basically full:

`/dev/nvme1n1   ext4       98G   93G  345M 100% /srv/prometheus.`

The other two volumes are not far behind.

This PR increases the size of the volume to fix the issue in the short
term. We probably want to do something better though to stop this issue
re-occurring.

I've planned this change against staging and can see the volume us
updated in place rather than replaced which means we won't lose the data
on it.