### PR TITLE
BAU - Create multiple log subscriptions

### DIFF
--- a/terraform/modules/hub/fargate-ecs.tf
+++ b/terraform/modules/hub/fargate-ecs.tf
@@ -8,8 +8,9 @@ resource "aws_cloudwatch_log_group" "fargate-logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "csls-subscription" {
-  name            = "${var.deployment}-hub-csls"
+  count           = length(var.logging_endpoint_arns)
+  name            = "${var.deployment}-hub-csls-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.fargate-logs.name
   filter_pattern  = ""
-  destination_arn = var.cls_destination_arn
+  destination_arn = var.cls_destination_arn[count.index]
 }

--- a/terraform/modules/hub/variables.tf
+++ b/terraform/modules/hub/variables.tf
@@ -107,6 +107,7 @@ variable "wildcard_cert_arn" {
 }
 
 variable "cls_destination_arn" {
+  type        = list(string)
   description = "ARN of the CSLS destination to send logs to"
 }
 


### PR DESCRIPTION
- We need to support both the old and new log subscriptions. Adapt the terraform resource so it can create multiple resources based on how many log subscriptions have been declared in the list.