### PR TITLE
Null edit to GPG sign instead of SSH sign

### DIFF
--- a/dockerfiles/nginx-tls/Dockerfile
+++ b/dockerfiles/nginx-tls/Dockerfile
@@ -7,5 +7,4 @@ RUN apk add --no-cache gettext openssl
 USER www-data
 WORKDIR /tmp
 COPY --chown=www-data . /tmp
-
 ENTRYPOINT ["/tmp/docker-entrypoint.sh"]


### PR DESCRIPTION
Resubmitting the same change but with a GPG signature instead of an SSH signature, as Concourse doesn't like SSH signatures